### PR TITLE
Document DB connection troubleshooting and add ADR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,25 @@ Open this folder in VSCode and use:
 - **Debugging** (F5)
   - "Full Stack (Web + API)" - Debug both simultaneously
 
+## Production Infrastructure
+
+Hosted on Render (free tier, spins down after inactivity) + Supabase (free tier).
+
+| Resource | Identifier |
+|---|---|
+| Render service name | `f1fantasyappapi` |
+| Render service ID | `srv-d2pqsbbe5dus73bcttfg` |
+| Supabase project ref | `cfuccajsckqzecbfyqrv` |
+| Supabase pooler host | `aws-1-us-east-2.pooler.supabase.com` |
+| Supabase direct DB host | `db.cfuccajsckqzecbfyqrv.supabase.co` |
+
+**MCP servers available for investigation:**
+- `mcp__render__list_logs` — runtime logs from the API (use `srv-d2pqsbbe5dus73bcttfg`)
+- `mcp__sentry__search_events` — error events (project slug: `f1-fantasy-api` or `f1-fantasy-web`, org: `emsqrd`, regionUrl: `https://us.sentry.io`)
+- `mcp__supabase__get_logs` — Postgres and API gateway logs (service: `postgres` or `api`)
+
+**Initial page load fires two concurrent requests:** `GET /api/me/profile` + `GET /api/me/team/`
+
 ## Project Documentation
 
 - `web/CLAUDE.md` - Frontend architecture, patterns, and conventions

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -75,3 +75,20 @@ Use `ILogger<T>` with structured logging (named placeholders, not string interpo
 ```csharp
 _logger.LogInformation("Creating league {LeagueName} for user {UserId}", name, userId);
 ```
+
+## Observability
+
+**ConnectionDiagnosticsInterceptor** (`Data/ConnectionDiagnosticsInterceptor.cs`) — logs a
+warning for any DB connection that takes >1s to open. Look for `Slow DB connection` entries in
+Render logs when diagnosing connectivity issues. The log includes a connection GUID, host:port,
+and duration in ms.
+
+**DbContext is Scoped** — all services in a single HTTP request share the same `ApplicationDbContext`
+instance. However, when using Supabase Supavisor in **Transaction mode** (port 6543), the physical
+Postgres connection is returned to Supavisor's pool after each implicit transaction (i.e. each
+EF Core query). This means each query in a request pays a reconnection cost through Supavisor.
+If connection overhead is suspected, check Render logs for repeated `Slow DB connection` entries
+with the same connection GUID — that indicates Transaction mode re-establishment overhead.
+
+**Production connection string** is in the `ConnectionStrings__DefaultConnection` env var on Render
+(not in source). Check `ServiceExtensions.cs:AddDbContext` for how it's consumed.

