### PR TITLE
Season-based driver/constructor associations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ React SPA (Vite) → .NET 9 Minimal API → PostgreSQL
 ## Claude Code Preferences
 
 - Avoid over-engineering; keep solutions focused on the requested task
+- Adhere to YAGNI philosophy
 - When in doubt about approach, ask rather than proceed
 - Keep solutions focused on solving the cause of a problem, not the symptom
 - Use conventional commit styling for commit messages
@@ -94,14 +95,15 @@ Open this folder in VSCode and use:
 
 Hosted on Fly.io + Supabase (free tier).
 
-| Resource | Identifier |
-|---|---|
-| Fly.io app name | `f1fantasyapp` |
-| Fly.io region | `iad` (Virginia) |
-| Supabase project ref | `cfuccajsckqzecbfyqrv` |
+| Resource                | Identifier                            |
+| ----------------------- | ------------------------------------- |
+| Fly.io app name         | `f1fantasyapp`                        |
+| Fly.io region           | `iad` (Virginia)                      |
+| Supabase project ref    | `cfuccajsckqzecbfyqrv`                |
 | Supabase direct DB host | `db.cfuccajsckqzecbfyqrv.supabase.co` |
 
 **MCP servers available for investigation:**
+
 - `fly logs -a f1fantasyapp` — runtime logs from the API
 - `mcp__sentry__search_events` — error events (project slug: `f1-fantasy-api` or `f1-fantasy-web`, org: `emsqrd`, regionUrl: `https://us.sentry.io`)
 - `mcp__supabase__get_logs` — Postgres and API gateway logs (service: `postgres` or `api`)

--- a/api/F1CompanionApi.UnitTests/Api/Endpoints/ConstructorEndpointsTests.cs
+++ b/api/F1CompanionApi.UnitTests/Api/Endpoints/ConstructorEndpointsTests.cs
@@ -32,7 +32,6 @@ public class ConstructorEndpointsTests
                 FullName = "McLaren F1 Team",
                 Abbreviation = "MCL",
                 CountryAbbreviation = "GBR",
-                IsActive = true,
             },
             new ConstructorResponse
             {
@@ -41,7 +40,6 @@ public class ConstructorEndpointsTests
                 FullName = "Scuderia Ferrari",
                 Abbreviation = "FER",
                 CountryAbbreviation = "ITA",
-                IsActive = true,
             },
         };
 
@@ -57,7 +55,7 @@ public class ConstructorEndpointsTests
     }
 
     [Fact]
-    public async Task GetConstructorsAsync_WithActiveOnlyTrue_ReturnsOnlyActiveConstructors()
+    public async Task GetConstructorsAsync_WithSeasonYear_PassesSeasonYearToService()
     {
         // Arrange
         var constructors = new List<ConstructorResponse>
@@ -69,20 +67,18 @@ public class ConstructorEndpointsTests
                 FullName = "McLaren F1 Team",
                 Abbreviation = "MCL",
                 CountryAbbreviation = "GBR",
-                IsActive = true,
             },
         };
 
-        _mockConstructorService.Setup(x => x.GetConstructorsAsync(true)).ReturnsAsync(constructors);
+        _mockConstructorService.Setup(x => x.GetConstructorsAsync(2026)).ReturnsAsync(constructors);
 
         // Act
-        var result = await InvokeGetConstructorsAsync(true);
+        var result = await InvokeGetConstructorsAsync(2026);
 
         // Assert
         Assert.IsType<Ok<IEnumerable<ConstructorResponse>>>(result);
         var okResult = (Ok<IEnumerable<ConstructorResponse>>)result;
         Assert.Single(okResult.Value!);
-        Assert.True(okResult.Value!.First().IsActive);
     }
 
     [Fact]
@@ -96,7 +92,6 @@ public class ConstructorEndpointsTests
             FullName = "McLaren F1 Team",
             Abbreviation = "MCL",
             CountryAbbreviation = "GBR",
-            IsActive = true,
         };
 
         _mockConstructorService.Setup(x => x.GetConstructorByIdAsync(1)).ReturnsAsync(constructor);
@@ -148,45 +143,6 @@ public class ConstructorEndpointsTests
         Assert.Empty(okResult.Value!);
     }
 
-    [Fact]
-    public async Task GetConstructorsAsync_WithActiveOnlyFalse_ReturnsAllConstructors()
-    {
-        // Arrange
-        var constructors = new List<ConstructorResponse>
-        {
-            new ConstructorResponse
-            {
-                Id = 1,
-                Name = "McLaren",
-                FullName = "McLaren F1 Team",
-                Abbreviation = "MCL",
-                CountryAbbreviation = "GBR",
-                IsActive = true,
-            },
-            new ConstructorResponse
-            {
-                Id = 2,
-                Name = "Williams",
-                FullName = "Williams Racing",
-                Abbreviation = "WIL",
-                CountryAbbreviation = "GBR",
-                IsActive = false,
-            },
-        };
-
-        _mockConstructorService
-            .Setup(x => x.GetConstructorsAsync(false))
-            .ReturnsAsync(constructors);
-
-        // Act
-        var result = await InvokeGetConstructorsAsync(false);
-
-        // Assert
-        Assert.IsType<Ok<IEnumerable<ConstructorResponse>>>(result);
-        var okResult = (Ok<IEnumerable<ConstructorResponse>>)result;
-        Assert.Equal(2, okResult.Value!.Count());
-    }
-
     [Theory]
     [InlineData(0)]
     [InlineData(-1)]
@@ -218,7 +174,6 @@ public class ConstructorEndpointsTests
             FullName = "Oracle Red Bull Racing",
             Abbreviation = "RBR",
             CountryAbbreviation = "AUT",
-            IsActive = true,
         };
 
         _mockConstructorService.Setup(x => x.GetConstructorByIdAsync(1)).ReturnsAsync(constructor);
@@ -236,7 +191,7 @@ public class ConstructorEndpointsTests
         Assert.NotEmpty(okResult.Value.CountryAbbreviation);
     }
 
-    private async Task<IResult> InvokeGetConstructorsAsync(bool? activeOnly)
+    private async Task<IResult> InvokeGetConstructorsAsync(int? seasonYear)
     {
         var method = typeof(ConstructorEndpoints).GetMethod(
             "GetConstructorsAsync",
@@ -247,7 +202,7 @@ public class ConstructorEndpointsTests
             (Task<IResult>)
                 method!.Invoke(
                     null,
-                    [_mockConstructorService.Object, activeOnly, _mockLogger.Object]
+                    new object?[] { _mockConstructorService.Object, seasonYear, _mockLogger.Object }
                 )!;
 
         return await task;

--- a/api/F1CompanionApi.UnitTests/Api/Endpoints/DriverEndpointsTests.cs
+++ b/api/F1CompanionApi.UnitTests/Api/Endpoints/DriverEndpointsTests.cs
@@ -55,7 +55,7 @@ public class DriverEndpointsTests
     }
 
     [Fact]
-    public async Task GetDriversAsync_WithActiveOnlyTrue_ReturnsOnlyActiveDrivers()
+    public async Task GetDriversAsync_WithSeasonYear_PassesSeasonYearToService()
     {
         // Arrange
         var drivers = new List<DriverResponse>
@@ -70,10 +70,10 @@ public class DriverEndpointsTests
             },
         };
 
-        _mockDriverService.Setup(x => x.GetDriversAsync(true)).ReturnsAsync(drivers);
+        _mockDriverService.Setup(x => x.GetDriversAsync(2026)).ReturnsAsync(drivers);
 
         // Act
-        var result = await InvokeGetDriversAsync(true);
+        var result = await InvokeGetDriversAsync(2026);
 
         // Assert
         Assert.IsType<Ok<IEnumerable<DriverResponse>>>(result);
@@ -141,41 +141,6 @@ public class DriverEndpointsTests
         Assert.Empty(okResult.Value!);
     }
 
-    [Fact]
-    public async Task GetDriversAsync_WithActiveOnlyFalse_ReturnsAllDrivers()
-    {
-        // Arrange
-        var drivers = new List<DriverResponse>
-        {
-            new DriverResponse
-            {
-                Id = 1,
-                FirstName = "Oscar",
-                LastName = "Piastri",
-                Abbreviation = "PIA",
-                CountryAbbreviation = "AUS",
-            },
-            new DriverResponse
-            {
-                Id = 2,
-                FirstName = "Fernando",
-                LastName = "Alonso",
-                Abbreviation = "ALO",
-                CountryAbbreviation = "ESP",
-            },
-        };
-
-        _mockDriverService.Setup(x => x.GetDriversAsync(false)).ReturnsAsync(drivers);
-
-        // Act
-        var result = await InvokeGetDriversAsync(false);
-
-        // Assert
-        Assert.IsType<Ok<IEnumerable<DriverResponse>>>(result);
-        var okResult = (Ok<IEnumerable<DriverResponse>>)result;
-        Assert.Equal(2, okResult.Value!.Count());
-    }
-
     [Theory]
     [InlineData(0)]
     [InlineData(-1)]
@@ -222,7 +187,7 @@ public class DriverEndpointsTests
         Assert.NotEmpty(okResult.Value.CountryAbbreviation);
     }
 
-    private async Task<IResult> InvokeGetDriversAsync(bool? activeOnly)
+    private async Task<IResult> InvokeGetDriversAsync(int? seasonYear)
     {
         var method = typeof(DriverEndpoints).GetMethod(
             "GetDriversAsync",
@@ -233,7 +198,7 @@ public class DriverEndpointsTests
             (Task<IResult>)
                 method!.Invoke(
                     null,
-                    new object?[] { _mockDriverService.Object, activeOnly, _mockLogger.Object }
+                    new object?[] { _mockDriverService.Object, seasonYear, _mockLogger.Object }
                 )!;
 
         return await task;

--- a/api/F1CompanionApi.UnitTests/Api/Endpoints/TeamEndpointsTests.cs
+++ b/api/F1CompanionApi.UnitTests/Api/Endpoints/TeamEndpointsTests.cs
@@ -309,7 +309,6 @@ public class TeamEndpointsTests
             LastName = "Hamilton",
             Abbreviation = "HAM",
             CountryAbbreviation = "GBR",
-            IsActive = true,
         };
 
         var constructor = new Constructor
@@ -319,7 +318,6 @@ public class TeamEndpointsTests
             FullName = "Mercedes-AMG Petronas F1 Team",
             Abbreviation = "MER",
             CountryAbbreviation = "GER",
-            IsActive = true,
         };
 
         var team = new Team

--- a/api/F1CompanionApi.UnitTests/Services/ConstructorServiceTests.cs
+++ b/api/F1CompanionApi.UnitTests/Services/ConstructorServiceTests.cs
@@ -50,7 +50,6 @@ public class ConstructorServiceTests
             FullName = "McLaren F1 Team",
             Abbreviation = "MCL",
             CountryAbbreviation = "GBR",
-            IsActive = true,
         };
         var constructor2 = new Constructor
         {
@@ -58,7 +57,6 @@ public class ConstructorServiceTests
             FullName = "Williams Racing",
             Abbreviation = "WIL",
             CountryAbbreviation = "GBR",
-            IsActive = true,
         };
 
         context.Seasons.Add(season);
@@ -110,7 +108,6 @@ public class ConstructorServiceTests
             FullName = "McLaren F1 Team",
             Abbreviation = "MCL",
             CountryAbbreviation = "GBR",
-            IsActive = true,
         };
 
         context.Seasons.Add(season);
@@ -161,7 +158,6 @@ public class ConstructorServiceTests
             FullName = "McLaren F1 Team",
             Abbreviation = "MCL",
             CountryAbbreviation = "GBR",
