### PR TITLE
Budget system

### DIFF
--- a/api/F1CompanionApi.UnitTests/Domain/Exceptions/BudgetExceededExceptionTests.cs
+++ b/api/F1CompanionApi.UnitTests/Domain/Exceptions/BudgetExceededExceptionTests.cs
@@ -1,0 +1,41 @@
+using F1CompanionApi.Domain;
+using F1CompanionApi.Domain.Exceptions;
+
+namespace F1CompanionApi.UnitTests.Domain.Exceptions;
+
+public class BudgetExceededExceptionTests
+{
+    [Fact]
+    public void Constructor_SetsAllPropertiesCorrectly()
+    {
+        // Arrange
+        const int teamId = 42;
+        const decimal playerPrice = 25_000_000m;
+        const decimal remainingBudget = 10_000_000m;
+
+        // Act
+        var exception = new BudgetExceededException(teamId, playerPrice, remainingBudget);
+
+        // Assert
+        Assert.Equal(teamId, exception.TeamId);
+        Assert.Equal(playerPrice, exception.PlayerPrice);
+        Assert.Equal(remainingBudget, exception.RemainingBudget);
+    }
+
+    [Fact]
+    public void Constructor_FormatsMessageWithCriticalContext()
+    {
+        // Arrange
+        const int teamId = 42;
+        const decimal playerPrice = 25_000_000m;
+        const decimal remainingBudget = 10_000_000m;
+
+        // Act
+        var exception = new BudgetExceededException(teamId, playerPrice, remainingBudget);
+
+        // Assert
+        Assert.Contains(teamId.ToString(), exception.Message);
+        Assert.Contains("cannot afford", exception.Message);
+        Assert.Contains(BudgetConstants.BudgetCap.ToString("C0"), exception.Message);
+    }
+}

--- a/api/F1CompanionApi.UnitTests/Domain/Exceptions/GlobalExceptionHandlerTests.cs
+++ b/api/F1CompanionApi.UnitTests/Domain/Exceptions/GlobalExceptionHandlerTests.cs
@@ -689,6 +689,51 @@ public class GlobalExceptionHandlerTests
     }
 
     [Fact]
+    public async Task TryHandleAsync_BudgetExceededException_Returns400WithBudgetExceeded()
+    {
+        // Arrange
+        var ex = new BudgetExceededException(
+            teamId: 10,
+            playerPrice: 25_000_000m,
+            remainingBudget: 10_000_000m
+        );
+
+        // Act
+        var result = await _handler.TryHandleAsync(_httpContext, ex, CancellationToken.None);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(StatusCodes.Status400BadRequest, _httpContext.Response.StatusCode);
+
+        _mockProblemDetailsService.Verify(
+            x =>
+                x.WriteAsync(
+                    It.Is<ProblemDetailsContext>(ctx =>
+                        ctx.ProblemDetails.Status == 400
+                        && ctx.ProblemDetails.Title == "Budget Exceeded"
+                        && ctx.ProblemDetails.Detail == ex.Message
+                        && ctx.ProblemDetails.Type == "https://httpstatuses.com/400"
+                        && ctx.Exception == null // 4xx does not include exception
+                    )
+                ),
+            Times.Once
+        );
+
+        // Verify warning logging for 4xx
+        _mockLogger.Verify(
+            x =>
+                x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => true),
+                    ex,
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()
+                ),
+            Times.Once
+        );
+    }
+
+    [Fact]
     public async Task TryHandleAsync_InvalidSlotPositionException_Returns400WithInvalidSlotPosition()
     {
         // Arrange

--- a/api/F1CompanionApi.UnitTests/Services/TeamServiceTests.cs
+++ b/api/F1CompanionApi.UnitTests/Services/TeamServiceTests.cs
@@ -458,6 +458,68 @@ public class TeamServiceTests
         Assert.Equal("Driver not found", exception.Message);
     }
 
+    [Fact]
+    public async Task AddDriverToTeamAsync_PlayerFitsWithinBudget_Succeeds()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        var driver = CreateTestDriver(context, "NOR", "Lando", "Norris", price: 50_000_000m);
+
+        // Act — 50M < 100M cap, should succeed
+        await service.AddDriverToTeamAsync(team.Id, driver.Id, 0, user.Id);
+
+        // Assert
+        var teamDriver = await context.TeamDrivers.FirstOrDefaultAsync(td =>
+            td.TeamId == team.Id && td.DriverId == driver.Id
+        );
+        Assert.NotNull(teamDriver);
+    }
+
+    [Fact]
+    public async Task AddDriverToTeamAsync_PlayerExceedsBudget_ThrowsBudgetExceededException()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        var driver = CreateTestDriver(context, "NOR", "Lando", "Norris", price: 101_000_000m);
+
+        // Act & Assert — 101M > 100M cap
+        var exception = await Assert.ThrowsAsync<BudgetExceededException>(() =>
+            service.AddDriverToTeamAsync(team.Id, driver.Id, 0, user.Id)
+        );
+        Assert.Equal(team.Id, exception.TeamId);
+        Assert.Equal(101_000_000m, exception.PlayerPrice);
+        Assert.Equal(100_000_000m, exception.RemainingBudget);
+    }
+
+    [Fact]
+    public async Task AddDriverToTeamAsync_ExactlyAtBudgetCap_Succeeds()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        var driver = CreateTestDriver(context, "NOR", "Lando", "Norris", price: 100_000_000m);
+
+        // Act — exactly at cap, should succeed
+        await service.AddDriverToTeamAsync(team.Id, driver.Id, 0, user.Id);
+
+        // Assert
+        var teamDriver = await context.TeamDrivers.FirstOrDefaultAsync(td =>
+            td.TeamId == team.Id && td.DriverId == driver.Id
+        );
+        Assert.NotNull(teamDriver);
+    }
+
     #endregion
 
     #region RemoveDriverFromTeamAsync Tests
@@ -766,6 +828,52 @@ public class TeamServiceTests
         Assert.Equal("Constructor not found", exception.Message);
     }
 
+    [Fact]
+    public async Task AddConstructorToTeamAsync_PlayerExceedsBudget_ThrowsBudgetExceededException()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        var constructor = CreateTestConstructor(context, "Red Bull Racing", price: 101_000_000m);
+
+        // Act & Assert — 101M > 100M cap
+        var exception = await Assert.ThrowsAsync<BudgetExceededException>(() =>
+            service.AddConstructorToTeamAsync(team.Id, constructor.Id, 0, user.Id)
+        );
+        Assert.Equal(team.Id, exception.TeamId);
+        Assert.Equal(101_000_000m, exception.PlayerPrice);
+        Assert.Equal(100_000_000m, exception.RemainingBudget);
+    }
+
+    [Fact]
+    public async Task AddConstructorToTeamAsync_CumulativeCostExceedsBudget_ThrowsBudgetExceededException()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+
+        // Add a driver costing 60M first
+        var driver = CreateTestDriver(context, "NOR", "Lando", "Norris", price: 60_000_000m);
+        await service.AddDriverToTeamAsync(team.Id, driver.Id, 0, user.Id);
+
+        // Now try to add a constructor costing 50M — 60M + 50M = 110M > 100M cap
+        var constructor = CreateTestConstructor(context, "Red Bull Racing", price: 50_000_000m);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<BudgetExceededException>(() =>
+            service.AddConstructorToTeamAsync(team.Id, constructor.Id, 0, user.Id)
+        );
+        Assert.Equal(team.Id, exception.TeamId);
+        Assert.Equal(50_000_000m, exception.PlayerPrice);
+        Assert.Equal(40_000_000m, exception.RemainingBudget); // 100M - 60M = 40M remaining
+    }
+
     #endregion
 
     #region RemoveConstructorFromTeamAsync Tests
@@ -884,7 +992,8 @@ public class TeamServiceTests
         ApplicationDbContext context,
         string abbreviation,
         string firstName,
-        string lastName
+        string lastName,
+        decimal price = 1_000_000m
     )
     {
         var driver = new Driver
@@ -893,20 +1002,26 @@ public class TeamServiceTests
             LastName = lastName,
             Abbreviation = abbreviation,
             CountryAbbreviation = "NL",
+            Price = price,
         };
         context.Drivers.Add(driver);
         context.SaveChanges();
         return driver;
     }
 
-    private Constructor CreateTestConstructor(ApplicationDbContext context, string name)
+    private Constructor CreateTestConstructor(
+        ApplicationDbContext context,
+        string name,
+        decimal price = 1_000_000m
+    )
     {
         var constructor = new Constructor
         {
             Name = name,
             FullName = "Test Constructor",
-            Abbreviation = "TES",
+            Abbreviation = name[..3].ToUpper(),
             CountryAbbreviation = "AT",
+            Price = price,
         };
         context.Constructors.Add(constructor);
         context.SaveChanges();

--- a/api/F1CompanionApi/Api/Mappers/ConstructorResponseMapper.cs
+++ b/api/F1CompanionApi/Api/Mappers/ConstructorResponseMapper.cs
@@ -14,6 +14,7 @@ public static class ConstructorResponseMapper
             Abbreviation = constructor.Abbreviation,
             CountryAbbreviation = constructor.CountryAbbreviation,
             Name = constructor.Name,
+            Price = constructor.Price,
         };
     }
 

--- a/api/F1CompanionApi/Api/Mappers/DriverResponseMapper.cs
+++ b/api/F1CompanionApi/Api/Mappers/DriverResponseMapper.cs
@@ -14,6 +14,7 @@ public static class DriverResponseMapper
             LastName = driver.LastName,
             Abbreviation = driver.Abbreviation,
             CountryAbbreviation = driver.CountryAbbreviation,
+            Price = driver.Price,
         };
     }
 

--- a/api/F1CompanionApi/Api/Mappers/TeamConstructorResponseMapper.cs
+++ b/api/F1CompanionApi/Api/Mappers/TeamConstructorResponseMapper.cs
@@ -15,6 +15,7 @@ public static class TeamConstructorResponseMapper
             FullName = teamConstructor.Constructor.FullName,
             Abbreviation = teamConstructor.Constructor.Abbreviation,
             CountryAbbreviation = teamConstructor.Constructor.CountryAbbreviation,
+            Price = teamConstructor.Constructor.Price,
         };
     }
 }

--- a/api/F1CompanionApi/Api/Mappers/TeamDriverResponseMapper.cs
+++ b/api/F1CompanionApi/Api/Mappers/TeamDriverResponseMapper.cs
@@ -15,6 +15,7 @@ public static class TeamDriverResponseMapper
             LastName = teamDriver.Driver.LastName,
             Abbreviation = teamDriver.Driver.Abbreviation,
             CountryAbbreviation = teamDriver.Driver.CountryAbbreviation,
+            Price = teamDriver.Driver.Price,
         };
     }
 }

--- a/api/F1CompanionApi/Api/Mappers/TeamResponseMapper.cs
+++ b/api/F1CompanionApi/Api/Mappers/TeamResponseMapper.cs
@@ -1,5 +1,6 @@
 using F1CompanionApi.Api.Models;
 using F1CompanionApi.Data.Entities;
+using F1CompanionApi.Domain;
 using F1CompanionApi.Extensions;
 
 namespace F1CompanionApi.Api.Mappers;
@@ -25,6 +26,10 @@ public static class TeamResponseMapper
             Name = team.Name,
             OwnerId = team.UserId,
             OwnerName = team.Owner.GetFullName(),
+            RemainingBudget =
+                BudgetConstants.BudgetCap
+                - team.TeamDrivers.Sum(td => td.Driver.Price)
+                - team.TeamConstructors.Sum(tc => tc.Constructor.Price),
             Drivers = team
                 .TeamDrivers.OrderBy(teamDriver => teamDriver.SlotPosition)
                 .Select(teamDriver => teamDriver.ToResponseModel())

--- a/api/F1CompanionApi/Api/Models/ConstructorResponse.cs
+++ b/api/F1CompanionApi/Api/Models/ConstructorResponse.cs
@@ -7,4 +7,5 @@ public class ConstructorResponse
     public required string FullName { get; set; }
     public required string Abbreviation { get; set; }
     public required string CountryAbbreviation { get; set; }
+    public decimal Price { get; set; }
 }

--- a/api/F1CompanionApi/Api/Models/DriverResponse.cs
+++ b/api/F1CompanionApi/Api/Models/DriverResponse.cs
@@ -7,4 +7,5 @@ public class DriverResponse
     public required string LastName { get; set; }
     public required string Abbreviation { get; set; }
     public required string CountryAbbreviation { get; set; }
+    public decimal Price { get; set; }
 }

