### PR TITLE
Enable retry on transient database connection failures

### DIFF
--- a/api/F1CompanionApi/Extensions/ServiceExtensions.cs
+++ b/api/F1CompanionApi/Extensions/ServiceExtensions.cs
@@ -70,7 +70,15 @@ public static class ServiceExtensions
     private static void AddDbContext(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddDbContext<ApplicationDbContext>(options =>
-            options.UseNpgsql(configuration.GetConnectionString("DefaultConnection"))
+            options.UseNpgsql(
+                configuration.GetConnectionString("DefaultConnection"),
+                npgsqlOptions =>
+                    npgsqlOptions.EnableRetryOnFailure(
+                        maxRetryCount: 3,
+                        maxRetryDelay: TimeSpan.FromSeconds(5),
+                        errorCodesToAdd: null
+                    )
+            )
         );
     }
 


### PR DESCRIPTION
## Summary
- Configures Npgsql's `EnableRetryOnFailure` on the EF Core DbContext to automatically retry transient connection failures from the Supabase pooler
- Addresses [F1-FANTASY-API-39](https://emsqrd.sentry.io/issues/F1-FANTASY-API-39): 28 connection errors across 2 users where stale pooled connections caused burst failures after idle periods
- Retries up to 3 times with exponential backoff (max 5s delay), making recovery transparent to users instead of requiring manual page refreshes

## Test plan
- [x] API builds successfully
- [x] All 316 unit tests pass
- [ ] Deploy and monitor Sentry for recurrence of F1-FANTASY-API-39