-            IsActive = true,
         };
         var inactiveConstructor = new Constructor
         {
@@ -169,7 +165,6 @@ public class ConstructorServiceTests
             FullName = "Williams Racing",
             Abbreviation = "WIL",
             CountryAbbreviation = "GBR",
-            IsActive = true,
         };
 
         context.Seasons.Add(season);
@@ -227,7 +222,6 @@ public class ConstructorServiceTests
             FullName = "Oracle Red Bull Racing",
             Abbreviation = "RBR",
             CountryAbbreviation = "AUT",
-            IsActive = true,
         };
         var constructor2 = new Constructor
         {
@@ -235,7 +229,6 @@ public class ConstructorServiceTests
             FullName = "Scuderia Ferrari",
             Abbreviation = "FER",
             CountryAbbreviation = "ITA",
-            IsActive = true,
         };
 
         context.Seasons.Add(season);
@@ -308,7 +301,6 @@ public class ConstructorServiceTests
             FullName = "McLaren F1 Team",
             Abbreviation = "MCL",
             CountryAbbreviation = "GBR",
-            IsActive = true,
         };
 
         context.Constructors.Add(constructor);

--- a/api/F1CompanionApi.UnitTests/Services/ConstructorServiceTests.cs
+++ b/api/F1CompanionApi.UnitTests/Services/ConstructorServiceTests.cs
@@ -10,10 +10,12 @@ namespace F1CompanionApi.UnitTests.Services;
 public class ConstructorServiceTests
 {
     private readonly Mock<ILogger<ConstructorService>> _mockLogger;
+    private readonly Mock<ISeasonService> _mockSeasonService;
 
     public ConstructorServiceTests()
     {
         _mockLogger = new Mock<ILogger<ConstructorService>>();
+        _mockSeasonService = new Mock<ISeasonService>();
     }
 
     private ApplicationDbContext CreateInMemoryContext()
@@ -26,78 +28,178 @@ public class ConstructorServiceTests
     }
 
     [Fact]
-    public async Task GetConstructorsAsync_ReturnsAllConstructors_WhenActiveOnlyIsNull()
+    public async Task GetConstructorsAsync_WithSeasonYear_ReturnsConstructorsForThatSeason()
     {
         // Arrange
         using var context = CreateInMemoryContext();
-        var service = new ConstructorService(context, _mockLogger.Object);
+        var service = new ConstructorService(
+            context,
+            _mockSeasonService.Object,
+            _mockLogger.Object
+        );
 
-        var constructors = new[]
+        var season = new Season
         {
-            new Constructor
-            {
-                Name = "McLaren",
-                FullName = "McLaren F1 Team",
-                Abbreviation = "MCL",
-                CountryAbbreviation = "GBR",
-                IsActive = true,
-            },
-            new Constructor
-            {
-                Name = "Williams",
-                FullName = "Williams Racing",
-                Abbreviation = "WIL",
-                CountryAbbreviation = "GBR",
-                IsActive = false,
-            },
+            Year = 2026,
+            StartDate = new DateTime(2026, 3, 1),
+            EndDate = new DateTime(2026, 12, 1),
+        };
+        var constructor1 = new Constructor
+        {
+            Name = "McLaren",
+            FullName = "McLaren F1 Team",
+            Abbreviation = "MCL",
+            CountryAbbreviation = "GBR",
+            IsActive = true,
+        };
+        var constructor2 = new Constructor
+        {
+            Name = "Williams",
+            FullName = "Williams Racing",
+            Abbreviation = "WIL",
+            CountryAbbreviation = "GBR",
+            IsActive = true,
         };
 
-        context.Constructors.AddRange(constructors);
+        context.Seasons.Add(season);
+        context.Constructors.AddRange(constructor1, constructor2);
         await context.SaveChangesAsync();
+
+        // Only link constructor1 to the 2026 season
+        context.SeasonConstructors.Add(
+            new SeasonConstructor
+            {
+                SeasonId = season.Id,
+                ConstructorId = constructor1.Id,
+                IsActive = true,
+            }
+        );
+        await context.SaveChangesAsync();
+
+        _mockSeasonService.Setup(s => s.GetSeasonAsync(2026)).ReturnsAsync(season);
+
+        // Act
+        var result = await service.GetConstructorsAsync(2026);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Equal("McLaren", result.First().Name);
+    }
+
+    [Fact]
+    public async Task GetConstructorsAsync_WithNoSeasonYear_UsesCurrentSeason()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new ConstructorService(
+            context,
+            _mockSeasonService.Object,
+            _mockLogger.Object
+        );
+
+        var season = new Season
+        {
+            Year = 2026,
+            StartDate = new DateTime(2026, 3, 1),
+            EndDate = new DateTime(2026, 12, 1),
+        };
+        var constructor = new Constructor
+        {
+            Name = "McLaren",
+            FullName = "McLaren F1 Team",
+            Abbreviation = "MCL",
+            CountryAbbreviation = "GBR",
+            IsActive = true,
+        };
+
+        context.Seasons.Add(season);
+        context.Constructors.Add(constructor);
+        await context.SaveChangesAsync();
+
+        context.SeasonConstructors.Add(
+            new SeasonConstructor
+            {
+                SeasonId = season.Id,
+                ConstructorId = constructor.Id,
+                IsActive = true,
+            }
+        );
+        await context.SaveChangesAsync();
+
+        _mockSeasonService.Setup(s => s.GetSeasonAsync(null)).ReturnsAsync(season);
 
         // Act
         var result = await service.GetConstructorsAsync(null);
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal(2, result.Count());
+        Assert.Single(result);
+        Assert.Equal("McLaren", result.First().Name);
     }
 
     [Fact]
-    public async Task GetConstructorsAsync_ReturnsOnlyActiveConstructors_WhenActiveOnlyIsTrue()
+    public async Task GetConstructorsAsync_ExcludesInactiveSeasonConstructors()
     {
         // Arrange
         using var context = CreateInMemoryContext();
-        var service = new ConstructorService(context, _mockLogger.Object);
+        var service = new ConstructorService(
+            context,
+            _mockSeasonService.Object,
+            _mockLogger.Object
+        );
 
-        var constructors = new[]
+        var season = new Season
         {
-            new Constructor
-            {
-                Name = "McLaren",
-                FullName = "McLaren F1 Team",
-                Abbreviation = "MCL",
-                CountryAbbreviation = "GBR",
-                IsActive = true,
-            },
-            new Constructor
-            {
-                Name = "Williams",
-                FullName = "Williams Racing",
-                Abbreviation = "WIL",
-                CountryAbbreviation = "GBR",
-                IsActive = false,
-            },
+            Year = 2026,
+            StartDate = new DateTime(2026, 3, 1),
+            EndDate = new DateTime(2026, 12, 1),
+        };
+        var activeConstructor = new Constructor
+        {
+            Name = "McLaren",
+            FullName = "McLaren F1 Team",
+            Abbreviation = "MCL",
+            CountryAbbreviation = "GBR",
+            IsActive = true,
+        };
+        var inactiveConstructor = new Constructor
+        {
+            Name = "Williams",
+            FullName = "Williams Racing",
+            Abbreviation = "WIL",
+            CountryAbbreviation = "GBR",
+            IsActive = true,
         };
 
-        context.Constructors.AddRange(constructors);
+        context.Seasons.Add(season);
+        context.Constructors.AddRange(activeConstructor, inactiveConstructor);
         await context.SaveChangesAsync();
 
+        context.SeasonConstructors.Add(
+            new SeasonConstructor
+            {
+                SeasonId = season.Id,
+                ConstructorId = activeConstructor.Id,
+                IsActive = true,
+            }
+        );
+        context.SeasonConstructors.Add(
+            new SeasonConstructor
+            {
+                SeasonId = season.Id,
+                ConstructorId = inactiveConstructor.Id,
+                IsActive = false,
+            }
+        );
+        await context.SaveChangesAsync();
+
+        _mockSeasonService.Setup(s => s.GetSeasonAsync(2026)).ReturnsAsync(season);
+
         // Act
-        var result = await service.GetConstructorsAsync(true);
+        var result = await service.GetConstructorsAsync(2026);
 
         // Assert
-        Assert.NotNull(result);
         Assert.Single(result);
         Assert.Equal("McLaren", result.First().Name);
     }
@@ -107,33 +209,61 @@ public class ConstructorServiceTests
     {
         // Arrange
         using var context = CreateInMemoryContext();
-        var service = new ConstructorService(context, _mockLogger.Object);
+        var service = new ConstructorService(
+            context,
+            _mockSeasonService.Object,
+            _mockLogger.Object
+        );
 
-        var constructors = new[]
+        var season = new Season
         {
-            new Constructor
-            {
-                Name = "Red Bull Racing",
-                FullName = "Oracle Red Bull Racing",
-                Abbreviation = "RBR",
-                CountryAbbreviation = "AUT",
-                IsActive = true,
-            },
-            new Constructor
-            {
-                Name = "Ferrari",
-                FullName = "Scuderia Ferrari",
-                Abbreviation = "FER",
-                CountryAbbreviation = "ITA",
-                IsActive = true,
-            },
+            Year = 2026,
+            StartDate = new DateTime(2026, 3, 1),
+            EndDate = new DateTime(2026, 12, 1),
+        };
+        var constructor1 = new Constructor
+        {
+            Name = "Red Bull Racing",
+            FullName = "Oracle Red Bull Racing",
+            Abbreviation = "RBR",
+            CountryAbbreviation = "AUT",
+            IsActive = true,
+        };
+        var constructor2 = new Constructor
+        {
+            Name = "Ferrari",
+            FullName = "Scuderia Ferrari",
+            Abbreviation = "FER",
+            CountryAbbreviation = "ITA",
+            IsActive = true,
         };
 
-        context.Constructors.AddRange(constructors);
+        context.Seasons.Add(season);
+        context.Constructors.AddRange(constructor1, constructor2);
         await context.SaveChangesAsync();
 
+        context.SeasonConstructors.Add(
+            new SeasonConstructor
+            {
+                SeasonId = season.Id,
+                ConstructorId = constructor1.Id,
+                IsActive = true,
+            }
+        );
+        context.SeasonConstructors.Add(
+            new SeasonConstructor
+            {
+                SeasonId = season.Id,
+                ConstructorId = constructor2.Id,
+                IsActive = true,
+            }
+        );
+        await context.SaveChangesAsync();
+
+        _mockSeasonService.Setup(s => s.GetSeasonAsync(2026)).ReturnsAsync(season);
+
         // Act
-        var result = await service.GetConstructorsAsync(null);
+        var result = await service.GetConstructorsAsync(2026);
 
         // Assert
         var constructorList = result.ToList();
@@ -142,11 +272,35 @@ public class ConstructorServiceTests
     }
 
     [Fact]
