### PR TITLE
Improve Claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,12 +3,16 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    paths:
+      # Frontend
+      - "web/src/**/*.ts"
+      - "web/src/**/*.tsx"
+      - "web/src/**/*.js"
+      - "web/src/**/*.jsx"
+      # Backend
+      - "api/**/*.cs"
+      - "api/**/*.csproj"
+      - "api/**/*.json"
 
 jobs:
   claude-review:
@@ -38,7 +42,10 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment
+
+            Always post a summary comment on the PR, even if no issues are found.'
+          show_full_output: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- Enable `show_full_output` so Claude's review output is visible in action logs
- Add `--comment` flag and instruction to always post a PR summary comment, even when no issues are found
- Add path filters to only trigger the review on source code changes (web/src and api), not docs or config files