--- a/api/F1CompanionApi/Data/ConnectionDiagnosticsInterceptor.cs
+++ b/api/F1CompanionApi/Data/ConnectionDiagnosticsInterceptor.cs
@@ -28,7 +28,7 @@ public class ConnectionDiagnosticsInterceptor(ILogger<ConnectionDiagnosticsInter
         }
         else
         {
-            logger.LogInformation(
+            logger.LogDebug(
                 "DB connection {ConnectionId} to {Host}:{Port} opened in {DurationMs:F0}ms",
                 eventData.ConnectionId,
                 host,

--- a/docs/adr/001-supabase-connection-strategy.md
+++ b/docs/adr/001-supabase-connection-strategy.md
@@ -1,0 +1,72 @@
+# ADR 001: Supabase Connection Strategy for Render Free Tier
+
+**Date:** 2026-02-18
+**Status:** Accepted
+
+## Context
+
+The F1 Fantasy API runs on Render's free tier and connects to a PostgreSQL database hosted on Supabase's free tier. Two platform constraints collide:
+
+1. **Supabase switched direct database connections to IPv6-only** (Feb 2024). The IPv4 add-on requires a paid plan ($4/month).
+2. **Render's free tier does not support IPv6 outbound connections.**
+
+This means the API cannot reach Supabase's direct connection host (`db.cfuccajsckqzecbfyqrv.supabase.co`). All database traffic must go through **Supavisor**, Supabase's connection pooler (`aws-1-us-east-2.pooler.supabase.com`), which supports IPv4.
+
+Supavisor offers two connection modes:
+- **Session mode** (port 5432) — binds a backend Postgres connection to the client connection for its lifetime. Suitable for persistent servers.
+- **Transaction mode** (port 6543) — returns the backend connection to Supavisor's pool after each transaction. Designed for serverless/short-lived connections.
+
+Supabase free tier limits:
+- Max database connections: 60
+- Max pooler client connections: 200
+- Backend connections per user/db/mode (Supavisor pool size): ~15-20
+
+Npgsql (the .NET PostgreSQL driver) defaults to `Maximum Pool Size=100`, which silently exceeds Supavisor's per-user pool size limit.
+
+## Decision
+
+Use **session mode (port 5432)** via Supavisor with `Maximum Pool Size=10` in the Npgsql connection string, combined with EF Core's retry-on-failure (3 retries, 5-second max delay).
+
+Connection string format:
+```
+User Id=postgres.<project-ref>;Password=<pw>;Server=aws-1-us-east-2.pooler.supabase.com;Port=5432;Database=postgres;SSL Mode=Require;Maximum Pool Size=10
+```
+
+EF Core configuration (in `ServiceExtensions.cs`):
+```csharp
+options.UseNpgsql(connectionString, npgsqlOptions =>
+    npgsqlOptions.EnableRetryOnFailure(
+        maxRetryCount: 3,
+        maxRetryDelay: TimeSpan.FromSeconds(5),
+        errorCodesToAdd: null
+    ))
+```
+
+## Consequences
+
+**What this enables:**
+- Stable database connectivity from Render free tier to Supabase free tier
+- Session mode keeps backend connections tied to client connections — no per-query reconnection overhead
+- Pool size of 10 stays safely within Supavisor's ~15-20 backend connection limit
+- EF Core retry handles transient failures (cold starts, brief Supavisor hiccups)
+
+**Limitations:**
+- Maximum 10 concurrent database connections, limiting API concurrency under load
+- Still dependent on Supavisor as an intermediary (adds slight latency vs. direct connections)
+- Supabase has no .NET/Npgsql-specific documentation — future Supavisor changes may require re-investigation
+
+**If moving off free tier:**
+- Upgrading Supabase to a paid plan enables direct IPv4 connections, removing the Supavisor dependency entirely
+- Upgrading Render would allow IPv6, also enabling direct connections
+- Either upgrade would allow increasing `Maximum Pool Size` and removing the Supavisor middleman
+
+## Alternatives Considered
+
+### Session mode with default pool size (Attempt 1)
+Session mode on port 5432, but with Npgsql's default `Maximum Pool Size=100`. Supavisor rejected connections with `MaxClientsInSessionMode` errors because 100 far exceeds the ~15-20 backend connection limit per user/db/mode.
+
+### Transaction mode (Attempt 2)
+Transaction mode on port 6543 returned the physical Postgres connection to Supavisor's pool after every query. Each subsequent EF Core query re-established a physical connection through Supavisor, adding ~7.5 seconds per query. Intermittent TCP timeouts to Supavisor compounded the problem. Transaction mode is designed for serverless workloads, not persistent API servers.
+
+### Transaction mode with multiplexing (Attempt 3)
+Adding `Multiplexing=true` to the connection string kept existing Npgsql connections alive (0ms reopens), but new TCP connections to Supavisor still intermittently timed out. Npgsql's multiplexing is also experimental and not validated with Supavisor.

--- a/docs/db-connection-troubleshooting.md
+++ b/docs/db-connection-troubleshooting.md
@@ -1,0 +1,138 @@
+# Database Connection Troubleshooting
+
+A walkthrough of debugging production database connection failures between Render (free tier) and Supabase (free tier), and how the issue was ultimately resolved.
+
+## Problem Statement
+
+After deploying the F1 Fantasy API to Render's free tier, database connections were failing intermittently or completely. The API could not reliably reach the Supabase-hosted PostgreSQL database, resulting in request failures on every endpoint that touches the database.
+
+The initial page load fires two concurrent requests (`GET /api/me/profile` + `GET /api/me/team/`), so connection issues were immediately visible to users.
+
+## Investigation
+
+### Root Cause: IPv6 Incompatibility
+
+The core issue was a platform mismatch:
+
+- **Supabase** switched direct database connections (`db.*.supabase.co`) to **IPv6-only** in February 2024. IPv4 access requires a paid add-on ($4/month).
+- **Render's free tier** does **not support IPv6 outbound** connections.
+
+This meant the API couldn't reach Supabase's direct connection host at all. The only path was through **Supavisor** (`aws-1-us-east-2.pooler.supabase.com`), Supabase's connection pooler, which still accepts IPv4.
+
+### Why This Was Hard to Diagnose
+
+- Supabase has **zero .NET/C#/Npgsql documentation** — all connection guides target JS/Python
+- The few .NET + Supabase tutorials assume direct connections (which don't work from Render)
+- Npgsql's default `Maximum Pool Size=100` silently exceeds Supavisor free tier limits
+- Error messages from Supavisor were not always self-explanatory
+
+## Attempts and Failures
+
+### Attempt 1: Session Mode with Default Pool Size
+
+**Configuration:** Session mode (port 5432 via Supavisor pooler), default Npgsql settings.
+
+**Error:** `MaxClientsInSessionMode` — pool exhaustion.
+
+**Why it failed:** Npgsql defaults to `Maximum Pool Size=100`. In session mode, each Npgsql pooled connection maps 1:1 to a Supavisor backend connection. Supavisor's free tier allows only ~15-20 backend connections per user/db/mode. The Npgsql pool tried to open far more connections than Supavisor would allow.
+
+### Attempt 2: Transaction Mode
+
+**Configuration:** Transaction mode (port 6543 via Supavisor pooler).
+
+**Error:** Per-query physical reconnection (~7.5 seconds each), intermittent TCP timeouts.
+
+**Why it failed:** Transaction mode returns the physical Postgres connection to Supavisor's pool after every implicit transaction (i.e., every EF Core query). For a persistent API server, this means every query in a request pays a full reconnection cost through Supavisor. This is by design — transaction mode is built for serverless workloads with short-lived connections, not persistent servers that issue multiple queries per request.
+
+The `ConnectionDiagnosticsInterceptor` logs confirmed this: repeated `Slow DB connection` entries with the same connection GUID showed the same logical connection re-establishing physical connections on every query.
+
+### Attempt 3: Transaction Mode with Multiplexing
+
+**Configuration:** Transaction mode (port 6543) + `Multiplexing=true` in the connection string.
+
+**Error:** New TCP connections to Supavisor still intermittently timed out.
+
+**Why it failed:** Multiplexing kept *existing* Npgsql connections alive (0ms reopens for reused connections), but establishing *new* TCP connections to Supavisor still hit intermittent timeouts. Additionally, Npgsql's multiplexing feature is experimental and has not been validated with Supavisor.
+
+## Solution
+
+### Configuration
+
+**Session mode (port 5432)** via Supavisor with `Maximum Pool Size=10`:
+
+```
+User Id=postgres.<project-ref>;Password=<pw>;Server=aws-1-us-east-2.pooler.supabase.com;Port=5432;Database=postgres;SSL Mode=Require;Maximum Pool Size=10
+```
+
+Combined with EF Core retry-on-failure in `api/F1CompanionApi/Extensions/ServiceExtensions.cs`:
+
+```csharp
+options.UseNpgsql(connectionString, npgsqlOptions =>
+    npgsqlOptions.EnableRetryOnFailure(
+        maxRetryCount: 3,
+        maxRetryDelay: TimeSpan.FromSeconds(5),
+        errorCodesToAdd: null
+    ))
+```
+
+### Why It Works
+
+- **Session mode** keeps the backend Postgres connection tied to the client connection for its lifetime — no per-query reconnection overhead
+- **Pool size of 10** stays safely within Supavisor's ~15-20 backend connection limit per user/db/mode
+- **EF Core retry** handles transient failures during cold starts or brief Supavisor hiccups
+- Both Render and Supabase are in the same AWS region (Ohio), so latency through the pooler is minimal
+
+## Diagnostics
+
+### ConnectionDiagnosticsInterceptor
+
+Added in `api/F1CompanionApi/Data/ConnectionDiagnosticsInterceptor.cs`, this EF Core `DbConnectionInterceptor` logs every connection open and failure:
+
+- **Normal connections:** `DB connection {ConnectionId} to {Host}:{Port} opened in {DurationMs}ms` (Info level)
+- **Slow connections (>1s):** `Slow DB connection {ConnectionId} to {Host}:{Port} opened in {DurationMs}ms` (Warning level)
+- **Failed connections:** Full error with exception, connection ID, host:port, duration, and connection state (Error level)
+
+**What to look for in Render logs:**
+- `Slow DB connection` warnings — indicates Supavisor or network latency issues
+- Repeated slow connections with the **same connection GUID** — suggests transaction mode re-establishment overhead (shouldn't happen with session mode)
+- `MaxClientsInSessionMode` errors — pool size exceeds Supavisor limits
+- Connection failures with TCP timeout — potential Supavisor or network issues
+
+### Viewing Logs
+
+Use the Render MCP server to check production logs:
+- `mcp__render__list_logs` with service ID `srv-d2pqsbbe5dus73bcttfg`
+
+## Reference
+
+### Supabase Free Tier Limits
+
+| Limit | Value |
+|---|---|
+| Max database connections | 60 |
+| Max pooler client connections | 200 |
+| Backend connections per user/db/mode | ~15-20 |
+
+### Key Connection String Parameters
+
+| Parameter | Value | Why |
+|---|---|---|
+| `Server` | `aws-1-us-east-2.pooler.supabase.com` | Supavisor pooler (IPv4 accessible) |
+| `Port` | `5432` | Session mode |
+| `SSL Mode` | `Require` | Required by Supabase |
+| `Maximum Pool Size` | `10` | Stay within Supavisor backend limit |
+| `User Id` | `postgres.<project-ref>` | Supavisor requires project ref suffix |
+
+### Key Files
+
+| File | Purpose |
+|---|---|
+| `api/F1CompanionApi/Extensions/ServiceExtensions.cs` | DB connection configuration and EF Core retry setup |
+| `api/F1CompanionApi/Data/ConnectionDiagnosticsInterceptor.cs` | Connection logging and slow-query detection |
+
+### Relevant Links
+
+- [Supabase Connection Pooler docs](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pooler)
+- [Supabase IPv6 announcement](https://supabase.com/docs/guides/platform/ipv6)
+- [Npgsql connection string parameters](https://www.npgsql.org/doc/connection-string-parameters.html)
+- [Render IPv6 support discussion](https://feedback.render.com/features/p/ipv6-support)


### PR DESCRIPTION
## Summary
- Add ADR 001 documenting the Supabase connection strategy decision (session mode via Supavisor, `Maximum Pool Size=10`) and the three failed alternatives
- Add troubleshooting doc with the full debugging narrative: problem, investigation, each failed attempt with errors, and the final solution
- Add production infrastructure section to root `CLAUDE.md` and observability docs to `api/CLAUDE.md`
- Lower normal DB connection log level from `Information` to `Debug` to reduce production log noise (slow/failed connections remain at Warning/Error)

## Test plan
- [x] Build passes
- [x] All 316 unit tests pass
- [x] No secrets or credentials in documentation
- [x] Connection string examples use placeholders (`<pw>`, `<project-ref>`)