### PR TITLE
chore: upgrade Entity Framework Core to 9.0.10

### DIFF
--- a/api/F1CompanionApi/F1CompanionApi.csproj
+++ b/api/F1CompanionApi/F1CompanionApi.csproj
@@ -10,8 +10,8 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.8" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8">
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.10">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
## Summary
- Upgraded `Microsoft.EntityFrameworkCore` from 9.0.8 to 9.0.10
- Upgraded `Microsoft.EntityFrameworkCore.Design` from 9.0.8 to 9.0.10

This resolves version conflicts with the test project's `Microsoft.EntityFrameworkCore.InMemory` package which was already at version 9.0.10.

## Test plan
- [x] API build succeeds
- [x] All 263 unit tests pass
- [x] No format violations