+    public async Task GetConstructorsAsync_NoSeasons_ReturnsEmptyList()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new ConstructorService(
+            context,
+            _mockSeasonService.Object,
+            _mockLogger.Object
+        );
+
+        _mockSeasonService.Setup(s => s.GetSeasonAsync(null)).ReturnsAsync((Season?)null);
+
+        // Act
+        var result = await service.GetConstructorsAsync(null);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
     public async Task GetConstructorByIdAsync_ExistingConstructor_ReturnsConstructor()
     {
         // Arrange
         using var context = CreateInMemoryContext();
-        var service = new ConstructorService(context, _mockLogger.Object);
+        var service = new ConstructorService(
+            context,
+            _mockSeasonService.Object,
+            _mockLogger.Object
+        );
 
         var constructor = new Constructor
         {
@@ -175,7 +329,11 @@ public class ConstructorServiceTests
     {
         // Arrange
         using var context = CreateInMemoryContext();
-        var service = new ConstructorService(context, _mockLogger.Object);
+        var service = new ConstructorService(
+            context,
+            _mockSeasonService.Object,
+            _mockLogger.Object
+        );
 
         // Act
         var result = await service.GetConstructorByIdAsync(999);
@@ -189,7 +347,11 @@ public class ConstructorServiceTests
     {
         // Arrange
         using var context = CreateInMemoryContext();
-        var service = new ConstructorService(context, _mockLogger.Object);
+        var service = new ConstructorService(
+            context,
+            _mockSeasonService.Object,
+            _mockLogger.Object
+        );
 
         // Act
         var result = await service.GetConstructorByIdAsync(1);

--- a/api/F1CompanionApi.UnitTests/Services/DriverServiceTests.cs
+++ b/api/F1CompanionApi.UnitTests/Services/DriverServiceTests.cs
@@ -10,10 +10,12 @@ namespace F1CompanionApi.UnitTests.Services;
 public class DriverServiceTests
 {
     private readonly Mock<ILogger<DriverService>> _mockLogger;
+    private readonly Mock<ISeasonService> _mockSeasonService;
 
     public DriverServiceTests()
     {
         _mockLogger = new Mock<ILogger<DriverService>>();
+        _mockSeasonService = new Mock<ISeasonService>();
     }
 
     private ApplicationDbContext CreateInMemoryContext()
@@ -26,78 +28,197 @@ public class DriverServiceTests
     }
 
     [Fact]
-    public async Task GetDriversAsync_ReturnsAllDrivers_WhenActiveOnlyIsNull()
+    public async Task GetDriversAsync_WithSeasonYear_ReturnsDriversForThatSeason()
     {
         // Arrange
         using var context = CreateInMemoryContext();
-        var service = new DriverService(context, _mockLogger.Object);
+        var service = new DriverService(context, _mockSeasonService.Object, _mockLogger.Object);
 
-        var drivers = new[]
+        var season = new Season
         {
-            new Driver
-            {
-                FirstName = "Oscar",
-                LastName = "Piastri",
-                Abbreviation = "PIA",
-                CountryAbbreviation = "AUS",
-                IsActive = true,
-            },
-            new Driver
-            {
-                FirstName = "Fernando",
-                LastName = "Alonso",
-                Abbreviation = "ALO",
-                CountryAbbreviation = "ESP",
-                IsActive = false,
-            },
+            Year = 2026,
+            StartDate = new DateTime(2026, 3, 1),
+            EndDate = new DateTime(2026, 12, 1),
+        };
+        var constructor = new Constructor
+        {
+            Name = "McLaren",
+            FullName = "McLaren F1 Team",
+            Abbreviation = "MCL",
+            CountryAbbreviation = "GBR",
+            IsActive = true,
+        };
+        var driver1 = new Driver
+        {
+            FirstName = "Oscar",
+            LastName = "Piastri",
+            Abbreviation = "PIA",
+            CountryAbbreviation = "AUS",
+            IsActive = true,
+        };
+        var driver2 = new Driver
+        {
+            FirstName = "Fernando",
+            LastName = "Alonso",
+            Abbreviation = "ALO",
+            CountryAbbreviation = "ESP",
+            IsActive = true,
         };
 
-        context.Drivers.AddRange(drivers);
+        context.Seasons.Add(season);
+        context.Constructors.Add(constructor);
+        context.Drivers.AddRange(driver1, driver2);
         await context.SaveChangesAsync();
+
+        // Only link driver1 to the 2026 season
+        context.SeasonDrivers.Add(
+            new SeasonDriver
+            {
+                SeasonId = season.Id,
+                DriverId = driver1.Id,
+                ConstructorId = constructor.Id,
+                IsActive = true,
+            }
+        );
+        await context.SaveChangesAsync();
+
+        _mockSeasonService.Setup(s => s.GetSeasonAsync(2026)).ReturnsAsync(season);
+
+        // Act
+        var result = await service.GetDriversAsync(2026);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Equal("Piastri", result.First().LastName);
+    }
+
+    [Fact]
+    public async Task GetDriversAsync_WithNoSeasonYear_UsesCurrentSeason()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new DriverService(context, _mockSeasonService.Object, _mockLogger.Object);
+
+        var season = new Season
+        {
+            Year = 2026,
+            StartDate = new DateTime(2026, 3, 1),
+            EndDate = new DateTime(2026, 12, 1),
+        };
+        var constructor = new Constructor
+        {
+            Name = "McLaren",
+            FullName = "McLaren F1 Team",
+            Abbreviation = "MCL",
+            CountryAbbreviation = "GBR",
+            IsActive = true,
+        };
+        var driver = new Driver
+        {
+            FirstName = "Oscar",
+            LastName = "Piastri",
+            Abbreviation = "PIA",
+            CountryAbbreviation = "AUS",
+            IsActive = true,
+        };
+
+        context.Seasons.Add(season);
+        context.Constructors.Add(constructor);
+        context.Drivers.Add(driver);
+        await context.SaveChangesAsync();
+
+        context.SeasonDrivers.Add(
+            new SeasonDriver
+            {
+                SeasonId = season.Id,
+                DriverId = driver.Id,
+                ConstructorId = constructor.Id,
+                IsActive = true,
+            }
+        );
+        await context.SaveChangesAsync();
+
+        _mockSeasonService.Setup(s => s.GetSeasonAsync(null)).ReturnsAsync(season);
 
         // Act
         var result = await service.GetDriversAsync(null);
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal(2, result.Count());
+        Assert.Single(result);
+        Assert.Equal("Piastri", result.First().LastName);
     }
 
     [Fact]
-    public async Task GetDriversAsync_ReturnsOnlyActiveDrivers_WhenActiveOnlyIsTrue()
+    public async Task GetDriversAsync_ExcludesInactiveSeasonDrivers()
     {
         // Arrange
         using var context = CreateInMemoryContext();
-        var service = new DriverService(context, _mockLogger.Object);
+        var service = new DriverService(context, _mockSeasonService.Object, _mockLogger.Object);
 
-        var drivers = new[]
+        var season = new Season
         {
-            new Driver
-            {
-                FirstName = "Oscar",
-                LastName = "Piastri",
-                Abbreviation = "PIA",
-                CountryAbbreviation = "AUS",
-                IsActive = true,
-            },
-            new Driver
-            {
-                FirstName = "Fernando",
-                LastName = "Alonso",
-                Abbreviation = "ALO",
-                CountryAbbreviation = "ESP",
-                IsActive = false,
-            },
+            Year = 2026,
+            StartDate = new DateTime(2026, 3, 1),
+            EndDate = new DateTime(2026, 12, 1),
+        };
+        var constructor = new Constructor
+        {
+            Name = "McLaren",
+            FullName = "McLaren F1 Team",
+            Abbreviation = "MCL",
+            CountryAbbreviation = "GBR",
+            IsActive = true,
+        };
+        var activeDriver = new Driver
+        {
+            FirstName = "Oscar",
+            LastName = "Piastri",
+            Abbreviation = "PIA",
+            CountryAbbreviation = "AUS",
+            IsActive = true,
+        };
+        var inactiveDriver = new Driver
+        {
+            FirstName = "Fernando",
+            LastName = "Alonso",
+            Abbreviation = "ALO",
+            CountryAbbreviation = "ESP",
+            IsActive = true,
         };
 
-        context.Drivers.AddRange(drivers);
+        context.Seasons.Add(season);
+        context.Constructors.Add(constructor);
+        context.Drivers.AddRange(activeDriver, inactiveDriver);
         await context.SaveChangesAsync();
 
+        context.SeasonDrivers.Add(
+            new SeasonDriver
+            {
+                SeasonId = season.Id,
+                DriverId = activeDriver.Id,
+                ConstructorId = constructor.Id,
+                IsActive = true,
+            }
+        );
+        context.SeasonDrivers.Add(
+            new SeasonDriver
+            {
+                SeasonId = season.Id,
+                DriverId = inactiveDriver.Id,
+                ConstructorId = constructor.Id,
+                IsActive = false,
+            }
+        );
+        await context.SaveChangesAsync();
+
+        _mockSeasonService.Setup(s => s.GetSeasonAsync(2026)).ReturnsAsync(season);
+
         // Act
-        var result = await service.GetDriversAsync(true);
+        var result = await service.GetDriversAsync(2026);
 
         // Assert
-        Assert.NotNull(result);
         Assert.Single(result);
         Assert.Equal("Piastri", result.First().LastName);
     }
@@ -107,33 +228,68 @@ public class DriverServiceTests
     {
         // Arrange
         using var context = CreateInMemoryContext();
-        var service = new DriverService(context, _mockLogger.Object);
+        var service = new DriverService(context, _mockSeasonService.Object, _mockLogger.Object);
 
-        var drivers = new[]
+        var season = new Season
         {
-            new Driver
-            {
-                FirstName = "Max",
-                LastName = "Verstappen",
-                Abbreviation = "VER",
-                CountryAbbreviation = "NED",
-                IsActive = true,
-            },
-            new Driver
-            {
-                FirstName = "Fernando",
-                LastName = "Alonso",
-                Abbreviation = "ALO",
-                CountryAbbreviation = "ESP",
-                IsActive = true,
-            },
+            Year = 2026,
+            StartDate = new DateTime(2026, 3, 1),
+            EndDate = new DateTime(2026, 12, 1),
+        };
+        var constructor = new Constructor
+        {
+            Name = "McLaren",
+            FullName = "McLaren F1 Team",
+            Abbreviation = "MCL",
+            CountryAbbreviation = "GBR",
+            IsActive = true,
+        };
+        var driver1 = new Driver
+        {
+            FirstName = "Max",
+            LastName = "Verstappen",
+            Abbreviation = "VER",
+            CountryAbbreviation = "NED",
+            IsActive = true,
+        };
+        var driver2 = new Driver
+        {
+            FirstName = "Fernando",
+            LastName = "Alonso",
+            Abbreviation = "ALO",
+            CountryAbbreviation = "ESP",
+            IsActive = true,
         };
 
-        context.Drivers.AddRange(drivers);
+        context.Seasons.Add(season);
+        context.Constructors.Add(constructor);
+        context.Drivers.AddRange(driver1, driver2);
         await context.SaveChangesAsync();
 
+        context.SeasonDrivers.Add(
+            new SeasonDriver
+            {
+                SeasonId = season.Id,
+                DriverId = driver1.Id,
+                ConstructorId = constructor.Id,
+                IsActive = true,
+            }
+        );
+        context.SeasonDrivers.Add(
+            new SeasonDriver
+            {
+                SeasonId = season.Id,
+                DriverId = driver2.Id,
+                ConstructorId = constructor.Id,
+                IsActive = true,
+            }
+        );
+        await context.SaveChangesAsync();
+
+        _mockSeasonService.Setup(s => s.GetSeasonAsync(2026)).ReturnsAsync(season);
+
         // Act
-        var result = await service.GetDriversAsync(null);
+        var result = await service.GetDriversAsync(2026);
 
         // Assert
         var driverList = result.ToList();
@@ -142,11 +298,27 @@ public class DriverServiceTests
     }
 
     [Fact]
+    public async Task GetDriversAsync_NoSeasons_ReturnsEmptyList()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new DriverService(context, _mockSeasonService.Object, _mockLogger.Object);
+
+        _mockSeasonService.Setup(s => s.GetSeasonAsync(null)).ReturnsAsync((Season?)null);
+
+        // Act
+        var result = await service.GetDriversAsync(null);
+
+        // Assert
+        Assert.Empty(result);
+    }
+
+    [Fact]
     public async Task GetDriverByIdAsync_ExistingDriver_ReturnsDriver()
     {
         // Arrange
         using var context = CreateInMemoryContext();
-        var service = new DriverService(context, _mockLogger.Object);
+        var service = new DriverService(context, _mockSeasonService.Object, _mockLogger.Object);
 
         var driver = new Driver
         {
@@ -177,7 +349,7 @@ public class DriverServiceTests
     {
         // Arrange
         using var context = CreateInMemoryContext();
-        var service = new DriverService(context, _mockLogger.Object);
+        var service = new DriverService(context, _mockSeasonService.Object, _mockLogger.Object);
 
         // Act
         var result = await service.GetDriverByIdAsync(999);
@@ -191,7 +363,7 @@ public class DriverServiceTests
     {
         // Arrange
         using var context = CreateInMemoryContext();
-        var service = new DriverService(context, _mockLogger.Object);
+        var service = new DriverService(context, _mockSeasonService.Object, _mockLogger.Object);
 
         // Act
         var result = await service.GetDriverByIdAsync(1);

--- a/api/F1CompanionApi.UnitTests/Services/DriverServiceTests.cs
+++ b/api/F1CompanionApi.UnitTests/Services/DriverServiceTests.cs
@@ -46,7 +46,6 @@ public class DriverServiceTests
             FullName = "McLaren F1 Team",
             Abbreviation = "MCL",
             CountryAbbreviation = "GBR",
-            IsActive = true,
         };
         var driver1 = new Driver
         {
@@ -54,7 +53,6 @@ public class DriverServiceTests
             LastName = "Piastri",
             Abbreviation = "PIA",
             CountryAbbreviation = "AUS",
-            IsActive = true,
         };
         var driver2 = new Driver
         {
@@ -62,7 +60,6 @@ public class DriverServiceTests
             LastName = "Alonso",
             Abbreviation = "ALO",
             CountryAbbreviation = "ESP",
-            IsActive = true,
         };
 
         context.Seasons.Add(season);
@@ -112,7 +109,6 @@ public class DriverServiceTests
             FullName = "McLaren F1 Team",
             Abbreviation = "MCL",
             CountryAbbreviation = "GBR",
-            IsActive = true,
         };
         var driver = new Driver
         {
@@ -120,7 +116,6 @@ public class DriverServiceTests
             LastName = "Piastri",
             Abbreviation = "PIA",
             CountryAbbreviation = "AUS",
-            IsActive = true,
         };
 
         context.Seasons.Add(season);
@@ -169,7 +164,6 @@ public class DriverServiceTests
             FullName = "McLaren F1 Team",
             Abbreviation = "MCL",
             CountryAbbreviation = "GBR",
-            IsActive = true,
         };
         var activeDriver = new Driver
         {
@@ -177,7 +171,6 @@ public class DriverServiceTests
             LastName = "Piastri",
             Abbreviation = "PIA",
             CountryAbbreviation = "AUS",
-            IsActive = true,
         };
         var inactiveDriver = new Driver
         {
@@ -185,7 +178,6 @@ public class DriverServiceTests
             LastName = "Alonso",
             Abbreviation = "ALO",
             CountryAbbreviation = "ESP",
-            IsActive = true,
         };
 
         context.Seasons.Add(season);
@@ -242,7 +234,6 @@ public class DriverServiceTests
             FullName = "McLaren F1 Team",
             Abbreviation = "MCL",
             CountryAbbreviation = "GBR",
-            IsActive = true,
         };
         var driver1 = new Driver
         {
@@ -250,7 +241,6 @@ public class DriverServiceTests
             LastName = "Verstappen",
             Abbreviation = "VER",
             CountryAbbreviation = "NED",
-            IsActive = true,
         };
         var driver2 = new Driver
         {
@@ -258,7 +248,6 @@ public class DriverServiceTests
             LastName = "Alonso",
             Abbreviation = "ALO",
             CountryAbbreviation = "ESP",
-            IsActive = true,
         };
 
         context.Seasons.Add(season);
@@ -326,7 +315,6 @@ public class DriverServiceTests
             LastName = "Piastri",
             Abbreviation = "PIA",
             CountryAbbreviation = "AUS",
-            IsActive = true,
         };
 
         context.Drivers.Add(driver);

--- a/api/F1CompanionApi.UnitTests/Services/SeasonServiceTests.cs
+++ b/api/F1CompanionApi.UnitTests/Services/SeasonServiceTests.cs
@@ -652,4 +652,122 @@ public class SeasonServiceTests
     }
 
     #endregion
