### PR TITLE
Fix API response time variance on Fly.io

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,18 +92,17 @@ Open this folder in VSCode and use:
 
 ## Production Infrastructure
 
-Hosted on Render (free tier, spins down after inactivity) + Supabase (free tier).
+Hosted on Fly.io + Supabase (free tier).
 
 | Resource | Identifier |
 |---|---|
-| Render service name | `f1fantasyappapi` |
-| Render service ID | `srv-d2pqsbbe5dus73bcttfg` |
+| Fly.io app name | `f1fantasyapp` |
+| Fly.io region | `iad` (Virginia) |
 | Supabase project ref | `cfuccajsckqzecbfyqrv` |
-| Supabase pooler host | `aws-1-us-east-2.pooler.supabase.com` |
 | Supabase direct DB host | `db.cfuccajsckqzecbfyqrv.supabase.co` |
 
 **MCP servers available for investigation:**
-- `mcp__render__list_logs` — runtime logs from the API (use `srv-d2pqsbbe5dus73bcttfg`)
+- `fly logs -a f1fantasyapp` — runtime logs from the API
 - `mcp__sentry__search_events` — error events (project slug: `f1-fantasy-api` or `f1-fantasy-web`, org: `emsqrd`, regionUrl: `https://us.sentry.io`)
 - `mcp__supabase__get_logs` — Postgres and API gateway logs (service: `postgres` or `api`)
 

--- a/api/F1CompanionApi/appsettings.json
+++ b/api/F1CompanionApi/appsettings.json
@@ -18,6 +18,6 @@
     "MinimumBreadcrumbLevel": "Information",
     "MinimumEventLevel": "Error",
     "Debug": false,
-    "TracesSampleRate": 1.0
+    "TracesSampleRate": 0.1
   }
 }

--- a/api/fly.toml
+++ b/api/fly.toml
@@ -1,4 +1,4 @@
-app = "f1fantasyappapi"
+app = "f1fantasyapp"
 primary_region = "iad"
 
 [build]
@@ -13,4 +13,4 @@ primary_region = "iad"
 
 [[vm]]
   size = "shared-cpu-1x"
-  memory = "256mb"
+  memory = "512mb"


### PR DESCRIPTION
## Summary

- Increase Fly.io VM memory from 256MB to 512MB — root cause of 2-8s response time spikes was GC pressure (only 11MB available memory, no swap)
- Reduce Sentry TracesSampleRate default from 1.0 to 0.1 — 100% tracing added unnecessary memory overhead
- Fix Fly.io app name in fly.toml (`f1fantasyappapi` → `f1fantasyapp`)
- Update CLAUDE.md infrastructure section for Fly.io migration (remove stale Render references)

## Investigation Findings

**Root cause**: The 256MB VM had only 11MB available memory with no swap. .NET's garbage collector was running under extreme pressure, causing multi-second stop-the-world pauses that froze in-flight operations (including DB connection establishment, showing as 2.8s and 7.9s connection open times in logs).

**Evidence**:
- `MemAvailable: 11,628 KB` (before) → `MemAvailable: 356,836 KB` (after)
- DbCommand times degraded from 22ms to 512-713ms over time, then recovered to 22ms after restart
- TCP connect from Fly (IAD) to Supabase (Ohio) is only 20-39ms — network latency was not the issue
- No `Sentry__TracesSampleRate` override existed, so 100% of requests were traced

## Test plan

- [x] Deployed to Fly.io and verified memory improvement (11MB → 348MB available)
- [x] Verified `Sentry__TracesSampleRate=0.1` secret deployed
- [x] DbCommand times consistently 21-22ms post-fix (vs 512-713ms before)
- [x] All 318 unit tests passing
- [ ] Monitor for idle-period response times over next few days to confirm spikes are eliminated