--- a/api/F1CompanionApi/Api/Models/TeamConstructorResponse.cs
+++ b/api/F1CompanionApi/Api/Models/TeamConstructorResponse.cs
@@ -8,4 +8,5 @@ public class TeamConstructorResponse
     public required string FullName { get; set; }
     public required string Abbreviation { get; set; }
     public required string CountryAbbreviation { get; set; }
+    public decimal Price { get; set; }
 }

--- a/api/F1CompanionApi/Api/Models/TeamDetailsResponse.cs
+++ b/api/F1CompanionApi/Api/Models/TeamDetailsResponse.cs
@@ -6,6 +6,7 @@ public class TeamDetailsResponse
     public required string Name { get; set; }
     public required int OwnerId { get; set; }
     public required string OwnerName { get; set; }
+    public decimal RemainingBudget { get; set; }
     public List<TeamDriverResponse> Drivers { get; set; } = new();
     public List<TeamConstructorResponse> Constructors { get; set; } = new();
 }

--- a/api/F1CompanionApi/Api/Models/TeamDriverResponse.cs
+++ b/api/F1CompanionApi/Api/Models/TeamDriverResponse.cs
@@ -8,4 +8,5 @@ public class TeamDriverResponse
     public required string LastName { get; set; }
     public required string Abbreviation { get; set; }
     public required string CountryAbbreviation { get; set; }
+    public decimal Price { get; set; }
 }

--- a/api/F1CompanionApi/Data/ApplicationDbContext.cs
+++ b/api/F1CompanionApi/Data/ApplicationDbContext.cs
@@ -34,6 +34,16 @@ public class ApplicationDbContext : DbContext
             entity.Property(e => e.Id).HasMaxLength(36); // UUID length
         });
 
+        modelBuilder.Entity<Driver>(entity =>
+        {
+            entity.Property(e => e.Price).HasDefaultValue(3_000_000m);
+        });
+
+        modelBuilder.Entity<Constructor>(entity =>
+        {
+            entity.Property(e => e.Price).HasDefaultValue(3_000_000m);
+        });
+
         modelBuilder
             .Entity<League>()
             .HasOne(e => e.Owner)

--- a/api/F1CompanionApi/Data/Entities/Constructor.cs
+++ b/api/F1CompanionApi/Data/Entities/Constructor.cs
@@ -12,4 +12,5 @@ public class Constructor : BaseEntity
     public required string FullName { get; set; }
     public required string Abbreviation { get; set; }
     public required string CountryAbbreviation { get; set; }
+    public decimal Price { get; set; }
 }

--- a/api/F1CompanionApi/Data/Entities/Driver.cs
+++ b/api/F1CompanionApi/Data/Entities/Driver.cs
@@ -12,4 +12,5 @@ public class Driver : BaseEntity
     public required string LastName { get; set; }
     public required string Abbreviation { get; set; }
     public required string CountryAbbreviation { get; set; }
+    public decimal Price { get; set; }
 }

--- a/api/F1CompanionApi/Data/Migrations/20260222150509_AddPriceToDriversAndConstructors.Designer.cs
+++ b/api/F1CompanionApi/Data/Migrations/20260222150509_AddPriceToDriversAndConstructors.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using F1CompanionApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace F1CompanionApi.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260222150509_AddPriceToDriversAndConstructors")]
+    partial class AddPriceToDriversAndConstructors
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/F1CompanionApi/Data/Migrations/20260222150509_AddPriceToDriversAndConstructors.cs
+++ b/api/F1CompanionApi/Data/Migrations/20260222150509_AddPriceToDriversAndConstructors.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace F1CompanionApi.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPriceToDriversAndConstructors : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "Price",
+                table: "Drivers",
+                type: "numeric",
+                nullable: false,
+                defaultValue: 3000000m);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "Price",
+                table: "Constructors",
+                type: "numeric",
+                nullable: false,
+                defaultValue: 3000000m);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Price",
+                table: "Drivers");
+
+            migrationBuilder.DropColumn(
+                name: "Price",
+                table: "Constructors");
+        }
+    }
+}

--- a/api/F1CompanionApi/Domain/BudgetConstants.cs
+++ b/api/F1CompanionApi/Domain/BudgetConstants.cs
@@ -1,0 +1,6 @@
+namespace F1CompanionApi.Domain;
+
+public static class BudgetConstants
+{
+    public const decimal BudgetCap = 100_000_000m;
+}

--- a/api/F1CompanionApi/Domain/Exceptions/BudgetExceededException.cs
+++ b/api/F1CompanionApi/Domain/Exceptions/BudgetExceededException.cs
@@ -1,0 +1,32 @@
+namespace F1CompanionApi.Domain.Exceptions;
+
+/// <summary>
+/// Exception thrown when adding a player would push a team over the budget cap.
+/// </summary>
+public class BudgetExceededException : Exception
+{
+    /// <summary>
+    /// Gets the ID of the team that cannot afford the player.
+    /// </summary>
+    public int TeamId { get; init; }
+
+    /// <summary>
+    /// Gets the price of the player that was attempted to be added.
+    /// </summary>
+    public decimal PlayerPrice { get; init; }
+
+    /// <summary>
+    /// Gets the remaining budget before the attempted addition.
+    /// </summary>
+    public decimal RemainingBudget { get; init; }
+
+    public BudgetExceededException(int teamId, decimal playerPrice, decimal remainingBudget)
+        : base(
+            $"Team {teamId} cannot afford this player. Cost: {playerPrice:C0}, Remaining: {remainingBudget:C0}, Cap: {BudgetConstants.BudgetCap:C0}"
+        )
+    {
+        TeamId = teamId;
+        PlayerPrice = playerPrice;
+        RemainingBudget = remainingBudget;
+    }
+}

--- a/api/F1CompanionApi/Domain/Exceptions/GlobalExceptionHandler.cs
+++ b/api/F1CompanionApi/Domain/Exceptions/GlobalExceptionHandler.cs
@@ -98,6 +98,12 @@ public class GlobalExceptionHandler : IExceptionHandler
             // Custom Domain Exceptions - Validation Failures
             TeamFullException ex => (StatusCodes.Status400BadRequest, "Team Full", ex.Message),
 
+            BudgetExceededException ex => (
+                StatusCodes.Status400BadRequest,
+                "Budget Exceeded",
+                ex.Message
+            ),
+
             InvalidSlotPositionException ex => (
                 StatusCodes.Status400BadRequest,
                 "Invalid Slot Position",

--- a/api/F1CompanionApi/Domain/Services/TeamService.cs
+++ b/api/F1CompanionApi/Domain/Services/TeamService.cs
@@ -108,6 +108,9 @@ public class TeamService : ITeamService
         // Validate team ownership
         var team = await _dbContext
             .Teams.Include(t => t.TeamDrivers)
+                .ThenInclude(td => td.Driver)
+            .Include(t => t.TeamConstructors)
+                .ThenInclude(tc => tc.Constructor)
             .FirstOrDefaultAsync(t => t.Id == teamId);
 
         if (team is null)
@@ -166,6 +169,19 @@ public class TeamService : ITeamService
             _logger.LogWarning("Driver {DriverId} not found", driverId);
             throw new InvalidOperationException("Driver not found");
         }
+
+        // Check budget cap
+        var currentSpend =
+            team.TeamDrivers.Sum(td => td.Driver.Price)
+            + team.TeamConstructors.Sum(tc => tc.Constructor.Price);
+        var projectedSpend = currentSpend + driver.Price;
+
+        if (projectedSpend > BudgetConstants.BudgetCap)
+            throw new BudgetExceededException(
+                team.Id,
+                driver.Price,
+                BudgetConstants.BudgetCap - currentSpend
+            );
 
         var teamDriver = new TeamDriver
         {
@@ -255,7 +271,10 @@ public class TeamService : ITeamService
 
         // Validate team ownership
         var team = await _dbContext
-            .Teams.Include(t => t.TeamConstructors)
+            .Teams.Include(t => t.TeamDrivers)
+                .ThenInclude(td => td.Driver)
+            .Include(t => t.TeamConstructors)
+                .ThenInclude(tc => tc.Constructor)
             .FirstOrDefaultAsync(t => t.Id == teamId);
 
         if (team is null)
@@ -322,6 +341,19 @@ public class TeamService : ITeamService
             _logger.LogWarning("Constructor {ConstructorId} not found", constructorId);
             throw new InvalidOperationException("Constructor not found");
         }
