### PR TITLE
Automate EF migrations via Fly release command

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,10 @@
+**/bin/
+**/obj/
+**/.vs/
+**/.DS_Store
+
+F1CompanionApi.UnitTests/
+
+supabase/
+fly.toml
+*.md

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -80,15 +80,11 @@ _logger.LogInformation("Creating league {LeagueName} for user {UserId}", name, u
 
 **ConnectionDiagnosticsInterceptor** (`Data/ConnectionDiagnosticsInterceptor.cs`) — logs a
 warning for any DB connection that takes >1s to open. Look for `Slow DB connection` entries in
-Render logs when diagnosing connectivity issues. The log includes a connection GUID, host:port,
-and duration in ms.
+Fly logs (`fly logs -a f1fantasyapp`) when diagnosing connectivity issues. The log includes a
+connection GUID, host:port, and duration in ms.
 
 **DbContext is Scoped** — all services in a single HTTP request share the same `ApplicationDbContext`
-instance. However, when using Supabase Supavisor in **Transaction mode** (port 6543), the physical
-Postgres connection is returned to Supavisor's pool after each implicit transaction (i.e. each
-EF Core query). This means each query in a request pays a reconnection cost through Supavisor.
-If connection overhead is suspected, check Render logs for repeated `Slow DB connection` entries
-with the same connection GUID — that indicates Transaction mode re-establishment overhead.
+instance.
 
-**Production connection string** is in the `ConnectionStrings__DefaultConnection` env var on Render
+**Production connection string** is in the `ConnectionStrings__DefaultConnection` Fly secret
 (not in source). Check `ServiceExtensions.cs:AddDbContext` for how it's consumed.

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -18,6 +18,11 @@ WORKDIR "/src/F1CompanionApi"
 # Build the application
 RUN dotnet build "F1CompanionApi.csproj" -c Release -o /app/build
 
+# Build the EF migrations bundle
+FROM build AS migrate
+RUN dotnet tool install --global dotnet-ef \
+    && /root/.dotnet/tools/dotnet-ef migrations bundle --self-contained -r linux-x64 -o /app/efbundle
+
 # Publish the application
 FROM build AS publish
 RUN dotnet publish "F1CompanionApi.csproj" -c Release -o /app/publish /p:UseAppHost=false
@@ -26,6 +31,7 @@ RUN dotnet publish "F1CompanionApi.csproj" -c Release -o /app/publish /p:UseAppH
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
+COPY --from=migrate /app/efbundle ./efbundle
 
 # Set environment variables for production
 ENV ASPNETCORE_ENVIRONMENT=Production
@@ -35,4 +41,4 @@ ENV ASPNETCORE_URLS=http://+:8080
 RUN adduser --disabled-password --gecos '' appuser && chown -R appuser /app
 USER appuser
 
-ENTRYPOINT ["dotnet", "F1CompanionApi.dll"]
+CMD ["dotnet", "F1CompanionApi.dll"]

--- a/api/fly.toml
+++ b/api/fly.toml
@@ -4,6 +4,9 @@ primary_region = "iad"
 [build]
   dockerfile = "Dockerfile"
 
+[deploy]
+  release_command = "/app/efbundle"
+
 [http_service]
   internal_port = 8080
   force_https = true


### PR DESCRIPTION
## Summary

- Add EF migrations bundle build stage to Dockerfile so the bundle is built and included in the production image
- Add `release_command` to `fly.toml` to run the bundle before each deploy, ensuring migrations are applied before the new app version goes live
- Switch Dockerfile from `ENTRYPOINT` to `CMD` so Fly can run the release command independently rather than appending it as arguments to the app
- Add `.dockerignore` to reduce build context from ~68MB to ~31KB
- Update `api/CLAUDE.md` to remove stale Render references and outdated Supavisor/Transaction mode note

## Test plan

- [ ] Verify deploy succeeds and release command runs without error in Fly monitoring
- [ ] Confirm app starts and serves requests after deploy