+
+    #region GetSeasonAsync Tests
+
+    [Fact]
+    public async Task GetSeasonAsync_WithYear_ReturnsSeason()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new SeasonService(context, _mockLogger.Object);
+
+        var season = new Season
+        {
+            Year = 2026,
+            StartDate = new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndDate = new DateTime(2026, 12, 1, 0, 0, 0, DateTimeKind.Utc),
+        };
+
+        context.Seasons.Add(season);
+        await context.SaveChangesAsync();
+
+        // Act
+        var result = await service.GetSeasonAsync(2026);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2026, result.Year);
+    }
+
+    [Fact]
+    public async Task GetSeasonAsync_WithYear_ReturnsNull_WhenYearNotFound()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new SeasonService(context, _mockLogger.Object);
+
+        // Act
+        var result = await service.GetSeasonAsync(2026);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetSeasonAsync_WithNull_DelegatesToGetCurrentSeasonAsync()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new SeasonService(context, _mockLogger.Object);
+
+        var now = DateTime.UtcNow;
+        var season = new Season
+        {
+            Year = 2024,
+            StartDate = now.AddMonths(-3),
+            EndDate = now.AddMonths(3),
+        };
+
+        context.Seasons.Add(season);
+        await context.SaveChangesAsync();
+
+        // Act
+        var result = await service.GetSeasonAsync(null);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2024, result.Year);
+    }
+
+    [Fact]
+    public async Task GetSeasonAsync_WithNull_FallsBackToLatestSeason_WhenNoCurrentSeason()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new SeasonService(context, _mockLogger.Object);
+
+        var now = DateTime.UtcNow;
+        var seasons = new[]
+        {
+            new Season
+            {
+                Year = 2023,
+                StartDate = now.AddYears(-2),
+                EndDate = now.AddDays(-10),
+            },
+            new Season
+            {
+                Year = 2024,
+                StartDate = now.AddDays(10),
+                EndDate = now.AddYears(1),
+            },
+        };
+
+        context.Seasons.AddRange(seasons);
+        await context.SaveChangesAsync();
+
+        // Act
+        var result = await service.GetSeasonAsync(null);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2024, result.Year);
+    }
+
+    [Fact]
+    public async Task GetSeasonAsync_WithNull_ReturnsNull_WhenNoSeasonsExist()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new SeasonService(context, _mockLogger.Object);
+
+        // Act
+        var result = await service.GetSeasonAsync(null);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    #endregion
 }

--- a/api/F1CompanionApi.UnitTests/Services/TeamServiceTests.cs
+++ b/api/F1CompanionApi.UnitTests/Services/TeamServiceTests.cs
@@ -893,7 +893,6 @@ public class TeamServiceTests
             LastName = lastName,
             Abbreviation = abbreviation,
             CountryAbbreviation = "NL",
-            IsActive = true,
         };
         context.Drivers.Add(driver);
         context.SaveChanges();
@@ -908,7 +907,6 @@ public class TeamServiceTests
             FullName = "Test Constructor",
             Abbreviation = "TES",
             CountryAbbreviation = "AT",
-            IsActive = true,
         };
         context.Constructors.Add(constructor);
         context.SaveChanges();

--- a/api/F1CompanionApi/Api/Endpoints/ConstructorEndpoints.cs
+++ b/api/F1CompanionApi/Api/Endpoints/ConstructorEndpoints.cs
@@ -27,13 +27,13 @@ public static class ConstructorEndpoints
 
     private static async Task<IResult> GetConstructorsAsync(
         IConstructorService constructorService,
-        [FromQuery] [Description("Filter to active constructors only")] bool? activeOnly,
+        [FromQuery] [Description("Filter constructors by season year")] int? seasonYear,
         [FromServices] ILogger logger
     )
     {
         logger.LogDebug("Fetching all constructors");
 
-        var constructors = await constructorService.GetConstructorsAsync(activeOnly);
+        var constructors = await constructorService.GetConstructorsAsync(seasonYear);
 
         return Results.Ok(constructors);
     }

--- a/api/F1CompanionApi/Api/Endpoints/DriverEndpoints.cs
+++ b/api/F1CompanionApi/Api/Endpoints/DriverEndpoints.cs
@@ -27,13 +27,13 @@ public static class DriverEndpoints
 
     private static async Task<IResult> GetDriversAsync(
         IDriverService driverService,
-        [FromQuery] [Description("Filter to active drivers only")] bool? activeOnly,
+        [FromQuery] [Description("Filter drivers by season year")] int? seasonYear,
         [FromServices] ILogger logger
     )
     {
         logger.LogDebug("Fetching all drivers");
 
-        var drivers = await driverService.GetDriversAsync(activeOnly);
+        var drivers = await driverService.GetDriversAsync(seasonYear);
 
         return Results.Ok(drivers);
     }

--- a/api/F1CompanionApi/Api/Mappers/ConstructorResponseMapper.cs
+++ b/api/F1CompanionApi/Api/Mappers/ConstructorResponseMapper.cs
@@ -14,7 +14,6 @@ public static class ConstructorResponseMapper
             Abbreviation = constructor.Abbreviation,
             CountryAbbreviation = constructor.CountryAbbreviation,
             Name = constructor.Name,
-            IsActive = constructor.IsActive,
         };
     }
 

--- a/api/F1CompanionApi/Api/Mappers/TeamConstructorResponseMapper.cs
+++ b/api/F1CompanionApi/Api/Mappers/TeamConstructorResponseMapper.cs
@@ -15,7 +15,6 @@ public static class TeamConstructorResponseMapper
             FullName = teamConstructor.Constructor.FullName,
             Abbreviation = teamConstructor.Constructor.Abbreviation,
             CountryAbbreviation = teamConstructor.Constructor.CountryAbbreviation,
-            IsActive = teamConstructor.Constructor.IsActive,
         };
     }
 }

--- a/api/F1CompanionApi/Api/Models/ConstructorResponse.cs
+++ b/api/F1CompanionApi/Api/Models/ConstructorResponse.cs
@@ -7,5 +7,4 @@ public class ConstructorResponse
     public required string FullName { get; set; }
     public required string Abbreviation { get; set; }
     public required string CountryAbbreviation { get; set; }
-    public bool IsActive { get; set; }
 }

--- a/api/F1CompanionApi/Api/Models/TeamConstructorResponse.cs
+++ b/api/F1CompanionApi/Api/Models/TeamConstructorResponse.cs
@@ -8,5 +8,4 @@ public class TeamConstructorResponse
     public required string FullName { get; set; }
     public required string Abbreviation { get; set; }
     public required string CountryAbbreviation { get; set; }
-    public bool IsActive { get; set; }
 }

--- a/api/F1CompanionApi/Data/ApplicationDbContext.cs
+++ b/api/F1CompanionApi/Data/ApplicationDbContext.cs
@@ -17,6 +17,8 @@ public class ApplicationDbContext : DbContext
     public DbSet<LeagueTeam> LeagueTeams => Set<LeagueTeam>();
     public DbSet<Race> Races => Set<Race>();
     public DbSet<Season> Seasons => Set<Season>();
+    public DbSet<SeasonConstructor> SeasonConstructors => Set<SeasonConstructor>();
+    public DbSet<SeasonDriver> SeasonDrivers => Set<SeasonDriver>();
     public DbSet<Team> Teams => Set<Team>();
     public DbSet<TeamDriver> TeamDrivers => Set<TeamDriver>();
     public DbSet<TeamConstructor> TeamConstructors => Set<TeamConstructor>();