+
+        // Check budget cap
+        var currentSpend =
+            team.TeamDrivers.Sum(td => td.Driver.Price)
+            + team.TeamConstructors.Sum(tc => tc.Constructor.Price);
+        var projectedSpend = currentSpend + constructor.Price;
+
+        if (projectedSpend > BudgetConstants.BudgetCap)
+            throw new BudgetExceededException(
+                team.Id,
+                constructor.Price,
+                BudgetConstants.BudgetCap - currentSpend
+            );
 
         var teamConstructor = new TeamConstructor
         {

--- a/api/supabase/seed-prices.sql
+++ b/api/supabase/seed-prices.sql
@@ -1,0 +1,46 @@
+-- Standalone price UPDATE script — run manually against any environment to set prices without a deploy.
+-- Update values here as real SportsDeck 2026 prices are confirmed.
+
+-- Driver prices
+-- Known (calculated from docs/research/driver-value-research.json via round_to_100K(262,000 × previous_average)):
+UPDATE "Drivers" SET "Price" = 25600000 WHERE "Abbreviation" = 'NOR';
+UPDATE "Drivers" SET "Price" = 22800000 WHERE "Abbreviation" = 'LEC';
+UPDATE "Drivers" SET "Price" = 18600000 WHERE "Abbreviation" = 'SAI';
+UPDATE "Drivers" SET "Price" = 18500000 WHERE "Abbreviation" = 'PIA';
+UPDATE "Drivers" SET "Price" = 17700000 WHERE "Abbreviation" = 'RUS';
+UPDATE "Drivers" SET "Price" = 7200000  WHERE "Abbreviation" = 'ALO';
+UPDATE "Drivers" SET "Price" = 5300000  WHERE "Abbreviation" = 'GAS';
+-- Placeholder ($3M floor — update when SportsDeck 2026 prices are available):
+UPDATE "Drivers" SET "Price" = 3000000  WHERE "Abbreviation" = 'VER';
+UPDATE "Drivers" SET "Price" = 3000000  WHERE "Abbreviation" = 'HAM';
+UPDATE "Drivers" SET "Price" = 3000000  WHERE "Abbreviation" = 'ANT';
+UPDATE "Drivers" SET "Price" = 3000000  WHERE "Abbreviation" = 'HAD';
+UPDATE "Drivers" SET "Price" = 3000000  WHERE "Abbreviation" = 'STR';
+UPDATE "Drivers" SET "Price" = 3000000  WHERE "Abbreviation" = 'LAW';
+UPDATE "Drivers" SET "Price" = 3000000  WHERE "Abbreviation" = 'ALB';
+UPDATE "Drivers" SET "Price" = 3000000  WHERE "Abbreviation" = 'HUL';
+UPDATE "Drivers" SET "Price" = 3000000  WHERE "Abbreviation" = 'BOR';
+UPDATE "Drivers" SET "Price" = 3000000  WHERE "Abbreviation" = 'OCO';
+UPDATE "Drivers" SET "Price" = 3000000  WHERE "Abbreviation" = 'BEA';
+UPDATE "Drivers" SET "Price" = 3000000  WHERE "Abbreviation" = 'COL';
+UPDATE "Drivers" SET "Price" = 3000000  WHERE "Abbreviation" = 'LIN';
+UPDATE "Drivers" SET "Price" = 3000000  WHERE "Abbreviation" = 'DOO';
+UPDATE "Drivers" SET "Price" = 3000000  WHERE "Abbreviation" = 'TSU';
+UPDATE "Drivers" SET "Price" = 3000000  WHERE "Abbreviation" = 'BOT';
+UPDATE "Drivers" SET "Price" = 3000000  WHERE "Abbreviation" = 'PER';
+
+-- Constructor prices
+-- Known:
+UPDATE "Constructors" SET "Price" = 28300000 WHERE "Abbreviation" = 'MCL';
+UPDATE "Constructors" SET "Price" = 26500000 WHERE "Abbreviation" = 'FER';
+UPDATE "Constructors" SET "Price" = 25200000 WHERE "Abbreviation" = 'RBR';
+UPDATE "Constructors" SET "Price" = 8000000  WHERE "Abbreviation" = 'AMR';
+UPDATE "Constructors" SET "Price" = 7500000  WHERE "Abbreviation" = 'ALP';
+UPDATE "Constructors" SET "Price" = 4400000  WHERE "Abbreviation" = 'WIL';
+-- Placeholder ($3M floor — update when SportsDeck 2026 prices are available):
+UPDATE "Constructors" SET "Price" = 3000000  WHERE "Abbreviation" = 'MER';
+UPDATE "Constructors" SET "Price" = 3000000  WHERE "Abbreviation" = 'RBS';
+UPDATE "Constructors" SET "Price" = 3000000  WHERE "Abbreviation" = 'SAU';
+UPDATE "Constructors" SET "Price" = 3000000  WHERE "Abbreviation" = 'HAA';
+UPDATE "Constructors" SET "Price" = 3000000  WHERE "Abbreviation" = 'AUD';
+UPDATE "Constructors" SET "Price" = 3000000  WHERE "Abbreviation" = 'CAD';

--- a/docs/plans/budget-system-implementation.md
+++ b/docs/plans/budget-system-implementation.md
@@ -1,0 +1,230 @@
+# Budget System Implementation Plan (Issue #31)
+
+## Context
+
+Add a budget cap system aligned with SportsDeck rules. Currently, drivers and constructors have no price data, and team composition is unconstrained by cost. The frontend already has placeholder stubs (`$--.-M` in picker list items, `$200k` hardcoded budget in Team page) waiting for real data.
+
+**Blockers resolved:** Issue #14 (UX Redesign) is closed. Phase 0 data collection is partially complete — scoring rules and pricing formula are documented. Driver/constructor starting prices will use known values from the research JSON where available, with $3M floor for unknowns (to be updated later when real SportsDeck prices are provided).
+
+**Scope assessment:** Single issue. All tasks form one cohesive vertical slice — the backend schema, validation, and frontend display are all interdependent.
+
+**Separate prerequisite:** Updating the grid to 2026 (new drivers/constructors, season-based associations replacing `IsActive`) should be a separate issue. This budget system works against whatever drivers/constructors currently exist in the DB.
+
+---
+
+## Implementation Steps
+
+### Step 1: Add `Price` to entities
+
+**Files:**
+- `api/F1CompanionApi/Data/Entities/Driver.cs`
+- `api/F1CompanionApi/Data/Entities/Constructor.cs`
+
+Add `public decimal Price { get; set; }` to both entities.
+
+### Step 2: Generate schema migration
+
+Run: `dotnet ef migrations add AddPriceToDriversAndConstructors --project F1CompanionApi`
+
+This adds a `Price` decimal column (NOT NULL, default 0) to both tables.
+
+### Step 3: Seed driver and constructor prices
+
+**File:** `api/supabase/seed.sql`
+
+Add UPDATE statements at the end of the existing seed script (after driver/constructor INSERTs). This matches the existing seeding pattern used for drivers, constructors, seasons, and races.
+
+```sql
+-- Seed driver prices (known from 2025 season data)
+UPDATE "Drivers" SET "Price" = 18600000 WHERE "Abbreviation" = 'SAI';
+UPDATE "Drivers" SET "Price" = 5300000 WHERE "Abbreviation" = 'GAS';
+-- ... etc for all drivers
+-- Catch-all for unknowns:
+UPDATE "Drivers" SET "Price" = 3000000 WHERE "Price" = 0;
+UPDATE "Constructors" SET "Price" = 3000000 WHERE "Price" = 0;
+```
+
+**Known prices** (from `docs/research/driver-value-research.json`, calculated via `round_to_100K(262,000 * previous_average)`):
+
+| Abbr | Player | Price |
+|------|--------|-------|
+| SAI | Sainz | 18,600,000 |
+| GAS | Gasly | 5,300,000 |
+| RUS | Russell | 17,700,000 |
+| NOR | Norris | 25,600,000 |
+| PIA | Piastri | 18,500,000 |
+| LEC | Leclerc | 22,800,000 |
+| ALO | Alonso | 7,200,000 |
+| MCL | McLaren | 28,300,000 |
+| WIL | Williams | 4,400,000 |
+| ALP | Alpine | 7,500,000 |
+| RBR | Red Bull | 25,200,000 |
+| FER | Ferrari | 26,500,000 |
+| AMR | Aston Martin | 8,000,000 |
+
+**Remaining players** (VER, HAM, ANT, LAW, STR, DOO, ALB, TSU, HAD, HUL, BOR, OCO, BEA + MER, RBS, SAU, HAA): Use $3,000,000 floor as placeholder — will be updated when real SportsDeck 2026 prices are provided.
+
+### Step 4: Define budget cap constant
+
+**New file:** `api/F1CompanionApi/Domain/BudgetConstants.cs`
+
+```csharp
+namespace F1CompanionApi.Domain;
+
+public static class BudgetConstants
+{
+    public const decimal BudgetCap = 100_000_000m;
+}
+```
+
+Kept separate from `TeamService` so the mapper can also reference it without a service dependency.
+
+### Step 5: Add `BudgetExceededException`
+
+**New file:** `api/F1CompanionApi/Domain/Exceptions/BudgetExceededException.cs`
+
+Follow the `TeamFullException` pattern — properties for `TeamId`, `PlayerPrice`, `RemainingBudget`. Message includes the budget cap value.
+
+### Step 6: Register exception in `GlobalExceptionHandler`
+
+**File:** `api/F1CompanionApi/Domain/Exceptions/GlobalExceptionHandler.cs`
+
+Add alongside the other validation failures (near `TeamFullException` on line 99):
+
+```csharp
+BudgetExceededException ex => (StatusCodes.Status400BadRequest, "Budget Exceeded", ex.Message),
+```
+
+### Step 7: Add budget validation to `TeamService`
+
+**File:** `api/F1CompanionApi/Domain/Services/TeamService.cs`
+
+In both `AddDriverToTeamAsync` and `AddConstructorToTeamAsync`:
+
+1. Expand the existing team `.Include()` query to also `.ThenInclude(td => td.Driver)` and `.ThenInclude(tc => tc.Constructor)` so prices are loaded
+2. After the existing validations (slot, duplicate, entity exists) and before the DB write, compute:
+   ```
+   currentSpend = team.TeamDrivers.Sum(td => td.Driver.Price) + team.TeamConstructors.Sum(tc => tc.Constructor.Price)
+   projectedSpend = currentSpend + newPlayer.Price
+   ```
+3. If `projectedSpend > BudgetConstants.BudgetCap`, throw `BudgetExceededException`
+
+### Step 8: Add `Price` to API response models and mappers
+
+**Response models — add `public decimal Price { get; set; }`:**
+- `api/F1CompanionApi/Api/Models/DriverResponse.cs`
+- `api/F1CompanionApi/Api/Models/ConstructorResponse.cs`
+- `api/F1CompanionApi/Api/Models/TeamDriverResponse.cs`
+- `api/F1CompanionApi/Api/Models/TeamConstructorResponse.cs`
+
+**Add `RemainingBudget` to team details:**
+- `api/F1CompanionApi/Api/Models/TeamDetailsResponse.cs` — add `public decimal RemainingBudget { get; set; }`
+
+**Mappers — add `Price = entity.Price` mapping:**
+- `api/F1CompanionApi/Api/Mappers/DriverResponseMapper.cs`
+- `api/F1CompanionApi/Api/Mappers/ConstructorResponseMapper.cs`
+- `api/F1CompanionApi/Api/Mappers/TeamDriverResponseMapper.cs` — `Price = teamDriver.Driver.Price`
+- `api/F1CompanionApi/Api/Mappers/TeamConstructorResponseMapper.cs` — `Price = teamConstructor.Constructor.Price`
+- `api/F1CompanionApi/Api/Mappers/TeamResponseMapper.cs` — in `ToDetailsResponseModel()`, compute:
+  ```
+  RemainingBudget = BudgetConstants.BudgetCap - drivers.Sum(Price) - constructors.Sum(Price)
+  ```
+
+### Step 9: Backend tests
+
+**File:** `api/F1CompanionApi.UnitTests/Services/TeamServiceTests.cs`
+- Update `CreateTestDriver`/`CreateTestConstructor` helpers with a `price` parameter (default to a reasonable value so existing tests still pass)
+- Add tests:
+  - `AddDriverToTeamAsync_PlayerFitsWithinBudget_Succeeds`
+  - `AddDriverToTeamAsync_PlayerExceedsBudget_ThrowsBudgetExceededException`
+  - `AddDriverToTeamAsync_ExactlyAtBudgetCap_Succeeds`
+  - `AddConstructorToTeamAsync_PlayerExceedsBudget_ThrowsBudgetExceededException`
+  - `AddConstructorToTeamAsync_CumulativeCostExceedsBudget_ThrowsBudgetExceededException`
+
+**New file:** `api/F1CompanionApi.UnitTests/Domain/Exceptions/BudgetExceededExceptionTests.cs`
+- Verify properties are set and message contains budget cap
+
+**File:** `api/F1CompanionApi.UnitTests/Domain/Exceptions/GlobalExceptionHandlerTests.cs`
+- Add test verifying `BudgetExceededException` maps to HTTP 400
+
+### Step 10: Update frontend contracts
+
+**File:** `web/src/contracts/Role.ts`
+- Add `price: number` to `Driver` and `Constructor` interfaces
+
+**File:** `web/src/contracts/Team.ts`
+- Add `price: number` to `TeamDriver` and `TeamConstructor` interfaces
+- Add `remainingBudget: number` to `Team` interface
+
+### Step 11: Update mock factories
+
+**File:** `web/src/test-utils/mockFactories.ts`
+- Add `price` field to all mock driver/constructor factories
+- Add `remainingBudget` field to mock team factory
+
+### Step 12: Update frontend picker list items
+
+**Files:**
+- `web/src/components/DriverListItem/DriverListItem.tsx`
+- `web/src/components/ConstructorListItem/ConstructorListItem.tsx`
+
+Changes:
+1. Replace `$--.-M` with `${formatMillions(driver.price)}M` (reuse existing `formatMillions` from `web/src/lib/utils.ts`)
+2. Add `disabled?: boolean` prop — when true, dim the item and prevent `onSelect` from firing
+
+### Step 13: Update frontend picker components
+
+**Files:**
+- `web/src/components/DriverPicker/DriverPicker.tsx`
+- `web/src/components/ConstructorPicker/ConstructorPicker.tsx`
+
+Add `remainingBudget: number` prop. When rendering list items, pass `disabled={item.price > remainingBudget}`.
+
+### Step 14: Update frontend cards
+
+**Files:**
+- `web/src/components/DriverCard/DriverCard.tsx`
+- `web/src/components/ConstructorCard/ConstructorCard.tsx`
+
+Replace `$--.-M` with formatted real price from the team member data.
+
+### Step 15: Update Team component
+
+**File:** `web/src/components/Team/Team.tsx`
+
+1. Replace hardcoded `$200k` budget display with `${formatMillions(team.remainingBudget)}M`
+2. Pass `remainingBudget={team.remainingBudget}` to `DriverPicker` and `ConstructorPicker`
+
+### Step 16: Frontend tests
+
+Update tests in:
+- `web/src/components/DriverListItem/DriverListItem.test.tsx` — assert real price display, test disabled state
+- `web/src/components/ConstructorListItem/ConstructorListItem.test.tsx` — same
+- `web/src/components/DriverCard/DriverCard.test.tsx` — assert price display
+- `web/src/components/ConstructorCard/ConstructorCard.test.tsx` — same
+- `web/src/components/Team/Team.test.tsx` — assert remaining budget display
+
+---
+
+## Key Design Decisions
+
+- **Budget cap:** $100,000,000 (100M)
+- **Budget is computed, not stored.** `RemainingBudget` is calculated in `TeamResponseMapper.ToDetailsResponseModel` from the cap minus team member prices. No new column on `Team` entity.
+- **`BudgetConstants` class** is a static class in the Domain layer, referenced by both the mapper and the service.
+- **Frontend disabling is a UX enhancement, not a security gate.** The backend rejects over-budget additions regardless. The frontend `disabled` prop prevents the user from attempting an obviously over-budget pick.
+- **Reuses existing `formatMillions`** utility from `web/src/lib/utils.ts` for price formatting.
+
+---
+
+## Verification
+
+1. **Build both projects:** `npm run api:build && npm run web:build`
+2. **Run all tests:** `npm run test:all`
+3. **Manual E2E check:**
+   - Apply migration: `dotnet ef database update --project api/F1CompanionApi`
+   - Run seed script: `psql <connection_string> -f api/supabase/seed.sql`
+   - Start both servers (`npm run api:watch` + `npm run web:dev`)
+   - Navigate to My Team page — verify budget shows a real dollar amount instead of `$200k`
+   - Open driver picker — verify prices appear instead of `$--.-M`
+   - Try adding a driver that would exceed the budget — verify the item is visually disabled
+   - Try API call directly to add an over-budget player — verify 400 response with "Budget Exceeded"

--- a/docs/plans/budget-system-implementation.md
+++ b/docs/plans/budget-system-implementation.md
@@ -2,207 +2,234 @@
 
 ## Context
 
-Add a budget cap system aligned with SportsDeck rules. Currently, drivers and constructors have no price data, and team composition is unconstrained by cost. The frontend already has placeholder stubs (`$--.-M` in picker list items, `$200k` hardcoded budget in Team page) waiting for real data.
+Add a budget cap system aligned with SportsDeck rules. Drivers and constructors currently have no price data; team composition is unconstrained by cost. The frontend has placeholder stubs (`$--.-M`, hardcoded `$200k` budget) waiting for real data.
 
-**Blockers resolved:** Issue #14 (UX Redesign) is closed. Phase 0 data collection is partially complete — scoring rules and pricing formula are documented. Driver/constructor starting prices will use known values from the research JSON where available, with $3M floor for unknowns (to be updated later when real SportsDeck prices are provided).
+**Budget cap:** $100,000,000 (confirmed)
+**Pricing source:** `docs/research/driver-value-research.json` (formula: `round_to_100K(262,000 × previous_average)`)
 
-**Scope assessment:** Single issue. All tasks form one cohesive vertical slice — the backend schema, validation, and frontend display are all interdependent.
-
-**Separate prerequisite:** Updating the grid to 2026 (new drivers/constructors, season-based associations replacing `IsActive`) should be a separate issue. This budget system works against whatever drivers/constructors currently exist in the DB.
+Each commit below is a complete, self-contained unit. Tests ship with the feature they cover. All tests must pass before requesting review.
 
 ---
 
-## Implementation Steps
-
-### Step 1: Add `Price` to entities
+## Commit 1 — Schema: add Price column to entities
 
 **Files:**
-- `api/F1CompanionApi/Data/Entities/Driver.cs`
-- `api/F1CompanionApi/Data/Entities/Constructor.cs`
+- `api/F1CompanionApi/Data/Entities/Driver.cs` — add `public decimal Price { get; set; }`
+- `api/F1CompanionApi/Data/Entities/Constructor.cs` — add `public decimal Price { get; set; }`
+- `api/F1CompanionApi/Data/ApplicationDbContext.cs` — add `HasDefaultValue(3_000_000m)` for both in `OnModelCreating`:
+  ```csharp
+  modelBuilder.Entity<Driver>(entity =>
+  {
+      entity.Property(e => e.Price).HasDefaultValue(3_000_000m);
+  });
+  modelBuilder.Entity<Constructor>(entity =>
+  {
+      entity.Property(e => e.Price).HasDefaultValue(3_000_000m);
+  });
+  ```
+- Migration: `dotnet ef migrations add AddPriceToDriversAndConstructors --project F1CompanionApi`
 
-Add `public decimal Price { get; set; }` to both entities.
+**Tests:** None — schema-only change.
 
-### Step 2: Generate schema migration
+**Commit message:** `chore: add Price column to Driver and Constructor entities`
 
-Run: `dotnet ef migrations add AddPriceToDriversAndConstructors --project F1CompanionApi`
+---
 
-This adds a `Price` decimal column (NOT NULL, default 0) to both tables.
+## Commit 2 — Seed data: price files
 
-### Step 3: Seed driver and constructor prices
+**Files:**
+- `api/supabase/seed.sql` — add `Price` inline in existing INSERT statements (column order: `FirstName, LastName, Abbreviation, CountryAbbreviation, Price, IsDeleted, CreatedAt, UpdatedAt, DeletedAt`). Known prices where available, `3000000` floor for all others.
+- `api/supabase/seed-prices.sql` *(new)* — standalone UPDATE script with every driver and constructor listed explicitly. Run manually against any environment to update prices without a deploy.
 
-**File:** `api/supabase/seed.sql`
+  ```sql
+  -- Driver prices — update values as real SportsDeck prices are confirmed
+  -- Known (from docs/research/driver-value-research.json):
+  UPDATE "Drivers" SET "Price" = 25600000 WHERE "Abbreviation" = 'NOR';
+  UPDATE "Drivers" SET "Price" = 22800000 WHERE "Abbreviation" = 'LEC';
+  UPDATE "Drivers" SET "Price" = 18600000 WHERE "Abbreviation" = 'SAI';
+  UPDATE "Drivers" SET "Price" = 18500000 WHERE "Abbreviation" = 'PIA';
+  UPDATE "Drivers" SET "Price" = 17700000 WHERE "Abbreviation" = 'RUS';
+  UPDATE "Drivers" SET "Price" = 7200000  WHERE "Abbreviation" = 'ALO';
+  UPDATE "Drivers" SET "Price" = 5300000  WHERE "Abbreviation" = 'GAS';
+  -- Placeholder ($3M floor — update when SportsDeck 2026 prices available):
+  UPDATE "Drivers" SET "Price" = 3000000 WHERE "Abbreviation" IN ('VER','HAM','ANT','HAD','STR','LAW','ALB','HUL','BOR','OCO','BEA','COL','LIN','DOO','TSU','BOT','PER');
 
-Add UPDATE statements at the end of the existing seed script (after driver/constructor INSERTs). This matches the existing seeding pattern used for drivers, constructors, seasons, and races.
+  -- Constructor prices — update values as real SportsDeck prices are confirmed
+  -- Known:
+  UPDATE "Constructors" SET "Price" = 28300000 WHERE "Abbreviation" = 'MCL';
+  UPDATE "Constructors" SET "Price" = 26500000 WHERE "Abbreviation" = 'FER';
+  UPDATE "Constructors" SET "Price" = 25200000 WHERE "Abbreviation" = 'RBR';
+  UPDATE "Constructors" SET "Price" = 8000000  WHERE "Abbreviation" = 'AMR';
+  UPDATE "Constructors" SET "Price" = 7500000  WHERE "Abbreviation" = 'ALP';
+  UPDATE "Constructors" SET "Price" = 4400000  WHERE "Abbreviation" = 'WIL';
+  -- Placeholder:
+  UPDATE "Constructors" SET "Price" = 3000000 WHERE "Abbreviation" IN ('MER','RBS','SAU','HAA','AUD','CAD');
+  ```
 
-```sql
--- Seed driver prices (known from 2025 season data)
-UPDATE "Drivers" SET "Price" = 18600000 WHERE "Abbreviation" = 'SAI';
-UPDATE "Drivers" SET "Price" = 5300000 WHERE "Abbreviation" = 'GAS';
--- ... etc for all drivers
--- Catch-all for unknowns:
-UPDATE "Drivers" SET "Price" = 3000000 WHERE "Price" = 0;
-UPDATE "Constructors" SET "Price" = 3000000 WHERE "Price" = 0;
-```
+**Tests:** None — SQL files only.
 
-**Known prices** (from `docs/research/driver-value-research.json`, calculated via `round_to_100K(262,000 * previous_average)`):
+**Commit message:** `chore: add price seed data for drivers and constructors`
 
-| Abbr | Player | Price |
-|------|--------|-------|
-| SAI | Sainz | 18,600,000 |
-| GAS | Gasly | 5,300,000 |
-| RUS | Russell | 17,700,000 |
-| NOR | Norris | 25,600,000 |
-| PIA | Piastri | 18,500,000 |
-| LEC | Leclerc | 22,800,000 |
-| ALO | Alonso | 7,200,000 |
-| MCL | McLaren | 28,300,000 |
-| WIL | Williams | 4,400,000 |
-| ALP | Alpine | 7,500,000 |
-| RBR | Red Bull | 25,200,000 |
-| FER | Ferrari | 26,500,000 |
-| AMR | Aston Martin | 8,000,000 |
+---
 
-**Remaining players** (VER, HAM, ANT, LAW, STR, DOO, ALB, TSU, HAD, HUL, BOR, OCO, BEA + MER, RBS, SAU, HAA): Use $3,000,000 floor as placeholder — will be updated when real SportsDeck 2026 prices are provided.
+## Commit 3 — Domain: BudgetExceededException + GlobalExceptionHandler
 
-### Step 4: Define budget cap constant
+**Files:**
+- `api/F1CompanionApi/Domain/BudgetConstants.cs` *(new)*:
+  ```csharp
+  namespace F1CompanionApi.Domain;
+  public static class BudgetConstants
+  {
+      public const decimal BudgetCap = 100_000_000m;
+  }
+  ```
+- `api/F1CompanionApi/Domain/Exceptions/BudgetExceededException.cs` *(new)* — follow `TeamFullException` pattern.
+- `api/F1CompanionApi/Domain/Exceptions/GlobalExceptionHandler.cs` — add alongside `TeamFullException`:
+  ```csharp
+  BudgetExceededException ex => (StatusCodes.Status400BadRequest, "Budget Exceeded", ex.Message),
+  ```
 
-**New file:** `api/F1CompanionApi/Domain/BudgetConstants.cs`
+**Tests:**
+- `api/F1CompanionApi.UnitTests/Domain/Exceptions/BudgetExceededExceptionTests.cs` *(new)* — verify properties are set and message contains expected values
+- `api/F1CompanionApi.UnitTests/Domain/Exceptions/GlobalExceptionHandlerTests.cs` — add test verifying `BudgetExceededException` → HTTP 400
 
-```csharp
-namespace F1CompanionApi.Domain;
+**Commit message:** `feat: add BudgetExceededException and register in GlobalExceptionHandler`
 
-public static class BudgetConstants
-{
-    public const decimal BudgetCap = 100_000_000m;
-}
-```
+---
 
-Kept separate from `TeamService` so the mapper can also reference it without a service dependency.
-
-### Step 5: Add `BudgetExceededException`
-
-**New file:** `api/F1CompanionApi/Domain/Exceptions/BudgetExceededException.cs`
-
-Follow the `TeamFullException` pattern — properties for `TeamId`, `PlayerPrice`, `RemainingBudget`. Message includes the budget cap value.
-
-### Step 6: Register exception in `GlobalExceptionHandler`
-
-**File:** `api/F1CompanionApi/Domain/Exceptions/GlobalExceptionHandler.cs`
-
-Add alongside the other validation failures (near `TeamFullException` on line 99):
-
-```csharp
-BudgetExceededException ex => (StatusCodes.Status400BadRequest, "Budget Exceeded", ex.Message),
-```
-
-### Step 7: Add budget validation to `TeamService`
+## Commit 4 — Service: budget validation in TeamService
 
 **File:** `api/F1CompanionApi/Domain/Services/TeamService.cs`
 
-In both `AddDriverToTeamAsync` and `AddConstructorToTeamAsync`:
+In **both** `AddDriverToTeamAsync` and `AddConstructorToTeamAsync`:
 
-1. Expand the existing team `.Include()` query to also `.ThenInclude(td => td.Driver)` and `.ThenInclude(tc => tc.Constructor)` so prices are loaded
-2. After the existing validations (slot, duplicate, entity exists) and before the DB write, compute:
+1. Expand the Include chain so both methods load both types:
+   ```csharp
+   .Include(t => t.TeamDrivers).ThenInclude(td => td.Driver)
+   .Include(t => t.TeamConstructors).ThenInclude(tc => tc.Constructor)
    ```
-   currentSpend = team.TeamDrivers.Sum(td => td.Driver.Price) + team.TeamConstructors.Sum(tc => tc.Constructor.Price)
-   projectedSpend = currentSpend + newPlayer.Price
+   (Required to sum both types for total spend.)
+
+2. After existing validations, before DB write:
+   ```csharp
+   var currentSpend = team.TeamDrivers.Sum(td => td.Driver.Price)
+                    + team.TeamConstructors.Sum(tc => tc.Constructor.Price);
+   var projectedSpend = currentSpend + newPlayer.Price;
+
+   if (projectedSpend > BudgetConstants.BudgetCap)
+       throw new BudgetExceededException(team.Id, newPlayer.Price, BudgetConstants.BudgetCap - currentSpend);
    ```
-3. If `projectedSpend > BudgetConstants.BudgetCap`, throw `BudgetExceededException`
 
-### Step 8: Add `Price` to API response models and mappers
-
-**Response models — add `public decimal Price { get; set; }`:**
-- `api/F1CompanionApi/Api/Models/DriverResponse.cs`
-- `api/F1CompanionApi/Api/Models/ConstructorResponse.cs`
-- `api/F1CompanionApi/Api/Models/TeamDriverResponse.cs`
-- `api/F1CompanionApi/Api/Models/TeamConstructorResponse.cs`
-
-**Add `RemainingBudget` to team details:**
-- `api/F1CompanionApi/Api/Models/TeamDetailsResponse.cs` — add `public decimal RemainingBudget { get; set; }`
-
-**Mappers — add `Price = entity.Price` mapping:**
-- `api/F1CompanionApi/Api/Mappers/DriverResponseMapper.cs`
-- `api/F1CompanionApi/Api/Mappers/ConstructorResponseMapper.cs`
-- `api/F1CompanionApi/Api/Mappers/TeamDriverResponseMapper.cs` — `Price = teamDriver.Driver.Price`
-- `api/F1CompanionApi/Api/Mappers/TeamConstructorResponseMapper.cs` — `Price = teamConstructor.Constructor.Price`
-- `api/F1CompanionApi/Api/Mappers/TeamResponseMapper.cs` — in `ToDetailsResponseModel()`, compute:
-  ```
-  RemainingBudget = BudgetConstants.BudgetCap - drivers.Sum(Price) - constructors.Sum(Price)
-  ```
-
-### Step 9: Backend tests
-
-**File:** `api/F1CompanionApi.UnitTests/Services/TeamServiceTests.cs`
-- Update `CreateTestDriver`/`CreateTestConstructor` helpers with a `price` parameter (default to a reasonable value so existing tests still pass)
-- Add tests:
+**Tests:** `api/F1CompanionApi.UnitTests/Services/TeamServiceTests.cs`
+- Add `price` parameter to `CreateTestDriver` / `CreateTestConstructor` (default to a small value so existing tests pass without budget concern)
+- Add:
   - `AddDriverToTeamAsync_PlayerFitsWithinBudget_Succeeds`
   - `AddDriverToTeamAsync_PlayerExceedsBudget_ThrowsBudgetExceededException`
   - `AddDriverToTeamAsync_ExactlyAtBudgetCap_Succeeds`
   - `AddConstructorToTeamAsync_PlayerExceedsBudget_ThrowsBudgetExceededException`
   - `AddConstructorToTeamAsync_CumulativeCostExceedsBudget_ThrowsBudgetExceededException`
 
-**New file:** `api/F1CompanionApi.UnitTests/Domain/Exceptions/BudgetExceededExceptionTests.cs`
-- Verify properties are set and message contains budget cap
+**Commit message:** `feat: add budget validation to TeamService`
 
-**File:** `api/F1CompanionApi.UnitTests/Domain/Exceptions/GlobalExceptionHandlerTests.cs`
-- Add test verifying `BudgetExceededException` maps to HTTP 400
+---
 
-### Step 10: Update frontend contracts
+## Commit 5 — API: expose Price and RemainingBudget in response models
 
-**File:** `web/src/contracts/Role.ts`
-- Add `price: number` to `Driver` and `Constructor` interfaces
+**Add `public decimal Price { get; set; }` to:**
+- `api/F1CompanionApi/Api/Models/DriverResponse.cs`
+- `api/F1CompanionApi/Api/Models/ConstructorResponse.cs`
+- `api/F1CompanionApi/Api/Models/TeamDriverResponse.cs`
+- `api/F1CompanionApi/Api/Models/TeamConstructorResponse.cs`
 
-**File:** `web/src/contracts/Team.ts`
-- Add `price: number` to `TeamDriver` and `TeamConstructor` interfaces
-- Add `remainingBudget: number` to `Team` interface
+**Add `public decimal RemainingBudget { get; set; }` to:**
+- `api/F1CompanionApi/Api/Models/TeamDetailsResponse.cs`
 
-### Step 11: Update mock factories
+**Update mappers:**
+- `api/F1CompanionApi/Api/Mappers/DriverResponseMapper.cs` — `Price = driver.Price`
+- `api/F1CompanionApi/Api/Mappers/ConstructorResponseMapper.cs` — `Price = constructor.Price`
+- `api/F1CompanionApi/Api/Mappers/TeamDriverResponseMapper.cs` — `Price = teamDriver.Driver.Price`
+- `api/F1CompanionApi/Api/Mappers/TeamConstructorResponseMapper.cs` — `Price = teamConstructor.Constructor.Price`
+- `api/F1CompanionApi/Api/Mappers/TeamResponseMapper.cs` — in `ToDetailsResponseModel()`:
+  ```csharp
+  RemainingBudget = BudgetConstants.BudgetCap
+      - team.TeamDrivers.Sum(td => td.Driver.Price)
+      - team.TeamConstructors.Sum(tc => tc.Constructor.Price)
+  ```
+  Note: `GetUserTeamAsync` already uses `.ThenInclude()` for both types, so prices are available without query changes.
 
-**File:** `web/src/test-utils/mockFactories.ts`
-- Add `price` field to all mock driver/constructor factories
-- Add `remainingBudget` field to mock team factory
+**Tests:** None — mappers are covered by service-level and E2E testing.
 
-### Step 12: Update frontend picker list items
+**Commit message:** `feat: expose Price and RemainingBudget in API response models`
+
+---
+
+## Commit 6 — Frontend: update contracts and mock factories
+
+**Files:**
+- `web/src/contracts/Role.ts` — add `price: number` to `Driver` and `Constructor`
+- `web/src/contracts/Team.ts` — add `price: number` to `TeamDriver` and `TeamConstructor`; add `remainingBudget: number` to `Team`
+- `web/src/test-utils/mockFactories.ts` — add `price` field to all driver/constructor/teamDriver/teamConstructor factories; add `remainingBudget` to team factory
+
+**Tests:** None — these are type definitions and test utilities.
+
+**Commit message:** `feat: add price and remainingBudget to frontend contracts and mock factories`
+
+---
+
+## Commit 7 — Frontend: prices in picker list items
 
 **Files:**
 - `web/src/components/DriverListItem/DriverListItem.tsx`
-- `web/src/components/ConstructorListItem/ConstructorListItem.tsx`
+  - Replace `$--.-M` with `` `$${formatMillions(driver.price)}M` `` (reuse `formatMillions` from `web/src/lib/utils.ts`)
+  - Add `disabled?: boolean` prop — dim item and suppress `onSelect` when true
+- `web/src/components/ConstructorListItem/ConstructorListItem.tsx` — same changes
 
-Changes:
-1. Replace `$--.-M` with `${formatMillions(driver.price)}M` (reuse existing `formatMillions` from `web/src/lib/utils.ts`)
-2. Add `disabled?: boolean` prop — when true, dim the item and prevent `onSelect` from firing
+**Tests:**
+- `web/src/components/DriverListItem/DriverListItem.test.tsx` — assert price display; test disabled state (item dimmed, onSelect not called)
+- `web/src/components/ConstructorListItem/ConstructorListItem.test.tsx` — same
 
-### Step 13: Update frontend picker components
+**Commit message:** `feat: display prices in driver and constructor picker list items`
 
-**Files:**
-- `web/src/components/DriverPicker/DriverPicker.tsx`
-- `web/src/components/ConstructorPicker/ConstructorPicker.tsx`
+---
 
-Add `remainingBudget: number` prop. When rendering list items, pass `disabled={item.price > remainingBudget}`.
-
-### Step 14: Update frontend cards
+## Commit 8 — Frontend: prices on team cards
 
 **Files:**
-- `web/src/components/DriverCard/DriverCard.tsx`
-- `web/src/components/ConstructorCard/ConstructorCard.tsx`
+- `web/src/components/DriverCard/DriverCard.tsx` — replace `$--.-M` with formatted real price
+- `web/src/components/ConstructorCard/ConstructorCard.tsx` — same
 
-Replace `$--.-M` with formatted real price from the team member data.
+**Tests:**
+- `web/src/components/DriverCard/DriverCard.test.tsx` — assert price display
+- `web/src/components/ConstructorCard/ConstructorCard.test.tsx` — assert price display
 
-### Step 15: Update Team component
+**Commit message:** `feat: display prices on driver and constructor team cards`
+
+---
+
+## Commit 9 — Frontend: disable over-budget picks in pickers
+
+**Files:**
+- `web/src/components/DriverPicker/DriverPicker.tsx` — add `remainingBudget: number` prop; pass `disabled={item.price > remainingBudget}` to each `DriverListItem`
+- `web/src/components/ConstructorPicker/ConstructorPicker.tsx` — same
+
+**Tests:**
+- `web/src/components/DriverPicker/DriverPicker.test.tsx` — add `remainingBudget` to all render calls; add tests for disabled state
+- `web/src/components/ConstructorPicker/ConstructorPicker.test.tsx` — same
+
+**Commit message:** `feat: disable over-budget picks in driver and constructor pickers`
+
+---
+
+## Commit 10 — Frontend: remaining budget on Team page
 
 **File:** `web/src/components/Team/Team.tsx`
+- Replace hardcoded `$200k` with `` `$${formatMillions(team.remainingBudget)}M` ``
+- Pass `remainingBudget={team.remainingBudget}` to both `DriverPicker` and `ConstructorPicker`
 
-1. Replace hardcoded `$200k` budget display with `${formatMillions(team.remainingBudget)}M`
-2. Pass `remainingBudget={team.remainingBudget}` to `DriverPicker` and `ConstructorPicker`
+**Tests:**
+- `web/src/components/Team/Team.test.tsx` — assert remaining budget display (not hardcoded value)
 
-### Step 16: Frontend tests
-
-Update tests in:
-- `web/src/components/DriverListItem/DriverListItem.test.tsx` — assert real price display, test disabled state
-- `web/src/components/ConstructorListItem/ConstructorListItem.test.tsx` — same
-- `web/src/components/DriverCard/DriverCard.test.tsx` — assert price display
-- `web/src/components/ConstructorCard/ConstructorCard.test.tsx` — same
-- `web/src/components/Team/Team.test.tsx` — assert remaining budget display
+**Commit message:** `feat: display remaining budget on Team page`
 
 ---
 
@@ -211,20 +238,20 @@ Update tests in:
 - **Budget cap:** $100,000,000 (100M)
 - **Budget is computed, not stored.** `RemainingBudget` is calculated in `TeamResponseMapper.ToDetailsResponseModel` from the cap minus team member prices. No new column on `Team` entity.
 - **`BudgetConstants` class** is a static class in the Domain layer, referenced by both the mapper and the service.
+- **`HasDefaultValue(3_000_000m)`** sets the DB column default so existing rows get the floor price on migration.
+- **`seed-prices.sql`** is a standalone file for updating prices in any environment without a deploy.
+- **Include chain:** Both `AddDriverToTeamAsync` and `AddConstructorToTeamAsync` load both TeamDrivers+Driver and TeamConstructors+Constructor to compute total spend accurately.
 - **Frontend disabling is a UX enhancement, not a security gate.** The backend rejects over-budget additions regardless. The frontend `disabled` prop prevents the user from attempting an obviously over-budget pick.
 - **Reuses existing `formatMillions`** utility from `web/src/lib/utils.ts` for price formatting.
 
 ---
 
-## Verification
+## Verification (after all commits)
 
-1. **Build both projects:** `npm run api:build && npm run web:build`
-2. **Run all tests:** `npm run test:all`
-3. **Manual E2E check:**
-   - Apply migration: `dotnet ef database update --project api/F1CompanionApi`
-   - Run seed script: `psql <connection_string> -f api/supabase/seed.sql`
-   - Start both servers (`npm run api:watch` + `npm run web:dev`)
-   - Navigate to My Team page — verify budget shows a real dollar amount instead of `$200k`
-   - Open driver picker — verify prices appear instead of `$--.-M`
-   - Try adding a driver that would exceed the budget — verify the item is visually disabled
-   - Try API call directly to add an over-budget player — verify 400 response with "Budget Exceeded"
+1. Apply migration: `dotnet ef database update --project api/F1CompanionApi`
+2. Run price seed: `psql <connection_string> -f api/supabase/seed-prices.sql`
+3. Start servers: `npm run api:watch` + `npm run web:dev`
+4. My Team page — budget shows a real dollar amount (not `$200k`)
+5. Driver picker — prices appear (not `$--.-M`)
+6. Add a driver that would exceed the budget — item visually disabled
+7. API call directly to add an over-budget player — 400 with "Budget Exceeded"

--- a/web/src/components/ConstructorCard/ConstructorCard.test.tsx
+++ b/web/src/components/ConstructorCard/ConstructorCard.test.tsx
@@ -128,6 +128,20 @@ describe('ConstructorCard', () => {
       expect(screen.queryByRole('button', { name: /add constructor/i })).not.toBeInTheDocument();
     });
 
+    it('displays formatted price when constructor is selected', () => {
+      const constructorWithPrice = createMockConstructor({ price: 28_300_000 });
+      render(
+        <ConstructorCard
+          constructor={constructorWithPrice}
+          onOpenPicker={vi.fn()}
+          onRemove={vi.fn()}
+          readOnly={false}
+        />,
+      );
+
+      expect(screen.getByText('$28.3M')).toBeInTheDocument();
+    });
+
     it('displays remove button with accessible label in edit mode', () => {
       render(
         <ConstructorCard

--- a/web/src/components/ConstructorCard/ConstructorCard.tsx
+++ b/web/src/components/ConstructorCard/ConstructorCard.tsx
@@ -1,4 +1,5 @@
 import type { Constructor } from '@/contracts/Role';
+import { formatMillions } from '@/lib/utils';
 import { CirclePlus, X } from 'lucide-react';
 
 import { Button } from '../ui/button';
@@ -37,7 +38,7 @@ export function ConstructorCard({
             </div>
             <div className="bg-border my-2.5 h-px" />
             <div className="text-muted-foreground flex justify-between px-1 text-xs">
-              <span>$--.-M</span>
+              <span>${formatMillions(constructor.price)}M</span>
               <span>-- pts</span>
             </div>
           </>

--- a/web/src/components/ConstructorListItem/ConstructorListItem.test.tsx
+++ b/web/src/components/ConstructorListItem/ConstructorListItem.test.tsx
@@ -11,6 +11,7 @@ describe('ConstructorListItem', () => {
     fullName: 'Mercedes-AMG Petronas F1 Team',
     abbreviation: 'MER',
     countryAbbreviation: 'DE',
+    price: 3_000_000,
   });
   const mockOnSelect = vi.fn();
 
@@ -24,7 +25,7 @@ describe('ConstructorListItem', () => {
     expect(screen.getByText('MER')).toBeInTheDocument();
     expect(screen.getByText('Mercedes')).toBeInTheDocument();
     expect(screen.getByText('DE')).toBeInTheDocument();
-    expect(screen.getByText('$--.-M')).toBeInTheDocument();
+    expect(screen.getByText('$3.0M')).toBeInTheDocument();
     expect(screen.getByText('-- pts')).toBeInTheDocument();
   });
 
@@ -35,5 +36,16 @@ describe('ConstructorListItem', () => {
     await userEvent.click(addConstructorButton);
 
     expect(mockOnSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('should dim the item and not call onSelect when disabled', async () => {
+    render(<ConstructorListItem constructor={constructor} onSelect={mockOnSelect} disabled />);
+
+    expect(screen.getByRole('listitem')).toHaveClass('opacity-40');
+
+    const addConstructorButton = screen.getByRole('button', { name: /add constructor/i });
+    await userEvent.click(addConstructorButton);
+
+    expect(mockOnSelect).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/ConstructorListItem/ConstructorListItem.tsx
+++ b/web/src/components/ConstructorListItem/ConstructorListItem.tsx
@@ -1,4 +1,5 @@
 import type { Constructor } from '@/contracts/Role';
+import { cn, formatMillions } from '@/lib/utils';
 import { CirclePlus } from 'lucide-react';
 
 import { Button } from '../ui/button';
@@ -6,11 +7,16 @@ import { Button } from '../ui/button';
 export interface ConstructorListItemProps {
   constructor: Constructor;
   onSelect: () => void;
+  disabled?: boolean;
 }
 
-export function ConstructorListItem({ constructor, onSelect }: ConstructorListItemProps) {
+export function ConstructorListItem({
+  constructor,
+  onSelect,
+  disabled = false,
+}: ConstructorListItemProps) {
   return (
-    <li className="flex items-center gap-3 py-2.5">
+    <li className={cn('flex items-center gap-3 py-2.5', disabled && 'opacity-40')}>
       <div className="bg-secondary text-secondary-foreground flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-xs font-bold tracking-wide">
         {constructor.abbreviation}
       </div>
@@ -19,12 +25,17 @@ export function ConstructorListItem({ constructor, onSelect }: ConstructorListIt
         <div className="text-muted-foreground flex items-center gap-1.5 text-xs">
           <span>{constructor.countryAbbreviation}</span>
           <span aria-hidden="true">&middot;</span>
-          <span>$--.-M</span>
+          <span>${formatMillions(constructor.price)}M</span>
           <span aria-hidden="true">&middot;</span>
           <span>-- pts</span>
         </div>
       </div>
-      <Button variant="ghost" aria-label="Add Constructor" onClick={onSelect}>
+      <Button
+        variant="ghost"
+        aria-label="Add Constructor"
+        onClick={disabled ? undefined : onSelect}
+        disabled={disabled}
+      >
         <CirclePlus />
       </Button>
     </li>

--- a/web/src/components/ConstructorPicker/ConstructorPicker.test.tsx
+++ b/web/src/components/ConstructorPicker/ConstructorPicker.test.tsx
@@ -3,7 +3,7 @@ import type { TeamConstructor } from '@/contracts/Team';
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createMockConstructorList } from '@/test-utils/mockFactories';
+import { createMockConstructor, createMockConstructorList } from '@/test-utils/mockFactories';
 import { ConstructorPicker } from './ConstructorPicker';
 
 // Mock useLineupPicker hook
@@ -59,7 +59,7 @@ describe('ConstructorPicker', () => {
 
   describe('Lineup Rendering', () => {
     it('renders 4 empty constructor slots by default', () => {
-      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} />);
+      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} remainingBudget={100_000_000} />);
 
       const addButtons = screen.getAllByRole('button', { name: /add constructor/i });
       expect(addButtons).toHaveLength(4);
@@ -78,6 +78,7 @@ describe('ConstructorPicker', () => {
           activeConstructors={mockConstructors}
           teamConstructors={teamConstructors}
           readOnly={false}
+          remainingBudget={100_000_000}
         />,
       );
 
@@ -109,6 +110,7 @@ describe('ConstructorPicker', () => {
           activeConstructors={mockConstructors}
           teamConstructors={teamConstructors}
           readOnly={false}
+          remainingBudget={100_000_000}
         />,
       );
 
@@ -130,7 +132,7 @@ describe('ConstructorPicker', () => {
     it('displays all available constructors from pool', () => {
       mockPool = mockConstructors; // All constructors available
 
-      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} />);
+      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} remainingBudget={100_000_000} />);
 
       expect(screen.getByText('McLaren')).toBeInTheDocument();
       expect(screen.getByText('Ferrari')).toBeInTheDocument();
@@ -153,6 +155,7 @@ describe('ConstructorPicker', () => {
           activeConstructors={mockConstructors}
           teamConstructors={[toTeamConstructor(mockConstructors[0], 0)]}
           readOnly={false}
+          remainingBudget={100_000_000}
         />,
       );
 
@@ -172,7 +175,7 @@ describe('ConstructorPicker', () => {
     it('does not display sheet when picker is closed', () => {
       mockSelectedPosition = null;
 
-      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} />);
+      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} remainingBudget={100_000_000} />);
 
       expect(screen.queryByText('Select Constructor')).not.toBeInTheDocument();
     });
@@ -181,7 +184,7 @@ describe('ConstructorPicker', () => {
       mockSelectedPosition = 0;
       mockIsPending = true;
 
-      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} />);
+      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} remainingBudget={100_000_000} />);
 
       // Sheet should remain open during pending operations
       expect(screen.getByText('Select Constructor')).toBeInTheDocument();
@@ -192,7 +195,7 @@ describe('ConstructorPicker', () => {
     it('displays error message above grid when error occurs', () => {
       mockError = 'Failed to add constructor. Please try again.';
 
-      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} />);
+      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} remainingBudget={100_000_000} />);
 
       const errorElement = screen.getByRole('alert');
       expect(errorElement).toHaveTextContent('Failed to add constructor. Please try again.');
@@ -202,7 +205,7 @@ describe('ConstructorPicker', () => {
       mockError = 'Failed to add constructor. Please try again.';
       mockSelectedPosition = null; // Picker closed
 
-      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} />);
+      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} remainingBudget={100_000_000} />);
 
       // Error should still be visible even when picker is closed
       const errorElement = screen.getByRole('alert');
@@ -212,7 +215,7 @@ describe('ConstructorPicker', () => {
     it('does not display error when no error exists', () => {
       mockError = null;
 
-      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} />);
+      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} remainingBudget={100_000_000} />);
 
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     });
@@ -222,7 +225,7 @@ describe('ConstructorPicker', () => {
     it('uses semantic HTML with proper roles', () => {
       mockSelectedPosition = 0;
 
-      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} />);
+      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} remainingBudget={100_000_000} />);
 
       // Sheet should have dialog role
       expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -233,7 +236,7 @@ describe('ConstructorPicker', () => {
     });
 
     it('provides descriptive button labels', async () => {
-      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} />);
+      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} remainingBudget={100_000_000} />);
 
       // Empty slot buttons should be clear
       const addButtons = screen.getAllByRole('button', { name: /add constructor/i });
@@ -248,6 +251,7 @@ describe('ConstructorPicker', () => {
           activeConstructors={mockConstructors}
           teamConstructors={[toTeamConstructor(mockConstructors[0], 0)]}
           readOnly={false}
+          remainingBudget={100_000_000}
         />,
       );
 
@@ -258,7 +262,7 @@ describe('ConstructorPicker', () => {
 
   describe('Duplicate Constructors', () => {
     it('passes maxDuplicates: 2 to useLineupPicker', () => {
-      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} />);
+      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} remainingBudget={100_000_000} />);
 
       expect(mockUseLineupPicker).toHaveBeenCalledWith(
         expect.objectContaining({ maxDuplicates: 2 }),
@@ -270,7 +274,7 @@ describe('ConstructorPicker', () => {
     it('does not render picker sheet when readOnly is true', () => {
       mockSelectedPosition = 0; // Even if picker would be "open"
 
-      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={true} />);
+      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={true} remainingBudget={100_000_000} />);
 
       // Sheet should not be rendered
       expect(screen.queryByText('Select Constructor')).not.toBeInTheDocument();
@@ -290,6 +294,7 @@ describe('ConstructorPicker', () => {
           activeConstructors={mockConstructors}
           teamConstructors={teamConstructors}
           readOnly={true}
+          remainingBudget={100_000_000}
         />,
       );
 
@@ -301,7 +306,7 @@ describe('ConstructorPicker', () => {
     it('displays errors in read-only mode', () => {
       mockError = 'Failed to load team data.';
 
-      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={true} />);
+      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={true} remainingBudget={100_000_000} />);
 
       const errorElement = screen.getByRole('alert');
       expect(errorElement).toHaveTextContent('Failed to load team data.');
@@ -310,10 +315,32 @@ describe('ConstructorPicker', () => {
     it('does not render picker sheet when readOnly is false and picker is closed', () => {
       mockSelectedPosition = null;
 
-      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} />);
+      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} remainingBudget={100_000_000} />);
 
       // Sheet should not be rendered when picker is closed
       expect(screen.queryByText('Select Constructor')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Budget Filtering', () => {
+    beforeEach(() => {
+      mockSelectedPosition = 0; // picker open
+    });
+
+    it('disables constructors that exceed remaining budget', () => {
+      mockPool = [createMockConstructor({ id: 99, price: 28_000_000 })];
+
+      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} remainingBudget={10_000_000} />);
+
+      expect(screen.getByRole('button', { name: /add constructor/i })).toBeDisabled();
+    });
+
+    it('does not disable constructors within remaining budget', () => {
+      mockPool = [createMockConstructor({ id: 98, price: 5_000_000 })];
+
+      render(<ConstructorPicker activeConstructors={mockConstructors} readOnly={false} remainingBudget={10_000_000} />);
+
+      expect(screen.getByRole('button', { name: /add constructor/i })).not.toBeDisabled();
     });
   });
 });

--- a/web/src/components/ConstructorPicker/ConstructorPicker.tsx
+++ b/web/src/components/ConstructorPicker/ConstructorPicker.tsx
@@ -21,6 +21,7 @@ interface ConstructorPickerProps {
   activeConstructors: Constructor[];
   teamConstructors?: TeamConstructor[];
   readOnly: boolean;
+  remainingBudget: number;
 }
 
 const CONSTRUCTOR_SLOTS = 4;
@@ -29,6 +30,7 @@ export function ConstructorPicker({
   activeConstructors,
   teamConstructors,
   readOnly,
+  remainingBudget,
 }: ConstructorPickerProps) {
   // build lineup with existing constructors
   const lineup = useMemo(() => {
@@ -108,6 +110,7 @@ export function ConstructorPicker({
                         handleAdd(selectedPosition, constructor);
                       }
                     }}
+                    disabled={constructor.price > remainingBudget}
                   />
                 ))}
               </ul>

--- a/web/src/components/DriverCard/DriverCard.test.tsx
+++ b/web/src/components/DriverCard/DriverCard.test.tsx
@@ -91,6 +91,20 @@ describe('DriverCard', () => {
       expect(screen.queryByRole('button', { name: /add driver/i })).not.toBeInTheDocument();
     });
 
+    it('displays formatted price when driver is selected', () => {
+      const driverWithPrice = createMockDriver({ price: 18_600_000 });
+      render(
+        <DriverCard
+          driver={driverWithPrice}
+          onOpenPicker={vi.fn()}
+          onRemove={vi.fn()}
+          readOnly={false}
+        />,
+      );
+
+      expect(screen.getByText('$18.6M')).toBeInTheDocument();
+    });
+
     it('displays remove button with accessible label in edit mode', () => {
       render(
         <DriverCard driver={driver} onOpenPicker={vi.fn()} onRemove={vi.fn()} readOnly={false} />,

--- a/web/src/components/DriverCard/DriverCard.tsx
+++ b/web/src/components/DriverCard/DriverCard.tsx
@@ -1,4 +1,5 @@
 import type { Driver } from '@/contracts/Role';
+import { formatMillions } from '@/lib/utils';
 import { CirclePlus, X } from 'lucide-react';
 
 import { Button } from '../ui/button';
@@ -30,7 +31,7 @@ export function DriverCard({ driver, onOpenPicker, onRemove, readOnly }: DriverC
             </div>
             <div className="bg-border my-2.5 h-px" />
             <div className="text-muted-foreground flex justify-between px-1 text-xs">
-              <span>$--.-M</span>
+              <span>${formatMillions(driver.price)}M</span>
               <span>-- pts</span>
             </div>
           </>

--- a/web/src/components/DriverListItem/DriverListItem.test.tsx
+++ b/web/src/components/DriverListItem/DriverListItem.test.tsx
@@ -11,6 +11,7 @@ describe('DriverListItem', () => {
     lastName: 'Sainz',
     abbreviation: 'SAI',
     countryAbbreviation: 'ESP',
+    price: 18_600_000,
   });
   const mockOnSelect = vi.fn();
 
@@ -24,16 +25,27 @@ describe('DriverListItem', () => {
     expect(screen.getByText('SAI')).toBeInTheDocument();
     expect(screen.getByText('Carlos Sainz')).toBeInTheDocument();
     expect(screen.getByText('ESP')).toBeInTheDocument();
-    expect(screen.getByText('$--.-M')).toBeInTheDocument();
+    expect(screen.getByText('$18.6M')).toBeInTheDocument();
     expect(screen.getByText('-- pts')).toBeInTheDocument();
   });
 
   it('should call onSelect when add button is clicked', async () => {
     render(<DriverListItem driver={driver} onSelect={mockOnSelect} />);
 
-    const addConstructorButton = screen.getByRole('button', { name: /add driver/i });
-    await userEvent.click(addConstructorButton);
+    const addDriverButton = screen.getByRole('button', { name: /add driver/i });
+    await userEvent.click(addDriverButton);
 
     expect(mockOnSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('should dim the item and not call onSelect when disabled', async () => {
+    render(<DriverListItem driver={driver} onSelect={mockOnSelect} disabled />);
+
+    expect(screen.getByRole('listitem')).toHaveClass('opacity-40');
+
+    const addDriverButton = screen.getByRole('button', { name: /add driver/i });
+    await userEvent.click(addDriverButton);
+
+    expect(mockOnSelect).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/DriverListItem/DriverListItem.tsx
+++ b/web/src/components/DriverListItem/DriverListItem.tsx
@@ -1,4 +1,5 @@
 import type { Driver } from '@/contracts/Role';
+import { cn, formatMillions } from '@/lib/utils';
 import { CirclePlus } from 'lucide-react';
 
 import { Button } from '../ui/button';
@@ -6,11 +7,12 @@ import { Button } from '../ui/button';
 interface DriverListItemProps {
   driver: Driver;
   onSelect: () => void;
+  disabled?: boolean;
 }
 
-export function DriverListItem({ driver, onSelect }: DriverListItemProps) {
+export function DriverListItem({ driver, onSelect, disabled = false }: DriverListItemProps) {
   return (
-    <li className="flex items-center gap-3 py-2.5">
+    <li className={cn('flex items-center gap-3 py-2.5', disabled && 'opacity-40')}>
       <div className="bg-secondary text-secondary-foreground flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-xs font-bold tracking-wide">
         {driver.abbreviation}
       </div>
@@ -21,12 +23,18 @@ export function DriverListItem({ driver, onSelect }: DriverListItemProps) {
         <div className="text-muted-foreground flex items-center gap-1.5 text-xs">
           <span>{driver.countryAbbreviation}</span>
           <span aria-hidden="true">&middot;</span>
-          <span>$--.-M</span>
+          <span>${formatMillions(driver.price)}M</span>
           <span aria-hidden="true">&middot;</span>
           <span>-- pts</span>
         </div>
       </div>
-      <Button variant="ghost" size="icon" aria-label="Add Driver" onClick={onSelect}>
+      <Button
+        variant="ghost"
+        size="icon"
+        aria-label="Add Driver"
+        onClick={disabled ? undefined : onSelect}
+        disabled={disabled}
+      >
         <CirclePlus />
       </Button>
     </li>

--- a/web/src/components/DriverPicker/DriverPicker.test.tsx
+++ b/web/src/components/DriverPicker/DriverPicker.test.tsx
@@ -3,7 +3,7 @@ import type { TeamDriver } from '@/contracts/Team';
 import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createMockDriverList } from '@/test-utils/mockFactories';
+import { createMockDriver, createMockDriverList } from '@/test-utils/mockFactories';
 import { DriverPicker } from './DriverPicker';
 
 // Mock useLineupPicker hook
@@ -56,7 +56,7 @@ describe('DriverPicker', () => {
 
   describe('Lineup Rendering', () => {
     it('renders 4 empty driver slots by default', () => {
-      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} />);
+      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} remainingBudget={100_000_000} />);
 
       const addButtons = screen.getAllByRole('button', { name: /add driver/i });
       expect(addButtons).toHaveLength(4);
@@ -71,7 +71,7 @@ describe('DriverPicker', () => {
       mockDisplayLineup = [mockDrivers[0], mockDrivers[1], null, null];
 
       render(
-        <DriverPicker activeDrivers={mockDrivers} teamDrivers={teamDrivers} readOnly={false} />,
+        <DriverPicker activeDrivers={mockDrivers} teamDrivers={teamDrivers} readOnly={false} remainingBudget={100_000_000} />,
       );
 
       expect(screen.getByText('Oscar Piastri')).toBeInTheDocument();
@@ -93,7 +93,7 @@ describe('DriverPicker', () => {
       mockDisplayLineup = [mockDrivers[0], mockDrivers[1], mockDrivers[2], mockDrivers[3]];
 
       render(
-        <DriverPicker activeDrivers={mockDrivers} teamDrivers={teamDrivers} readOnly={false} />,
+        <DriverPicker activeDrivers={mockDrivers} teamDrivers={teamDrivers} readOnly={false} remainingBudget={100_000_000} />,
       );
 
       expect(screen.getByText('Oscar Piastri')).toBeInTheDocument();
@@ -114,7 +114,7 @@ describe('DriverPicker', () => {
     it('displays all available drivers from pool', () => {
       mockPool = mockDrivers; // All drivers available
 
-      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} />);
+      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} remainingBudget={100_000_000} />);
 
       expect(screen.getByText('Oscar Piastri')).toBeInTheDocument();
       expect(screen.getByText('Lando Norris')).toBeInTheDocument();
@@ -132,6 +132,7 @@ describe('DriverPicker', () => {
           activeDrivers={mockDrivers}
           teamDrivers={[toTeamDriver(mockDrivers[0], 0)]}
           readOnly={false}
+          remainingBudget={100_000_000}
         />,
       );
 
@@ -151,7 +152,7 @@ describe('DriverPicker', () => {
     it('does not display sheet when picker is closed', () => {
       mockSelectedPosition = null;
 
-      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} />);
+      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} remainingBudget={100_000_000} />);
 
       expect(screen.queryByText('Select Driver')).not.toBeInTheDocument();
     });
@@ -160,7 +161,7 @@ describe('DriverPicker', () => {
       mockSelectedPosition = 0;
       mockIsPending = true;
 
-      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} />);
+      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} remainingBudget={100_000_000} />);
 
       // Sheet should remain open during pending operations
       expect(screen.getByText('Select Driver')).toBeInTheDocument();
@@ -172,7 +173,7 @@ describe('DriverPicker', () => {
       mockSelectedPosition = 0; // User tried to open picker
       mockIsPending = true; // Operation is pending
 
-      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} />);
+      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} remainingBudget={100_000_000} />);
 
       // Sheet should remain open during pending operations
       expect(screen.getByText('Select Driver')).toBeInTheDocument();
@@ -183,7 +184,7 @@ describe('DriverPicker', () => {
     it('displays error message above grid when error occurs', () => {
       mockError = 'Failed to add driver. Please try again.';
 
-      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} />);
+      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} remainingBudget={100_000_000} />);
 
       const errorElement = screen.getByRole('alert');
       expect(errorElement).toHaveTextContent('Failed to add driver. Please try again.');
@@ -193,7 +194,7 @@ describe('DriverPicker', () => {
       mockError = 'Failed to add driver. Please try again.';
       mockSelectedPosition = null; // Picker closed
 
-      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} />);
+      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} remainingBudget={100_000_000} />);
 
       // Error should still be visible even when picker is closed
       const errorElement = screen.getByRole('alert');
@@ -203,7 +204,7 @@ describe('DriverPicker', () => {
     it('does not display error when no error exists', () => {
       mockError = null;
 
-      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} />);
+      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} remainingBudget={100_000_000} />);
 
       expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     });
@@ -213,7 +214,7 @@ describe('DriverPicker', () => {
     it('uses semantic HTML with proper roles', () => {
       mockSelectedPosition = 0;
 
-      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} />);
+      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} remainingBudget={100_000_000} />);
 
       // Sheet should have dialog role
       expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -224,7 +225,7 @@ describe('DriverPicker', () => {
     });
 
     it('provides descriptive button labels', async () => {
-      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} />);
+      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} remainingBudget={100_000_000} />);
 
       // Empty slot buttons should be clear
       const addButtons = screen.getAllByRole('button', { name: /add driver/i });
@@ -239,6 +240,7 @@ describe('DriverPicker', () => {
           activeDrivers={mockDrivers}
           teamDrivers={[toTeamDriver(mockDrivers[0], 0)]}
           readOnly={false}
+          remainingBudget={100_000_000}
         />,
       );
 
@@ -251,7 +253,7 @@ describe('DriverPicker', () => {
     it('does not render picker sheet when readOnly is true', () => {
       mockSelectedPosition = 0; // Even if picker would be "open"
 
-      render(<DriverPicker activeDrivers={mockDrivers} readOnly={true} />);
+      render(<DriverPicker activeDrivers={mockDrivers} readOnly={true} remainingBudget={100_000_000} />);
 
       // Sheet should not be rendered
       expect(screen.queryByText('Select Driver')).not.toBeInTheDocument();
@@ -267,7 +269,7 @@ describe('DriverPicker', () => {
       mockDisplayLineup = [mockDrivers[0], mockDrivers[1], null, null];
 
       render(
-        <DriverPicker activeDrivers={mockDrivers} teamDrivers={teamDrivers} readOnly={true} />,
+        <DriverPicker activeDrivers={mockDrivers} teamDrivers={teamDrivers} readOnly={true} remainingBudget={100_000_000} />,
       );
 
       // Drivers should still be displayed
@@ -278,7 +280,7 @@ describe('DriverPicker', () => {
     it('displays errors in read-only mode', () => {
       mockError = 'Failed to load team data.';
 
-      render(<DriverPicker activeDrivers={mockDrivers} readOnly={true} />);
+      render(<DriverPicker activeDrivers={mockDrivers} readOnly={true} remainingBudget={100_000_000} />);
 
       const errorElement = screen.getByRole('alert');
       expect(errorElement).toHaveTextContent('Failed to load team data.');
@@ -287,10 +289,32 @@ describe('DriverPicker', () => {
     it('does not render picker sheet when readOnly is false and picker is closed', () => {
       mockSelectedPosition = null;
 
-      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} />);
+      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} remainingBudget={100_000_000} />);
 
       // Sheet should not be rendered when picker is closed
       expect(screen.queryByText('Select Driver')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Budget Filtering', () => {
+    beforeEach(() => {
+      mockSelectedPosition = 0; // picker open
+    });
+
+    it('disables drivers that exceed remaining budget', () => {
+      mockPool = [createMockDriver({ id: 99, price: 25_000_000 })];
+
+      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} remainingBudget={10_000_000} />);
+
+      expect(screen.getByRole('button', { name: /add driver/i })).toBeDisabled();
+    });
+
+    it('does not disable drivers within remaining budget', () => {
+      mockPool = [createMockDriver({ id: 98, price: 5_000_000 })];
+
+      render(<DriverPicker activeDrivers={mockDrivers} readOnly={false} remainingBudget={10_000_000} />);
+
+      expect(screen.getByRole('button', { name: /add driver/i })).not.toBeDisabled();
     });
   });
 });

--- a/web/src/components/DriverPicker/DriverPicker.tsx
+++ b/web/src/components/DriverPicker/DriverPicker.tsx
@@ -21,11 +21,17 @@ interface DriverPickerProps {
   activeDrivers: Driver[];
   teamDrivers?: TeamDriver[];
   readOnly: boolean;
+  remainingBudget: number;
 }
 
 const DRIVER_SLOTS = 4;
 
-export function DriverPicker({ activeDrivers, teamDrivers, readOnly }: DriverPickerProps) {
+export function DriverPicker({
+  activeDrivers,
+  teamDrivers,
+  readOnly,
+  remainingBudget,
+}: DriverPickerProps) {
   // build lineup with existing drivers
   const lineup = useMemo(() => {
     const slots: (Driver | null)[] = Array(DRIVER_SLOTS).fill(null);
@@ -104,6 +110,7 @@ export function DriverPicker({ activeDrivers, teamDrivers, readOnly }: DriverPic
                         handleAdd(selectedPosition, driver);
                       }
                     }}
+                    disabled={driver.price > remainingBudget}
                   />
                 ))}
               </ul>

--- a/web/src/components/Team/Team.test.tsx
+++ b/web/src/components/Team/Team.test.tsx
@@ -29,6 +29,7 @@ vi.mock('../DriverPicker/DriverPicker', () => ({
     activeDrivers: Driver[];
     teamDrivers?: unknown[];
     readOnly: boolean;
+    remainingBudget: number;
   }) => {
     mockDriverPicker(props);
     return (
@@ -49,6 +50,7 @@ vi.mock('../ConstructorPicker/ConstructorPicker', () => ({
     activeConstructors: Constructor[];
     teamConstructors?: unknown[];
     readOnly: boolean;
+    remainingBudget: number;
   }) => {
     mockConstructorPicker(props);
     return (

--- a/web/src/components/Team/Team.test.tsx
+++ b/web/src/components/Team/Team.test.tsx
@@ -167,6 +167,36 @@ describe('Team Component', () => {
       expect(screen.getByText('Test Team')).toBeInTheDocument();
     });
 
+    it('displays formatted remaining budget in millions', () => {
+      const team = createMockTeam({ remainingBudget: 75_400_000 });
+      render(
+        <Team
+          team={team}
+          activeDrivers={mockActiveDrivers}
+          activeConstructors={mockActiveConstructors}
+          races={mockRaces}
+          readOnly={false}
+        />,
+      );
+
+      expect(screen.getByText('$75.4M')).toBeInTheDocument();
+    });
+
+    it('displays sub-million remaining budget in thousands', () => {
+      const team = createMockTeam({ remainingBudget: 900_000 });
+      render(
+        <Team
+          team={team}
+          activeDrivers={mockActiveDrivers}
+          activeConstructors={mockActiveConstructors}
+          races={mockRaces}
+          readOnly={false}
+        />,
+      );
+
+      expect(screen.getByText('$900k')).toBeInTheDocument();
+    });
+
     it('renders with drivers tab selected by default', () => {
       render(
         <Team

--- a/web/src/components/Team/Team.tsx
+++ b/web/src/components/Team/Team.tsx
@@ -141,6 +141,7 @@ export function Team({ team, activeDrivers, activeConstructors, races, readOnly 
                 activeDrivers={activeDrivers}
                 teamDrivers={team.drivers}
                 readOnly={readOnly}
+                remainingBudget={team.remainingBudget}
               />
             </CardContent>
           </Card>
@@ -156,6 +157,7 @@ export function Team({ team, activeDrivers, activeConstructors, races, readOnly 
                 activeConstructors={activeConstructors}
                 teamConstructors={team.constructors}
                 readOnly={readOnly}
+                remainingBudget={team.remainingBudget}
               />
             </CardContent>
           </Card>

--- a/web/src/components/Team/Team.tsx
+++ b/web/src/components/Team/Team.tsx
@@ -4,6 +4,8 @@ import type { Team } from '@/contracts/Team';
 import { useLoaderData } from '@tanstack/react-router';
 import { useState } from 'react';
 
+import { formatBudget } from '@/lib/utils';
+
 import { AppContainer } from '../AppContainer/AppContainer';
 import { ConstructorPicker } from '../ConstructorPicker/ConstructorPicker';
 import { DriverPicker } from '../DriverPicker/DriverPicker';
@@ -76,7 +78,7 @@ export function Team({ team, activeDrivers, activeConstructors, races, readOnly 
             <div className="grid grid-cols-2 gap-4 sm:flex sm:flex-row sm:justify-center">
               <div className="flex flex-col items-center">
                 <p className="text-muted-foreground font-medium">Budget</p>
-                <h1 className="text-lg font-bold">$200k</h1>
+                <h1 className="text-lg font-bold">{formatBudget(team.remainingBudget)}</h1>
               </div>
               <div className="flex flex-col items-center">
                 <p className="text-muted-foreground font-medium">Trades</p>

--- a/web/src/contracts/Role.ts
+++ b/web/src/contracts/Role.ts
@@ -4,6 +4,7 @@ export interface Driver {
   lastName: string;
   abbreviation: string;
   countryAbbreviation: string;
+  price: number;
 }
 
 export interface Constructor {
@@ -12,4 +13,5 @@ export interface Constructor {
   fullName: string;
   abbreviation: string;
   countryAbbreviation: string;
+  price: number;
 }

--- a/web/src/contracts/Team.ts
+++ b/web/src/contracts/Team.ts
@@ -5,6 +5,7 @@ export interface TeamDriver {
   lastName: string;
   abbreviation: string;
   countryAbbreviation: string;
+  price: number;
 }
 
 export interface TeamConstructor {
@@ -14,6 +15,7 @@ export interface TeamConstructor {
   fullName: string;
   abbreviation: string;
   countryAbbreviation: string;
+  price: number;
 }
 
 export interface Team {
@@ -21,6 +23,7 @@ export interface Team {
   name: string;
   ownerId: number;
   ownerName: string;
+  remainingBudget: number;
   drivers: TeamDriver[];
   constructors: TeamConstructor[];
 }

--- a/web/src/lib/route-guards.test.ts
+++ b/web/src/lib/route-guards.test.ts
@@ -177,6 +177,7 @@ describe('route-guards', () => {
         name: 'Test Team',
         ownerId: 1,
         ownerName: 'Test Owner',
+        remainingBudget: 100_000_000,
         drivers: [],
         constructors: [],
       });
@@ -274,6 +275,7 @@ describe('route-guards', () => {
         name: 'Test Team',
         ownerId: 1,
         ownerName: 'Test Owner',
+        remainingBudget: 100_000_000,
         drivers: [],
         constructors: [],
       });
@@ -366,6 +368,7 @@ describe('route-guards', () => {
         name: 'Test Team',
         ownerId: 1,
         ownerName: 'Test Owner',
+        remainingBudget: 100_000_000,
         drivers: [],
         constructors: [],
       });

--- a/web/src/lib/utils.test.tsx
+++ b/web/src/lib/utils.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { cn, formatMillions } from './utils';
+import { cn, formatBudget, formatMillions } from './utils';
 
 describe('utils', () => {
   describe('cn', () => {
@@ -141,6 +141,29 @@ describe('utils', () => {
     it('should handle numbers with many decimal places in input', () => {
       expect(formatMillions(1_234_567.123456789)).toBe('1.2');
       expect(formatMillions(9_876_543.987654321)).toBe('9.9');
+    });
+  });
+
+  describe('formatBudget', () => {
+    it('formats values >= 1M with M suffix', () => {
+      expect(formatBudget(100_000_000)).toBe('$100.0M');
+      expect(formatBudget(18_600_000)).toBe('$18.6M');
+      expect(formatBudget(1_000_000)).toBe('$1.0M');
+    });
+
+    it('formats values < 1M in thousands with k suffix', () => {
+      expect(formatBudget(900_000)).toBe('$900k');
+      expect(formatBudget(500_000)).toBe('$500k');
+      expect(formatBudget(100_000)).toBe('$100k');
+    });
+
+    it('rounds thousands to nearest whole number', () => {
+      expect(formatBudget(950_500)).toBe('$951k');
+      expect(formatBudget(199_499)).toBe('$199k');
+    });
+
+    it('formats zero as $0k', () => {
+      expect(formatBudget(0)).toBe('$0k');
     });
   });
 });

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -11,3 +11,10 @@ export function formatMillions(value: number): string {
     maximumFractionDigits: 1,
   });
 }
+
+export function formatBudget(value: number): string {
+  if (value < 1_000_000) {
+    return `$${Math.round(value / 1_000)}k`;
+  }
+  return `$${formatMillions(value)}M`;
+}

--- a/web/src/test-utils/mockFactories.ts
+++ b/web/src/test-utils/mockFactories.ts
@@ -15,6 +15,7 @@ export function createMockDriver(overrides: Partial<Driver> = {}): Driver {
     lastName: 'Driver',
     abbreviation: 'TDS',
     countryAbbreviation: 'TST',
+    price: 1_000_000,
     ...overrides,
   };
 }
@@ -65,6 +66,7 @@ export function createMockConstructor(overrides: Partial<Constructor> = {}): Con
     fullName: 'Test Constructor',
     abbreviation: 'TST',
     countryAbbreviation: 'TST',
+    price: 1_000_000,
     ...overrides,
   };
 }
@@ -116,6 +118,7 @@ export function createMockTeamDriver(overrides: Partial<TeamDriver> = {}): TeamD
     lastName: 'Driver',
     abbreviation: 'TDR',
     countryAbbreviation: 'TST',
+    price: 1_000_000,
     ...overrides,
   };
 }
@@ -162,6 +165,7 @@ export function createMockTeamConstructor(
     abbreviation: 'TS',
     fullName: 'Test Constructor',
     countryAbbreviation: 'TST',
+    price: 1_000_000,
     ...overrides,
   };
 }
@@ -217,6 +221,7 @@ export function createMockTeam(overrides: Partial<Team> = {}): Team {
     name: 'Test Team',
     ownerId: 1,
     ownerName: 'Test Owner',
+    remainingBudget: 100_000_000,
     drivers: [],
     constructors: [],
     ...overrides,


### PR DESCRIPTION
## Summary

- Adds a `Price` column to `Driver` and `Constructor` entities with a `$3M` floor default
- Enforces a `$100M` budget cap in `TeamService` via `BudgetExceededException` (HTTP 400 on violation)
- Exposes `Price` on driver/constructor responses and `RemainingBudget` on team details
- Displays real prices in the driver/constructor picker list items and team cards (replacing `$--.-M` placeholders)
- Disables over-budget picks in the picker sheets
- Shows remaining budget on the Team page with smart M/k formatting (`$18.6M` for millions, `$900k` for sub-million values)

## Setup

After merging, apply the migration and seed prices:

```bash
dotnet ef database update --project api/F1CompanionApi
psql <connection_string> -f api/supabase/seed-prices.sql
```

## Test plan

- [ ] My Team page shows a real budget (not `$200k`)
- [ ] Driver/constructor picker shows prices (not `$--.-M`)
- [ ] Over-budget items are visually dimmed and the add button is disabled
- [ ] Adding a driver/constructor that exceeds the budget via direct API call returns HTTP 400 "Budget Exceeded"
- [ ] Sub-million remaining budget displays in thousands (e.g. `$900k`)
- [ ] All 333 API tests pass (`npm run api:test`)
- [ ] All 612 frontend tests pass (`npm run web:test`)