### PR TITLE
Fix inconsistent card heights on mobile

### DIFF
--- a/web/src/components/ConstructorPicker/ConstructorPicker.tsx
+++ b/web/src/components/ConstructorPicker/ConstructorPicker.tsx
@@ -67,7 +67,7 @@ export function ConstructorPicker({
           <InlineError message={error} />
         </div>
       )}
-      <div className="relative grid grid-cols-1 gap-4 sm:grid-cols-2 sm:grid-rows-2">
+      <div className="relative grid auto-rows-fr grid-cols-1 gap-4 sm:grid-cols-2">
         {displayLineup.map((constructor, idx) => (
           <ConstructorCard
             key={idx}

--- a/web/src/components/DriverPicker/DriverPicker.tsx
+++ b/web/src/components/DriverPicker/DriverPicker.tsx
@@ -63,7 +63,7 @@ export function DriverPicker({ activeDrivers, teamDrivers, readOnly }: DriverPic
           <InlineError message={error} />
         </div>
       )}
-      <div className="relative grid grid-cols-1 gap-4 sm:grid-cols-2 sm:grid-rows-2">
+      <div className="relative grid auto-rows-fr grid-cols-1 gap-4 sm:grid-cols-2">
         {displayLineup.map((driver, idx) => (
           <DriverCard
             key={idx}


### PR DESCRIPTION
## Summary
- Replace `sm:grid-rows-2` with `auto-rows-fr` on the picker grids so empty and filled cards have equal heights at all breakpoints, not just desktop
- Applied to both DriverPicker and ConstructorPicker

## Test plan
- [ ] Verify on mobile viewport: empty "Add Driver/Constructor" cards match the height of filled cards
- [ ] Verify on desktop: 2×2 grid still renders with consistent row heights
- [ ] Verify read-only "Empty Slot" cards also match height