@@ -72,6 +74,46 @@ public class ApplicationDbContext : DbContext
                 .WithMany(s => s.Races)
                 .HasForeignKey(e => e.SeasonId)
                 .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<SeasonDriver>(entity =>
+        {
+            entity
+                .HasOne(sd => sd.Season)
+                .WithMany(s => s.SeasonDrivers)
+                .HasForeignKey(sd => sd.SeasonId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity
+                .HasOne(sd => sd.Driver)
+                .WithMany()
+                .HasForeignKey(sd => sd.DriverId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity
+                .HasOne(sd => sd.Constructor)
+                .WithMany()
+                .HasForeignKey(sd => sd.ConstructorId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity.HasIndex(sd => new { sd.SeasonId, sd.DriverId }).IsUnique();
+        });
+
+        modelBuilder.Entity<SeasonConstructor>(entity =>
+        {
+            entity
+                .HasOne(sc => sc.Season)
+                .WithMany(s => s.SeasonConstructors)
+                .HasForeignKey(sc => sc.SeasonId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity
+                .HasOne(sc => sc.Constructor)
+                .WithMany()
+                .HasForeignKey(sc => sc.ConstructorId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity.HasIndex(sc => new { sc.SeasonId, sc.ConstructorId }).IsUnique();
         });
 
         modelBuilder.Entity<Team>(entity =>

--- a/api/F1CompanionApi/Data/Entities/Constructor.cs
+++ b/api/F1CompanionApi/Data/Entities/Constructor.cs
@@ -12,5 +12,4 @@ public class Constructor : BaseEntity
     public required string FullName { get; set; }
     public required string Abbreviation { get; set; }
     public required string CountryAbbreviation { get; set; }
-    public bool IsActive { get; set; }
 }

--- a/api/F1CompanionApi/Data/Entities/Driver.cs
+++ b/api/F1CompanionApi/Data/Entities/Driver.cs
@@ -12,5 +12,4 @@ public class Driver : BaseEntity
     public required string LastName { get; set; }
     public required string Abbreviation { get; set; }
     public required string CountryAbbreviation { get; set; }
-    public bool IsActive { get; set; }
 }

--- a/api/F1CompanionApi/Data/Entities/Season.cs
+++ b/api/F1CompanionApi/Data/Entities/Season.cs
@@ -10,4 +10,6 @@ public class Season : BaseEntity
     public required DateTime EndDate { get; set; }
 
     public ICollection<Race> Races { get; set; } = [];
+    public ICollection<SeasonDriver> SeasonDrivers { get; set; } = [];
+    public ICollection<SeasonConstructor> SeasonConstructors { get; set; } = [];
 }

--- a/api/F1CompanionApi/Data/Entities/SeasonConstructor.cs
+++ b/api/F1CompanionApi/Data/Entities/SeasonConstructor.cs
@@ -1,0 +1,10 @@
+namespace F1CompanionApi.Data.Entities;
+
+public class SeasonConstructor : BaseEntity
+{
+    public int SeasonId { get; set; }
+    public Season Season { get; set; } = null!;
+    public int ConstructorId { get; set; }
+    public Constructor Constructor { get; set; } = null!;
+    public bool IsActive { get; set; } = true;
+}

--- a/api/F1CompanionApi/Data/Entities/SeasonDriver.cs
+++ b/api/F1CompanionApi/Data/Entities/SeasonDriver.cs
@@ -1,0 +1,12 @@
+namespace F1CompanionApi.Data.Entities;
+
+public class SeasonDriver : BaseEntity
+{
+    public int SeasonId { get; set; }
+    public Season Season { get; set; } = null!;
+    public int DriverId { get; set; }
+    public Driver Driver { get; set; } = null!;
+    public int ConstructorId { get; set; }
+    public Constructor Constructor { get; set; } = null!;
+    public bool IsActive { get; set; } = true;
+}

--- a/api/F1CompanionApi/Data/Migrations/20260222013751_AddSeasonDriverAndSeasonConstructor.Designer.cs
+++ b/api/F1CompanionApi/Data/Migrations/20260222013751_AddSeasonDriverAndSeasonConstructor.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using F1CompanionApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace F1CompanionApi.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260222013751_AddSeasonDriverAndSeasonConstructor")]
+    partial class AddSeasonDriverAndSeasonConstructor
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/F1CompanionApi/Data/Migrations/20260222013751_AddSeasonDriverAndSeasonConstructor.cs
+++ b/api/F1CompanionApi/Data/Migrations/20260222013751_AddSeasonDriverAndSeasonConstructor.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace F1CompanionApi.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSeasonDriverAndSeasonConstructor : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SeasonConstructors",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    SeasonId = table.Column<int>(type: "integer", nullable: false),
+                    ConstructorId = table.Column<int>(type: "integer", nullable: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SeasonConstructors", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SeasonConstructors_Constructors_ConstructorId",
+                        column: x => x.ConstructorId,
+                        principalTable: "Constructors",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_SeasonConstructors_Seasons_SeasonId",
+                        column: x => x.SeasonId,
+                        principalTable: "Seasons",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "SeasonDrivers",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    SeasonId = table.Column<int>(type: "integer", nullable: false),
+                    DriverId = table.Column<int>(type: "integer", nullable: false),
+                    ConstructorId = table.Column<int>(type: "integer", nullable: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SeasonDrivers", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SeasonDrivers_Constructors_ConstructorId",
+                        column: x => x.ConstructorId,
+                        principalTable: "Constructors",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_SeasonDrivers_Drivers_DriverId",
+                        column: x => x.DriverId,
+                        principalTable: "Drivers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_SeasonDrivers_Seasons_SeasonId",
+                        column: x => x.SeasonId,
+                        principalTable: "Seasons",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SeasonConstructors_ConstructorId",
+                table: "SeasonConstructors",
+                column: "ConstructorId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SeasonConstructors_SeasonId_ConstructorId",
+                table: "SeasonConstructors",
+                columns: new[] { "SeasonId", "ConstructorId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SeasonDrivers_ConstructorId",
+                table: "SeasonDrivers",
+                column: "ConstructorId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SeasonDrivers_DriverId",
+                table: "SeasonDrivers",
+                column: "DriverId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SeasonDrivers_SeasonId_DriverId",
+                table: "SeasonDrivers",
+                columns: new[] { "SeasonId", "DriverId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SeasonConstructors");
+
+            migrationBuilder.DropTable(
+                name: "SeasonDrivers");
+        }
+    }
+}

--- a/api/F1CompanionApi/Data/Migrations/20260222031354_RemoveIsActiveFromDriverAndConstructor.Designer.cs
+++ b/api/F1CompanionApi/Data/Migrations/20260222031354_RemoveIsActiveFromDriverAndConstructor.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using F1CompanionApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace F1CompanionApi.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260222031354_RemoveIsActiveFromDriverAndConstructor")]
+    partial class RemoveIsActiveFromDriverAndConstructor
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/F1CompanionApi/Data/Migrations/20260222031354_RemoveIsActiveFromDriverAndConstructor.cs
+++ b/api/F1CompanionApi/Data/Migrations/20260222031354_RemoveIsActiveFromDriverAndConstructor.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace F1CompanionApi.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveIsActiveFromDriverAndConstructor : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsActive",
+                table: "Drivers");
+
+            migrationBuilder.DropColumn(
+                name: "IsActive",
+                table: "Constructors");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsActive",
+                table: "Drivers",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsActive",
+                table: "Constructors",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+    }
+}

--- a/api/F1CompanionApi/Domain/Services/ConstructorService.cs
+++ b/api/F1CompanionApi/Domain/Services/ConstructorService.cs
@@ -46,7 +46,6 @@ public class ConstructorService : IConstructorService
 
         var constructors = await _dbContext
             .SeasonConstructors.Where(sc => sc.SeasonId == season.Id && sc.IsActive)
-            .Include(sc => sc.Constructor)
             .OrderBy(sc => sc.Constructor.Name)
             .Select(sc => sc.Constructor)
             .ToListAsync();

--- a/api/F1CompanionApi/Domain/Services/ConstructorService.cs
+++ b/api/F1CompanionApi/Domain/Services/ConstructorService.cs
@@ -7,36 +7,55 @@ namespace F1CompanionApi.Domain.Services;
 
 public interface IConstructorService
 {
-    Task<IEnumerable<ConstructorResponse>> GetConstructorsAsync(bool? activeOnly);
+    Task<IEnumerable<ConstructorResponse>> GetConstructorsAsync(int? seasonYear);
     Task<ConstructorResponse?> GetConstructorByIdAsync(int id);
 }
 
 public class ConstructorService : IConstructorService
 {
     private readonly ApplicationDbContext _dbContext;
+    private readonly ISeasonService _seasonService;
     private readonly ILogger<ConstructorService> _logger;
 
-    public ConstructorService(ApplicationDbContext dbContext, ILogger<ConstructorService> logger)
+    public ConstructorService(
+        ApplicationDbContext dbContext,
+        ISeasonService seasonService,
+        ILogger<ConstructorService> logger
+    )
     {
         ArgumentNullException.ThrowIfNull(dbContext);
+        ArgumentNullException.ThrowIfNull(seasonService);
         ArgumentNullException.ThrowIfNull(logger);
 
         _dbContext = dbContext;
+        _seasonService = seasonService;
         _logger = logger;
     }
 
-    public async Task<IEnumerable<ConstructorResponse>> GetConstructorsAsync(bool? activeOnly)
+    public async Task<IEnumerable<ConstructorResponse>> GetConstructorsAsync(int? seasonYear)
     {
-        var query = _dbContext.Constructors.AsQueryable();
+        _logger.LogDebug("Fetching constructors for season year {SeasonYear}", seasonYear);
 
-        if (activeOnly is not null)
+        var season = await _seasonService.GetSeasonAsync(seasonYear);
+
+        if (season is null)
         {
-            query = query.Where(constructor => constructor.IsActive == activeOnly);
+            _logger.LogDebug("No season found, returning empty list");
+            return [];
         }
 
-        var constructors = await query.OrderBy(x => x.Name).ToListAsync();
+        var constructors = await _dbContext
+            .SeasonConstructors.Where(sc => sc.SeasonId == season.Id && sc.IsActive)
+            .Include(sc => sc.Constructor)
+            .OrderBy(sc => sc.Constructor.Name)
+            .Select(sc => sc.Constructor)
+            .ToListAsync();
 
-        _logger.LogDebug("Retrieved {ConstructorCount} constructors", constructors.Count);
+        _logger.LogDebug(
+            "Retrieved {ConstructorCount} constructors for season {SeasonYear}",
+            constructors.Count,
+            season.Year
+        );
 
         return constructors.ToResponseModel();
     }

--- a/api/F1CompanionApi/Domain/Services/DriverService.cs
+++ b/api/F1CompanionApi/Domain/Services/DriverService.cs
@@ -7,38 +7,55 @@ namespace F1CompanionApi.Domain.Services;
 
 public interface IDriverService
 {
-    Task<IEnumerable<DriverResponse>> GetDriversAsync(bool? activeOnly);
+    Task<IEnumerable<DriverResponse>> GetDriversAsync(int? seasonYear);
     Task<DriverResponse?> GetDriverByIdAsync(int id);
 }
 
 public class DriverService : IDriverService
 {
     private readonly ApplicationDbContext _dbContext;
+    private readonly ISeasonService _seasonService;
     private readonly ILogger<DriverService> _logger;
 
-    public DriverService(ApplicationDbContext dbContext, ILogger<DriverService> logger)
+    public DriverService(
+        ApplicationDbContext dbContext,
+        ISeasonService seasonService,
+        ILogger<DriverService> logger
+    )
     {
         ArgumentNullException.ThrowIfNull(dbContext);
+        ArgumentNullException.ThrowIfNull(seasonService);
         ArgumentNullException.ThrowIfNull(logger);
 
         _dbContext = dbContext;
+        _seasonService = seasonService;
         _logger = logger;
     }
 
-    public async Task<IEnumerable<DriverResponse>> GetDriversAsync(bool? activeOnly = null)
+    public async Task<IEnumerable<DriverResponse>> GetDriversAsync(int? seasonYear = null)
     {
-        _logger.LogDebug("Fetching all drivers");
+        _logger.LogDebug("Fetching drivers for season year {SeasonYear}", seasonYear);
 
-        var query = _dbContext.Drivers.AsQueryable();
+        var season = await _seasonService.GetSeasonAsync(seasonYear);
 
-        if (activeOnly is not null)
+        if (season is null)
         {
-            query = query.Where(driver => driver.IsActive == activeOnly);
+            _logger.LogDebug("No season found, returning empty list");
+            return [];
         }
 
-        var drivers = await query.OrderBy(o => o.LastName).ToListAsync();
+        var drivers = await _dbContext
+            .SeasonDrivers.Where(sd => sd.SeasonId == season.Id && sd.IsActive)
+            .Include(sd => sd.Driver)
+            .OrderBy(sd => sd.Driver.LastName)
+            .Select(sd => sd.Driver)
+            .ToListAsync();
 
-        _logger.LogDebug("Retrieved {DriverCount} drivers", drivers.Count);
+        _logger.LogDebug(
+            "Retrieved {DriverCount} drivers for season {SeasonYear}",
+            drivers.Count,
+            season.Year
+        );
 
         return drivers.ToResponseModel();
     }

--- a/api/F1CompanionApi/Domain/Services/DriverService.cs
+++ b/api/F1CompanionApi/Domain/Services/DriverService.cs
@@ -46,7 +46,6 @@ public class DriverService : IDriverService
 
         var drivers = await _dbContext
             .SeasonDrivers.Where(sd => sd.SeasonId == season.Id && sd.IsActive)
-            .Include(sd => sd.Driver)
             .OrderBy(sd => sd.Driver.LastName)
             .Select(sd => sd.Driver)
             .ToListAsync();

--- a/api/F1CompanionApi/Domain/Services/SeasonService.cs
+++ b/api/F1CompanionApi/Domain/Services/SeasonService.cs
@@ -11,6 +11,7 @@ public interface ISeasonService
     Task<IEnumerable<SeasonResponse>> GetSeasonsAsync();
     Task<SeasonResponse?> GetSeasonByIdAsync(int id);
     Task<Season?> GetCurrentSeasonAsync();
+    Task<Season?> GetSeasonAsync(int? seasonYear);
 }
 
 public class SeasonService : ISeasonService
@@ -75,5 +76,37 @@ public class SeasonService : ISeasonService
         }
 
         return currentSeason;
+    }
+
+    public async Task<Season?> GetSeasonAsync(int? seasonYear)
+    {
+        if (seasonYear.HasValue)
+        {
+            _logger.LogDebug("Fetching season for year {Year}", seasonYear.Value);
+            return await _dbContext.Seasons.FirstOrDefaultAsync(s => s.Year == seasonYear.Value);
+        }
+
+        var currentSeason = await GetCurrentSeasonAsync();
+        if (currentSeason is not null)
+        {
+            return currentSeason;
+        }
+
+        _logger.LogDebug("No active season found, falling back to latest season");
+
+        var latestSeason = await _dbContext
+            .Seasons.OrderByDescending(s => s.Year)
+            .FirstOrDefaultAsync();
+
+        if (latestSeason is not null)
+        {
+            _logger.LogDebug("Latest season is {Year}", latestSeason.Year);
+        }
+        else
+        {
+            _logger.LogDebug("No seasons found");
+        }
+
+        return latestSeason;
     }
 }

--- a/api/supabase/seed.sql
+++ b/api/supabase/seed.sql
@@ -1,72 +1,72 @@
 -- Insert F1 Drivers
 INSERT INTO "Drivers"
-  ("FirstName", "LastName", "Abbreviation", "CountryAbbreviation", "IsActive", "IsDeleted", "CreatedAt", "UpdatedAt", "DeletedAt")
+  ("FirstName", "LastName", "Abbreviation", "CountryAbbreviation", "IsDeleted", "CreatedAt", "UpdatedAt", "DeletedAt")
 VALUES
   -- Red Bull Racing
-  ('Max', 'Verstappen', 'VER', 'NED', true, false, NOW(), NOW(), NULL),
-  ('Isack', 'Hadjar', 'HAD', 'FRA', true, false, NOW(), NOW(), NULL),
+  ('Max', 'Verstappen', 'VER', 'NED', false, NOW(), NOW(), NULL),
+  ('Isack', 'Hadjar', 'HAD', 'FRA', false, NOW(), NOW(), NULL),
 
   -- Mercedes
-  ('George', 'Russell', 'RUS', 'GBR', true, false, NOW(), NOW(), NULL),
-  ('Kimi', 'Antonelli', 'ANT', 'ITA', true, false, NOW(), NOW(), NULL),
+  ('George', 'Russell', 'RUS', 'GBR', false, NOW(), NOW(), NULL),
+  ('Kimi', 'Antonelli', 'ANT', 'ITA', false, NOW(), NOW(), NULL),
 
   -- Ferrari
-  ('Charles', 'Leclerc', 'LEC', 'MON', true, false, NOW(), NOW(), NULL),
-  ('Lewis', 'Hamilton', 'HAM', 'GBR', true, false, NOW(), NOW(), NULL),
+  ('Charles', 'Leclerc', 'LEC', 'MON', false, NOW(), NOW(), NULL),
+  ('Lewis', 'Hamilton', 'HAM', 'GBR', false, NOW(), NOW(), NULL),
 
   -- McLaren
-  ('Lando', 'Norris', 'NOR', 'GBR', true, false, NOW(), NOW(), NULL),
-  ('Oscar', 'Piastri', 'PIA', 'AUS', true, false, NOW(), NOW(), NULL),
+  ('Lando', 'Norris', 'NOR', 'GBR', false, NOW(), NOW(), NULL),
+  ('Oscar', 'Piastri', 'PIA', 'AUS', false, NOW(), NOW(), NULL),
 
   -- Aston Martin
-  ('Fernando', 'Alonso', 'ALO', 'ESP', true, false, NOW(), NOW(), NULL),
-  ('Lance', 'Stroll', 'STR', 'CAN', true, false, NOW(), NOW(), NULL),
+  ('Fernando', 'Alonso', 'ALO', 'ESP', false, NOW(), NOW(), NULL),
+  ('Lance', 'Stroll', 'STR', 'CAN', false, NOW(), NOW(), NULL),
 
   -- Alpine
-  ('Pierre', 'Gasly', 'GAS', 'FRA', true, false, NOW(), NOW(), NULL),
-  ('Franco', 'Colapinto', 'COL', 'ARG', true, false, NOW(), NOW(), NULL),
+  ('Pierre', 'Gasly', 'GAS', 'FRA', false, NOW(), NOW(), NULL),
+  ('Franco', 'Colapinto', 'COL', 'ARG', false, NOW(), NOW(), NULL),
 
   -- Williams
-  ('Alex', 'Albon', 'ALB', 'THA', true, false, NOW(), NOW(), NULL),
-  ('Carlos', 'Sainz', 'SAI', 'ESP', true, false, NOW(), NOW(), NULL),
+  ('Alex', 'Albon', 'ALB', 'THA', false, NOW(), NOW(), NULL),
+  ('Carlos', 'Sainz', 'SAI', 'ESP', false, NOW(), NOW(), NULL),
 
   -- Racing Bulls
-  ('Liam', 'Lawson', 'LAW', 'NZL', true, false, NOW(), NOW(), NULL),
-  ('Arvid', 'Lindblad', 'LIN', 'GBR', true, false, NOW(), NOW(), NULL),
+  ('Liam', 'Lawson', 'LAW', 'NZL', false, NOW(), NOW(), NULL),
+  ('Arvid', 'Lindblad', 'LIN', 'GBR', false, NOW(), NOW(), NULL),
 
   -- Audi
-  ('Nico', 'Hulkenberg', 'HUL', 'GER', true, false, NOW(), NOW(), NULL),
-  ('Gabriel', 'Bortoleto', 'BOR', 'BRA', true, false, NOW(), NOW(), NULL),
+  ('Nico', 'Hulkenberg', 'HUL', 'GER', false, NOW(), NOW(), NULL),
+  ('Gabriel', 'Bortoleto', 'BOR', 'BRA', false, NOW(), NOW(), NULL),
 
   -- Haas
-  ('Esteban', 'Ocon', 'OCO', 'FRA', true, false, NOW(), NOW(), NULL),
-  ('Oliver', 'Bearman', 'BEA', 'GBR', true, false, NOW(), NOW(), NULL),
+  ('Esteban', 'Ocon', 'OCO', 'FRA', false, NOW(), NOW(), NULL),
+  ('Oliver', 'Bearman', 'BEA', 'GBR', false, NOW(), NOW(), NULL),
 
   -- Cadillac
-  ('Valtteri', 'Bottas', 'BOT', 'FIN', true, false, NOW(), NOW(), NULL),
-  ('Sergio', 'Perez', 'PER', 'MEX', true, false, NOW(), NOW(), NULL),
+  ('Valtteri', 'Bottas', 'BOT', 'FIN', false, NOW(), NOW(), NULL),
+  ('Sergio', 'Perez', 'PER', 'MEX', false, NOW(), NOW(), NULL),
 
   -- Historical drivers (no 2026 seat)
-  ('Jack', 'Doohan', 'DOO', 'AUS', true, false, NOW(), NOW(), NULL),
-  ('Yuki', 'Tsunoda', 'TSU', 'JPN', true, false, NOW(), NOW(), NULL)
+  ('Jack', 'Doohan', 'DOO', 'AUS', false, NOW(), NOW(), NULL),
+  ('Yuki', 'Tsunoda', 'TSU', 'JPN', false, NOW(), NOW(), NULL)
 ON CONFLICT DO NOTHING;
 
 -- Insert F1 Constructors
 INSERT INTO "Constructors"
-  ("Name", "FullName", "Abbreviation", "CountryAbbreviation", "IsActive", "IsDeleted", "CreatedAt", "UpdatedAt", "DeletedAt")
+  ("Name", "FullName", "Abbreviation", "CountryAbbreviation", "IsDeleted", "CreatedAt", "UpdatedAt", "DeletedAt")
 VALUES
-  ('Red Bull Racing', 'Oracle Red Bull Racing', 'RBR', 'AUT', true, false, NOW(), NOW(), NULL),
-  ('Mercedes', 'Mercedes-AMG Petronas F1 Team', 'MER', 'GER', true, false, NOW(), NOW(), NULL),
-  ('Ferrari', 'Scuderia Ferrari HP', 'FER', 'ITA', true, false, NOW(), NOW(), NULL),
-  ('McLaren', 'McLaren F1 Team', 'MCL', 'GBR', true, false, NOW(), NOW(), NULL),
-  ('Aston Martin', 'Aston Martin Aramco F1 Team', 'AMR', 'GBR', true, false, NOW(), NOW(), NULL),
-  ('Alpine', 'BWT Alpine F1 Team', 'ALP', 'FRA', true, false, NOW(), NOW(), NULL),
-  ('Williams', 'Williams Racing', 'WIL', 'GBR', true, false, NOW(), NOW(), NULL),
-  ('Racing Bulls', 'Visa Cash App RB F1 Team', 'RBS', 'ITA', true, false, NOW(), NOW(), NULL),
-  ('Kick Sauber', 'Stake F1 Team Kick Sauber', 'SAU', 'SUI', true, false, NOW(), NOW(), NULL),
-  ('Haas', 'MoneyGram Haas F1 Team', 'HAA', 'USA', true, false, NOW(), NOW(), NULL),
-  ('Audi', 'Audi F1 Team', 'AUD', 'GER', true, false, NOW(), NOW(), NULL),
-  ('Cadillac', 'Cadillac F1 Team', 'CAD', 'USA', true, false, NOW(), NOW(), NULL)
+  ('Red Bull Racing', 'Oracle Red Bull Racing', 'RBR', 'AUT', false, NOW(), NOW(), NULL),
+  ('Mercedes', 'Mercedes-AMG Petronas F1 Team', 'MER', 'GER', false, NOW(), NOW(), NULL),
+  ('Ferrari', 'Scuderia Ferrari HP', 'FER', 'ITA', false, NOW(), NOW(), NULL),
+  ('McLaren', 'McLaren F1 Team', 'MCL', 'GBR', false, NOW(), NOW(), NULL),
+  ('Aston Martin', 'Aston Martin Aramco F1 Team', 'AMR', 'GBR', false, NOW(), NOW(), NULL),
+  ('Alpine', 'BWT Alpine F1 Team', 'ALP', 'FRA', false, NOW(), NOW(), NULL),
+  ('Williams', 'Williams Racing', 'WIL', 'GBR', false, NOW(), NOW(), NULL),
+  ('Racing Bulls', 'Visa Cash App RB F1 Team', 'RBS', 'ITA', false, NOW(), NOW(), NULL),
+  ('Kick Sauber', 'Stake F1 Team Kick Sauber', 'SAU', 'SUI', false, NOW(), NOW(), NULL),
+  ('Haas', 'MoneyGram Haas F1 Team', 'HAA', 'USA', false, NOW(), NOW(), NULL),
+  ('Audi', 'Audi F1 Team', 'AUD', 'GER', false, NOW(), NOW(), NULL),
+  ('Cadillac', 'Cadillac F1 Team', 'CAD', 'USA', false, NOW(), NOW(), NULL)
 ON CONFLICT ("Name") DO UPDATE SET
   "FullName" = EXCLUDED."FullName",
   "Abbreviation" = EXCLUDED."Abbreviation",

--- a/api/supabase/seed.sql
+++ b/api/supabase/seed.sql
@@ -1,49 +1,57 @@
--- Insert 2025 F1 Season Drivers
-INSERT INTO "Drivers" 
+-- Insert F1 Drivers
+INSERT INTO "Drivers"
   ("FirstName", "LastName", "Abbreviation", "CountryAbbreviation", "IsActive", "IsDeleted", "CreatedAt", "UpdatedAt", "DeletedAt")
 VALUES
   -- Red Bull Racing
   ('Max', 'Verstappen', 'VER', 'NED', true, false, NOW(), NOW(), NULL),
-  ('Liam', 'Lawson', 'LAW', 'NZL', true, false, NOW(), NOW(), NULL),
-  
+  ('Isack', 'Hadjar', 'HAD', 'FRA', true, false, NOW(), NOW(), NULL),
+
   -- Mercedes
   ('George', 'Russell', 'RUS', 'GBR', true, false, NOW(), NOW(), NULL),
   ('Kimi', 'Antonelli', 'ANT', 'ITA', true, false, NOW(), NOW(), NULL),
-  
+
   -- Ferrari
   ('Charles', 'Leclerc', 'LEC', 'MON', true, false, NOW(), NOW(), NULL),
   ('Lewis', 'Hamilton', 'HAM', 'GBR', true, false, NOW(), NOW(), NULL),
-  
+
   -- McLaren
   ('Lando', 'Norris', 'NOR', 'GBR', true, false, NOW(), NOW(), NULL),
   ('Oscar', 'Piastri', 'PIA', 'AUS', true, false, NOW(), NOW(), NULL),
-  
+
   -- Aston Martin
   ('Fernando', 'Alonso', 'ALO', 'ESP', true, false, NOW(), NOW(), NULL),
   ('Lance', 'Stroll', 'STR', 'CAN', true, false, NOW(), NOW(), NULL),
-  
+
   -- Alpine
   ('Pierre', 'Gasly', 'GAS', 'FRA', true, false, NOW(), NOW(), NULL),
-  ('Jack', 'Doohan', 'DOO', 'AUS', true, false, NOW(), NOW(), NULL),
-  
+  ('Franco', 'Colapinto', 'COL', 'ARG', true, false, NOW(), NOW(), NULL),
+
   -- Williams
   ('Alex', 'Albon', 'ALB', 'THA', true, false, NOW(), NOW(), NULL),
   ('Carlos', 'Sainz', 'SAI', 'ESP', true, false, NOW(), NOW(), NULL),
-  
-  -- RB (AlphaTauri)
-  ('Yuki', 'Tsunoda', 'TSU', 'JPN', true, false, NOW(), NOW(), NULL),
-  ('Isack', 'Hadjar', 'HAD', 'FRA', true, false, NOW(), NOW(), NULL),
-  
-  -- Kick Sauber
+
+  -- Racing Bulls
+  ('Liam', 'Lawson', 'LAW', 'NZL', true, false, NOW(), NOW(), NULL),
+  ('Arvid', 'Lindblad', 'LIN', 'GBR', true, false, NOW(), NOW(), NULL),
+
+  -- Audi
   ('Nico', 'Hulkenberg', 'HUL', 'GER', true, false, NOW(), NOW(), NULL),
   ('Gabriel', 'Bortoleto', 'BOR', 'BRA', true, false, NOW(), NOW(), NULL),
-  
+
   -- Haas
   ('Esteban', 'Ocon', 'OCO', 'FRA', true, false, NOW(), NOW(), NULL),
-  ('Oliver', 'Bearman', 'BEA', 'GBR', true, false, NOW(), NOW(), NULL)
+  ('Oliver', 'Bearman', 'BEA', 'GBR', true, false, NOW(), NOW(), NULL),
+
+  -- Cadillac
+  ('Valtteri', 'Bottas', 'BOT', 'FIN', true, false, NOW(), NOW(), NULL),
+  ('Sergio', 'Perez', 'PER', 'MEX', true, false, NOW(), NOW(), NULL),
+
+  -- Historical drivers (no 2026 seat)
+  ('Jack', 'Doohan', 'DOO', 'AUS', true, false, NOW(), NOW(), NULL),
+  ('Yuki', 'Tsunoda', 'TSU', 'JPN', true, false, NOW(), NOW(), NULL)
 ON CONFLICT DO NOTHING;
 
--- Insert 2025 F1 Season Constructors
+-- Insert F1 Constructors
 INSERT INTO "Constructors"
   ("Name", "FullName", "Abbreviation", "CountryAbbreviation", "IsActive", "IsDeleted", "CreatedAt", "UpdatedAt", "DeletedAt")
 VALUES
@@ -56,7 +64,9 @@ VALUES
   ('Williams', 'Williams Racing', 'WIL', 'GBR', true, false, NOW(), NOW(), NULL),
   ('Racing Bulls', 'Visa Cash App RB F1 Team', 'RBS', 'ITA', true, false, NOW(), NOW(), NULL),
   ('Kick Sauber', 'Stake F1 Team Kick Sauber', 'SAU', 'SUI', true, false, NOW(), NOW(), NULL),
-  ('Haas', 'MoneyGram Haas F1 Team', 'HAA', 'USA', true, false, NOW(), NOW(), NULL)
+  ('Haas', 'MoneyGram Haas F1 Team', 'HAA', 'USA', true, false, NOW(), NOW(), NULL),
+  ('Audi', 'Audi F1 Team', 'AUD', 'GER', true, false, NOW(), NOW(), NULL),
+  ('Cadillac', 'Cadillac F1 Team', 'CAD', 'USA', true, false, NOW(), NOW(), NULL)
 ON CONFLICT ("Name") DO UPDATE SET
   "FullName" = EXCLUDED."FullName",
   "Abbreviation" = EXCLUDED."Abbreviation",
@@ -70,13 +80,94 @@ VALUES
   (2026, '2026-03-08', '2026-12-06', false, NOW(), NOW(), NULL)
 ON CONFLICT ("Year") DO NOTHING;
 
--- Insert 2026 F1 Season Races
+-- Insert 2026 F1 Season Races, SeasonConstructors, and SeasonDrivers
 DO $$
 DECLARE
   season_id INTEGER;
+  -- Constructor IDs
+  rbr_id INTEGER;
+  mer_id INTEGER;
+  fer_id INTEGER;
+  mcl_id INTEGER;
+  amr_id INTEGER;
+  alp_id INTEGER;
+  wil_id INTEGER;
+  rbs_id INTEGER;
+  haa_id INTEGER;
+  aud_id INTEGER;
+  cad_id INTEGER;
 BEGIN
   -- Get the SeasonId for 2026
   SELECT "Id" INTO season_id FROM "Seasons" WHERE "Year" = 2026;
+
+  -- Get Constructor IDs
+  SELECT "Id" INTO rbr_id FROM "Constructors" WHERE "Abbreviation" = 'RBR';
+  SELECT "Id" INTO mer_id FROM "Constructors" WHERE "Abbreviation" = 'MER';
+  SELECT "Id" INTO fer_id FROM "Constructors" WHERE "Abbreviation" = 'FER';
+  SELECT "Id" INTO mcl_id FROM "Constructors" WHERE "Abbreviation" = 'MCL';
+  SELECT "Id" INTO amr_id FROM "Constructors" WHERE "Abbreviation" = 'AMR';
+  SELECT "Id" INTO alp_id FROM "Constructors" WHERE "Abbreviation" = 'ALP';
+  SELECT "Id" INTO wil_id FROM "Constructors" WHERE "Abbreviation" = 'WIL';
+  SELECT "Id" INTO rbs_id FROM "Constructors" WHERE "Abbreviation" = 'RBS';
+  SELECT "Id" INTO haa_id FROM "Constructors" WHERE "Abbreviation" = 'HAA';
+  SELECT "Id" INTO aud_id FROM "Constructors" WHERE "Abbreviation" = 'AUD';
+  SELECT "Id" INTO cad_id FROM "Constructors" WHERE "Abbreviation" = 'CAD';
+
+  -- Insert SeasonConstructors for 2026 (11 teams, Kick Sauber excluded)
+  INSERT INTO "SeasonConstructors"
+    ("SeasonId", "ConstructorId", "IsActive", "IsDeleted", "CreatedAt", "UpdatedAt", "DeletedAt")
+  VALUES
+    (season_id, rbr_id, true, false, NOW(), NOW(), NULL),
+    (season_id, mer_id, true, false, NOW(), NOW(), NULL),
+    (season_id, fer_id, true, false, NOW(), NOW(), NULL),
+    (season_id, mcl_id, true, false, NOW(), NOW(), NULL),
+    (season_id, amr_id, true, false, NOW(), NOW(), NULL),
+    (season_id, alp_id, true, false, NOW(), NOW(), NULL),
+    (season_id, wil_id, true, false, NOW(), NOW(), NULL),
+    (season_id, rbs_id, true, false, NOW(), NOW(), NULL),
+    (season_id, haa_id, true, false, NOW(), NOW(), NULL),
+    (season_id, aud_id, true, false, NOW(), NOW(), NULL),
+    (season_id, cad_id, true, false, NOW(), NOW(), NULL)
+  ON CONFLICT ("SeasonId", "ConstructorId") DO NOTHING;
+
+  -- Insert SeasonDrivers for 2026 (22 drivers)
+  INSERT INTO "SeasonDrivers"
+    ("SeasonId", "DriverId", "ConstructorId", "IsActive", "IsDeleted", "CreatedAt", "UpdatedAt", "DeletedAt")
+  VALUES
+    -- Red Bull Racing
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'VER'), rbr_id, true, false, NOW(), NOW(), NULL),
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'HAD'), rbr_id, true, false, NOW(), NOW(), NULL),
+    -- Mercedes
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'RUS'), mer_id, true, false, NOW(), NOW(), NULL),
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'ANT'), mer_id, true, false, NOW(), NOW(), NULL),
+    -- Ferrari
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'LEC'), fer_id, true, false, NOW(), NOW(), NULL),
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'HAM'), fer_id, true, false, NOW(), NOW(), NULL),
+    -- McLaren
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'NOR'), mcl_id, true, false, NOW(), NOW(), NULL),
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'PIA'), mcl_id, true, false, NOW(), NOW(), NULL),
+    -- Aston Martin
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'ALO'), amr_id, true, false, NOW(), NOW(), NULL),
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'STR'), amr_id, true, false, NOW(), NOW(), NULL),
+    -- Alpine
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'GAS'), alp_id, true, false, NOW(), NOW(), NULL),
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'COL'), alp_id, true, false, NOW(), NOW(), NULL),
+    -- Williams
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'ALB'), wil_id, true, false, NOW(), NOW(), NULL),
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'SAI'), wil_id, true, false, NOW(), NOW(), NULL),
+    -- Racing Bulls
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'LAW'), rbs_id, true, false, NOW(), NOW(), NULL),
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'LIN'), rbs_id, true, false, NOW(), NOW(), NULL),
+    -- Audi
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'HUL'), aud_id, true, false, NOW(), NOW(), NULL),
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'BOR'), aud_id, true, false, NOW(), NOW(), NULL),
+    -- Haas
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'OCO'), haa_id, true, false, NOW(), NOW(), NULL),
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'BEA'), haa_id, true, false, NOW(), NOW(), NULL),
+    -- Cadillac
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'BOT'), cad_id, true, false, NOW(), NOW(), NULL),
+    (season_id, (SELECT "Id" FROM "Drivers" WHERE "Abbreviation" = 'PER'), cad_id, true, false, NOW(), NOW(), NULL)
+  ON CONFLICT ("SeasonId", "DriverId") DO NOTHING;
 
   -- Insert all races for 2026 season
   INSERT INTO "Races"

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -33,8 +33,8 @@ import { BrowseLeagues } from './components/BrowseLeagues/BrowseLeagues';
 import { JoinInvite } from './components/JoinInvite/JoinInvite';
 import type { Race } from './contracts/Race';
 import type { Constructor, Driver } from './contracts/Role';
-import { getActiveConstructors } from './services/constructorService';
-import { getActiveDrivers } from './services/driverService';
+import { getConstructors } from './services/constructorService';
+import { getDrivers } from './services/driverService';
 import { previewInvite } from './services/leagueInviteService';
 import { getRaces } from './services/raceService';
 
@@ -586,8 +586,8 @@ const teamRoute = createRoute({
     // Fetch all data in parallel
     const [team, activeDrivers, activeConstructors, races] = await Promise.all([
       getTeamById(teamId),
-      getActiveDrivers(),
-      getActiveConstructors(),
+      getDrivers(),
+      getConstructors(),
       getRaces(),
     ]);
 
@@ -641,8 +641,8 @@ const myTeamRoute = createRoute({
     // Fetch all data in parallel
     const [team, activeDrivers, activeConstructors, races] = await Promise.all([
       getMyTeam(),
-      getActiveDrivers(),
-      getActiveConstructors(),
+      getDrivers(),
+      getConstructors(),
       getRaces(),
     ]);
 

--- a/web/src/services/constructorService.test.ts
+++ b/web/src/services/constructorService.test.ts
@@ -3,7 +3,7 @@ import { apiClient } from '@/lib/api';
 import { createMockConstructorList } from '@/test-utils/mockFactories';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getActiveConstructors } from './constructorService';
+import { getConstructors } from './constructorService';
 
 vi.mock('@/lib/api', () => ({
   apiClient: {
@@ -18,8 +18,8 @@ describe('constructorService', () => {
     vi.clearAllMocks();
   });
 
-  describe('getActiveConstructors', () => {
-    it('calls apiClient.get with correct endpoint and query parameter', async () => {
+  describe('getConstructors', () => {
+    it('calls apiClient.get with default endpoint when no season year provided', async () => {
       const mockConstructors: Constructor[] = createMockConstructorList([
         {
           name: 'Red Bull Racing',
@@ -37,25 +37,30 @@ describe('constructorService', () => {
 
       mockApiClient.get.mockResolvedValue(mockConstructors);
 
-      const result = await getActiveConstructors();
+      const result = await getConstructors();
 
-      expect(mockApiClient.get).toHaveBeenCalledWith(
-        '/constructors?activeOnly=true',
-        'get constructors',
-      );
+      expect(mockApiClient.get).toHaveBeenCalledWith('/constructors', 'get constructors');
       expect(result).toEqual(mockConstructors);
     });
 
-    it('returns empty array when no active constructors exist', async () => {
+    it('calls apiClient.get with seasonYear query parameter when provided', async () => {
       mockApiClient.get.mockResolvedValue([]);
 
-      const result = await getActiveConstructors();
+      await getConstructors(2026);
 
-      expect(result).toEqual([]);
       expect(mockApiClient.get).toHaveBeenCalledWith(
-        '/constructors?activeOnly=true',
+        '/constructors?seasonYear=2026',
         'get constructors',
       );
+    });
+
+    it('returns empty array when no constructors exist', async () => {
+      mockApiClient.get.mockResolvedValue([]);
+
+      const result = await getConstructors();
+
+      expect(result).toEqual([]);
+      expect(mockApiClient.get).toHaveBeenCalledWith('/constructors', 'get constructors');
     });
 
     it('propagates API errors during constructor retrieval', async () => {
@@ -63,11 +68,8 @@ describe('constructorService', () => {
 
       mockApiClient.get.mockRejectedValue(mockError);
 
-      await expect(getActiveConstructors()).rejects.toThrow('Failed to fetch constructors');
-      expect(mockApiClient.get).toHaveBeenCalledWith(
-        '/constructors?activeOnly=true',
-        'get constructors',
-      );
+      await expect(getConstructors()).rejects.toThrow('Failed to fetch constructors');
+      expect(mockApiClient.get).toHaveBeenCalledWith('/constructors', 'get constructors');
     });
   });
 });

--- a/web/src/services/constructorService.ts
+++ b/web/src/services/constructorService.ts
@@ -1,6 +1,7 @@
 import type { Constructor } from '@/contracts/Role';
 import { apiClient } from '@/lib/api';
 
-export function getActiveConstructors(): Promise<Constructor[]> {
-  return apiClient.get<Constructor[]>('/constructors?activeOnly=true', 'get constructors');
+export function getConstructors(seasonYear?: number): Promise<Constructor[]> {
+  const url = seasonYear ? `/constructors?seasonYear=${seasonYear}` : '/constructors';
+  return apiClient.get<Constructor[]>(url, 'get constructors');
 }

--- a/web/src/services/driverService.test.ts
+++ b/web/src/services/driverService.test.ts
@@ -3,7 +3,7 @@ import { apiClient } from '@/lib/api';
 import { createMockDriverList } from '@/test-utils/mockFactories';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getActiveDrivers } from './driverService';
+import { getDrivers } from './driverService';
 
 vi.mock('@/lib/api', () => ({
   apiClient: {
@@ -18,8 +18,8 @@ describe('driverService', () => {
     vi.clearAllMocks();
   });
 
-  describe('getActiveDrivers', () => {
-    it('calls apiClient.get with correct endpoint and query parameter', async () => {
+  describe('getDrivers', () => {
+    it('calls apiClient.get with default endpoint when no season year provided', async () => {
       const mockDrivers: Driver[] = createMockDriverList([
         {
           firstName: 'Max',
@@ -37,19 +37,27 @@ describe('driverService', () => {
 
       mockApiClient.get.mockResolvedValue(mockDrivers);
 
-      const result = await getActiveDrivers();
+      const result = await getDrivers();
 
-      expect(mockApiClient.get).toHaveBeenCalledWith('/drivers?activeOnly=true', 'get drivers');
+      expect(mockApiClient.get).toHaveBeenCalledWith('/drivers', 'get drivers');
       expect(result).toEqual(mockDrivers);
     });
 
-    it('returns empty array when no active drivers exist', async () => {
+    it('calls apiClient.get with seasonYear query parameter when provided', async () => {
       mockApiClient.get.mockResolvedValue([]);
 
-      const result = await getActiveDrivers();
+      await getDrivers(2026);
+
+      expect(mockApiClient.get).toHaveBeenCalledWith('/drivers?seasonYear=2026', 'get drivers');
+    });
+
+    it('returns empty array when no drivers exist', async () => {
+      mockApiClient.get.mockResolvedValue([]);
+
+      const result = await getDrivers();
 
       expect(result).toEqual([]);
-      expect(mockApiClient.get).toHaveBeenCalledWith('/drivers?activeOnly=true', 'get drivers');
+      expect(mockApiClient.get).toHaveBeenCalledWith('/drivers', 'get drivers');
     });
 
     it('propagates API errors during driver retrieval', async () => {
@@ -57,8 +65,8 @@ describe('driverService', () => {
 
       mockApiClient.get.mockRejectedValue(mockError);
 
-      await expect(getActiveDrivers()).rejects.toThrow('Failed to fetch drivers');
-      expect(mockApiClient.get).toHaveBeenCalledWith('/drivers?activeOnly=true', 'get drivers');
+      await expect(getDrivers()).rejects.toThrow('Failed to fetch drivers');
+      expect(mockApiClient.get).toHaveBeenCalledWith('/drivers', 'get drivers');
     });
   });
 });

--- a/web/src/services/driverService.ts
+++ b/web/src/services/driverService.ts
@@ -1,6 +1,7 @@
 import type { Driver } from '@/contracts/Role';
 import { apiClient } from '@/lib/api';
 
-export async function getActiveDrivers(): Promise<Driver[]> {
-  return apiClient.get<Driver[]>('/drivers?activeOnly=true', 'get drivers');
+export async function getDrivers(seasonYear?: number): Promise<Driver[]> {
+  const url = seasonYear ? `/drivers?seasonYear=${seasonYear}` : '/drivers';
+  return apiClient.get<Driver[]>(url, 'get drivers');
 }


### PR DESCRIPTION
## Summary
- Adds `SeasonDriver` and `SeasonConstructor` junction tables to track driver/constructor participation per season, replacing the global `IsActive` boolean on entity tables
- Updates seed data with the 2026 F1 grid (11 teams, 22 drivers including Cadillac and Audi)
- Refactors backend services and endpoints to filter by season year instead of `activeOnly`, with automatic fallback to current/latest season
- Removes `IsActive` from `Driver` and `Constructor` entities (now tracked per-season)
- Updates frontend services and route loaders to use the new season-based API

## Test plan
- [x] All 325 backend tests pass
- [x] All 598 frontend tests pass
- [x] EF Core migrations applied and seed script run on local Supabase DB
- [x] Build passes for both API and web
- [ ] Manually verify `/drivers` and `/constructors` endpoints return 2026 season data
- [ ] Manually verify team detail page loads drivers and constructors correctly

Closes #38