### PR TITLE
Lineup snapshot: record team picks per race

### DIFF
--- a/api/F1CompanionApi.UnitTests/Services/TeamServiceTests.cs
+++ b/api/F1CompanionApi.UnitTests/Services/TeamServiceTests.cs
@@ -1100,6 +1100,267 @@ public class TeamServiceTests
 
     #endregion
 
+    #region Lineup Snapshot Tests
+
+    [Fact]
+    public async Task AddDriverToTeamAsync_WithUpcomingRace_CreatesLineupEntry()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        var driver = CreateTestDriver(context, "VER", "Max", "Verstappen");
+        var race = CreateTestRace(
+            context,
+            raceDate: DateTime.UtcNow.AddDays(2),
+            lockDeadline: DateTime.UtcNow.AddHours(1)
+        );
+
+        // Act
+        await service.AddDriverToTeamAsync(team.Id, driver.Id, 0, user.Id);
+
+        // Assert
+        var entry = await context.LineupEntries.FirstOrDefaultAsync();
+        Assert.NotNull(entry);
+        Assert.Equal(team.Id, entry.TeamId);
+        Assert.Equal(race.Id, entry.RaceId);
+        Assert.Equal(driver.Id, entry.EntityId);
+        Assert.Equal(LineupEntityType.Driver, entry.EntityType);
+        Assert.Equal(0, entry.SlotPosition);
+    }
+
+    [Fact]
+    public async Task AddDriverToTeamAsync_WithNoUpcomingRace_DoesNotCreateLineupEntry()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        var driver = CreateTestDriver(context, "VER", "Max", "Verstappen");
+
+        // Act
+        await service.AddDriverToTeamAsync(team.Id, driver.Id, 0, user.Id);
+
+        // Assert
+        Assert.NotNull(await context.TeamDrivers.FirstOrDefaultAsync());
+        Assert.Equal(0, await context.LineupEntries.CountAsync());
+    }
+
+    [Fact]
+    public async Task AddDriverToTeamAsync_RaceHasNoLockDeadline_CreatesLineupEntry()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        var driver = CreateTestDriver(context, "VER", "Max", "Verstappen");
+        var race = CreateTestRace(
+            context,
+            raceDate: DateTime.UtcNow.AddDays(2),
+            lockDeadline: null
+        );
+
+        // Act
+        await service.AddDriverToTeamAsync(team.Id, driver.Id, 0, user.Id);
+
+        // Assert
+        var entry = await context.LineupEntries.FirstOrDefaultAsync();
+        Assert.NotNull(entry);
+        Assert.Equal(race.Id, entry.RaceId);
+        Assert.Equal(LineupEntityType.Driver, entry.EntityType);
+    }
+
+    [Fact]
+    public async Task RemoveDriverFromTeamAsync_WithUpcomingRace_DeletesLineupEntry()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        var driver = CreateTestDriver(context, "VER", "Max", "Verstappen");
+        CreateTestRace(
+            context,
+            raceDate: DateTime.UtcNow.AddDays(2),
+            lockDeadline: DateTime.UtcNow.AddHours(1)
+        );
+
+        await service.AddDriverToTeamAsync(team.Id, driver.Id, 0, user.Id);
+
+        // Act
+        await service.RemoveDriverFromTeamAsync(team.Id, 0, user.Id);
+
+        // Assert
+        Assert.Null(await context.LineupEntries.FirstOrDefaultAsync());
+    }
+
+    [Fact]
+    public async Task RemoveDriverFromTeamAsync_NoSnapshotExists_StillRemovesDriver()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        var driver = CreateTestDriver(context, "VER", "Max", "Verstappen");
+        CreateTestRace(
+            context,
+            raceDate: DateTime.UtcNow.AddDays(2),
+            lockDeadline: DateTime.UtcNow.AddHours(1)
+        );
+
+        // Add driver directly — no snapshot written
+        context.TeamDrivers.Add(
+            new TeamDriver
+            {
+                TeamId = team.Id,
+                DriverId = driver.Id,
+                SlotPosition = 0,
+                CreatedBy = user.Id,
+                CreatedAt = DateTime.UtcNow,
+            }
+        );
+        await context.SaveChangesAsync();
+
+        // Act — should not throw even though no lineup entry exists
+        await service.RemoveDriverFromTeamAsync(team.Id, 0, user.Id);
+
+        // Assert
+        Assert.Null(await context.TeamDrivers.FirstOrDefaultAsync());
+        Assert.Equal(0, await context.LineupEntries.CountAsync());
+    }
+
+    [Fact]
+    public async Task AddConstructorToTeamAsync_WithUpcomingRace_CreatesLineupEntry()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        var constructor = CreateTestConstructor(context, "Red Bull Racing");
+        var race = CreateTestRace(
+            context,
+            raceDate: DateTime.UtcNow.AddDays(2),
+            lockDeadline: DateTime.UtcNow.AddHours(1)
+        );
+
+        // Act
+        await service.AddConstructorToTeamAsync(team.Id, constructor.Id, 0, user.Id);
+
+        // Assert
+        var entry = await context.LineupEntries.FirstOrDefaultAsync();
+        Assert.NotNull(entry);
+        Assert.Equal(team.Id, entry.TeamId);
+        Assert.Equal(race.Id, entry.RaceId);
+        Assert.Equal(constructor.Id, entry.EntityId);
+        Assert.Equal(LineupEntityType.Constructor, entry.EntityType);
+        Assert.Equal(0, entry.SlotPosition);
+    }
+
+    [Fact]
+    public async Task AddConstructorToTeamAsync_WithNoUpcomingRace_DoesNotCreateLineupEntry()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        var constructor = CreateTestConstructor(context, "Red Bull Racing");
+
+        // Act
+        await service.AddConstructorToTeamAsync(team.Id, constructor.Id, 0, user.Id);
+
+        // Assert
+        Assert.NotNull(await context.TeamConstructors.FirstOrDefaultAsync());
+        Assert.Equal(0, await context.LineupEntries.CountAsync());
+    }
+
+    [Fact]
+    public async Task RemoveConstructorFromTeamAsync_WithUpcomingRace_DeletesLineupEntry()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        var constructor = CreateTestConstructor(context, "Red Bull Racing");
+        CreateTestRace(
+            context,
+            raceDate: DateTime.UtcNow.AddDays(2),
+            lockDeadline: DateTime.UtcNow.AddHours(1)
+        );
+
+        await service.AddConstructorToTeamAsync(team.Id, constructor.Id, 0, user.Id);
+
+        // Act
+        await service.RemoveConstructorFromTeamAsync(team.Id, 0, user.Id);
+
+        // Assert
+        Assert.Null(await context.LineupEntries.FirstOrDefaultAsync());
+    }
+
+    [Fact]
+    public async Task AddConstructorToTeamAsync_SameConstructorTwice_CreatesTwoLineupEntries()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        var constructor = CreateTestConstructor(context, "Red Bull Racing");
+        CreateTestRace(
+            context,
+            raceDate: DateTime.UtcNow.AddDays(2),
+            lockDeadline: DateTime.UtcNow.AddHours(1)
+        );
+
+        // Act
+        await service.AddConstructorToTeamAsync(team.Id, constructor.Id, 0, user.Id);
+        await service.AddConstructorToTeamAsync(team.Id, constructor.Id, 1, user.Id);
+
+        // Assert
+        Assert.Equal(2, await context.LineupEntries.CountAsync());
+    }
+
+    [Fact]
+    public async Task AddDriverToTeamAsync_AtomicSave_TeamDriverAndLineupEntryBothPersist()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        var driver = CreateTestDriver(context, "VER", "Max", "Verstappen");
+        CreateTestRace(
+            context,
+            raceDate: DateTime.UtcNow.AddDays(2),
+            lockDeadline: DateTime.UtcNow.AddHours(1)
+        );
+
+        // Act
+        await service.AddDriverToTeamAsync(team.Id, driver.Id, 0, user.Id);
+
+        // Assert
+        Assert.Equal(1, await context.TeamDrivers.CountAsync());
+        Assert.Equal(1, await context.LineupEntries.CountAsync());
+    }
+
+    #endregion
+
     #region Helper Methods
 
     private UserProfile CreateTestUser(ApplicationDbContext context, string email = "user@test.com")

--- a/api/F1CompanionApi/Data/ApplicationDbContext.cs
+++ b/api/F1CompanionApi/Data/ApplicationDbContext.cs
@@ -22,6 +22,7 @@ public class ApplicationDbContext : DbContext
     public DbSet<Team> Teams => Set<Team>();
     public DbSet<TeamDriver> TeamDrivers => Set<TeamDriver>();
     public DbSet<TeamConstructor> TeamConstructors => Set<TeamConstructor>();
+    public DbSet<LineupEntry> LineupEntries => Set<LineupEntry>();
     public DbSet<UserProfile> UserProfiles => Set<UserProfile>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -178,6 +179,21 @@ public class ApplicationDbContext : DbContext
                 .WithOne(e => e.Profile)
                 .HasForeignKey<UserProfile>(e => e.AccountId)
                 .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<LineupEntry>(entity =>
+        {
+            entity
+                .HasOne(le => le.Team)
+                .WithMany()
+                .HasForeignKey(le => le.TeamId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity
+                .HasOne(le => le.Race)
+                .WithMany()
+                .HasForeignKey(le => le.RaceId)
+                .OnDelete(DeleteBehavior.Restrict);
         });
 
         // Configure audit trail FK for user-owned entities only

--- a/api/F1CompanionApi/Data/Entities/LineupEntityType.cs
+++ b/api/F1CompanionApi/Data/Entities/LineupEntityType.cs
@@ -1,0 +1,7 @@
+namespace F1CompanionApi.Data.Entities;
+
+public enum LineupEntityType
+{
+    Driver = 0,
+    Constructor = 1,
+}

--- a/api/F1CompanionApi/Data/Entities/LineupEntry.cs
+++ b/api/F1CompanionApi/Data/Entities/LineupEntry.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace F1CompanionApi.Data.Entities;
+
+/// <summary>
+/// Records a single driver or constructor selection on a fantasy team for a specific race.
+/// Written on every add (insert) and deleted on every remove. Always reflects the team's
+/// current pre-lock lineup for the upcoming race. Used as the scoring engine input.
+/// </summary>
+[Index(nameof(TeamId), nameof(RaceId), nameof(EntityType), nameof(SlotPosition), IsUnique = true)]
+public class LineupEntry
+{
+    public int Id { get; set; }
+    public int TeamId { get; set; }
+    public int RaceId { get; set; }
+    public int EntityId { get; set; }
+    public LineupEntityType EntityType { get; set; }
+    public int SlotPosition { get; set; }
+    public DateTime CreatedAt { get; set; }
+
+    public Team Team { get; set; } = null!;
+    public Race Race { get; set; } = null!;
+}

--- a/api/F1CompanionApi/Data/Migrations/20260225164608_AddLineupEntries.Designer.cs
+++ b/api/F1CompanionApi/Data/Migrations/20260225164608_AddLineupEntries.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using F1CompanionApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace F1CompanionApi.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260225164608_AddLineupEntries")]
+    partial class AddLineupEntries
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/F1CompanionApi/Data/Migrations/20260225164608_AddLineupEntries.cs
+++ b/api/F1CompanionApi/Data/Migrations/20260225164608_AddLineupEntries.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace F1CompanionApi.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLineupEntries : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "LineupEntries",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    TeamId = table.Column<int>(type: "integer", nullable: false),
+                    RaceId = table.Column<int>(type: "integer", nullable: false),
+                    EntityId = table.Column<int>(type: "integer", nullable: false),
+                    EntityType = table.Column<int>(type: "integer", nullable: false),
+                    SlotPosition = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LineupEntries", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_LineupEntries_Races_RaceId",
+                        column: x => x.RaceId,
+                        principalTable: "Races",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_LineupEntries_Teams_TeamId",
+                        column: x => x.TeamId,
+                        principalTable: "Teams",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LineupEntries_RaceId",
+                table: "LineupEntries",
+                column: "RaceId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LineupEntries_TeamId_RaceId_EntityType_SlotPosition",
+                table: "LineupEntries",
+                columns: new[] { "TeamId", "RaceId", "EntityType", "SlotPosition" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LineupEntries");
+        }
+    }
+}

--- a/api/F1CompanionApi/Domain/Services/TeamService.cs
+++ b/api/F1CompanionApi/Domain/Services/TeamService.cs
@@ -105,7 +105,7 @@ public class TeamService : ITeamService
             slotPosition
         );
 
-        await ThrowIfRosterLockedAsync();
+        var currentRace = await GetCurrentRaceOrThrowIfLockedAsync();
 
         // Validate team ownership
         var team = await _dbContext
@@ -195,6 +195,22 @@ public class TeamService : ITeamService
         };
 
         _dbContext.TeamDrivers.Add(teamDriver);
+
+        if (currentRace is not null)
+        {
+            _dbContext.LineupEntries.Add(
+                new LineupEntry
+                {
+                    TeamId = teamId,
+                    RaceId = currentRace.Id,
+                    EntityId = driverId,
+                    EntityType = LineupEntityType.Driver,
+                    SlotPosition = slotPosition,
+                    CreatedAt = DateTime.UtcNow,
+                }
+            );
+        }
+
         await _dbContext.SaveChangesAsync();
 
         _logger.LogInformation(
@@ -213,7 +229,7 @@ public class TeamService : ITeamService
             slotPosition
         );
 
-        await ThrowIfRosterLockedAsync();
+        var currentRace = await GetCurrentRaceOrThrowIfLockedAsync();
 
         // Validate team ownership
         var team = await _dbContext.Teams.FirstOrDefaultAsync(t => t.Id == teamId);
@@ -250,6 +266,20 @@ public class TeamService : ITeamService
         }
 
         _dbContext.TeamDrivers.Remove(teamDriver);
+
+        if (currentRace is not null)
+        {
+            var entry = await _dbContext.LineupEntries.FirstOrDefaultAsync(le =>
+                le.TeamId == teamId
+                && le.RaceId == currentRace.Id
+                && le.EntityId == teamDriver.DriverId
+                && le.EntityType == LineupEntityType.Driver
+            );
+
+            if (entry is not null)
+                _dbContext.LineupEntries.Remove(entry);
+        }
+
         await _dbContext.SaveChangesAsync();
 
         _logger.LogInformation(
@@ -273,7 +303,7 @@ public class TeamService : ITeamService
             slotPosition
         );
 
-        await ThrowIfRosterLockedAsync();
+        var currentRace = await GetCurrentRaceOrThrowIfLockedAsync();
 
         // Validate team ownership
         var team = await _dbContext
@@ -371,6 +401,22 @@ public class TeamService : ITeamService
         };
 
         _dbContext.TeamConstructors.Add(teamConstructor);
+
+        if (currentRace is not null)
+        {
+            _dbContext.LineupEntries.Add(
+                new LineupEntry
+                {
+                    TeamId = teamId,
+                    RaceId = currentRace.Id,
+                    EntityId = constructorId,
+                    EntityType = LineupEntityType.Constructor,
+                    SlotPosition = slotPosition,
+                    CreatedAt = DateTime.UtcNow,
+                }
+            );
+        }
+
         await _dbContext.SaveChangesAsync();
 
         _logger.LogInformation(
@@ -389,7 +435,7 @@ public class TeamService : ITeamService
             slotPosition
         );
 
-        await ThrowIfRosterLockedAsync();
+        var currentRace = await GetCurrentRaceOrThrowIfLockedAsync();
 
         // Validate team ownership
         var team = await _dbContext.Teams.FirstOrDefaultAsync(t => t.Id == teamId);
@@ -428,6 +474,20 @@ public class TeamService : ITeamService
         }
 
         _dbContext.TeamConstructors.Remove(teamConstructor);
+
+        if (currentRace is not null)
+        {
+            var entry = await _dbContext.LineupEntries.FirstOrDefaultAsync(le =>
+                le.TeamId == teamId
+                && le.RaceId == currentRace.Id
+                && le.EntityId == teamConstructor.ConstructorId
+                && le.EntityType == LineupEntityType.Constructor
+            );
+
+            if (entry is not null)
+                _dbContext.LineupEntries.Remove(entry);
+        }
+
         await _dbContext.SaveChangesAsync();
 
         _logger.LogInformation(
@@ -437,7 +497,7 @@ public class TeamService : ITeamService
         );
     }
 
-    private async Task ThrowIfRosterLockedAsync()
+    private async Task<Race?> GetCurrentRaceOrThrowIfLockedAsync()
     {
         var now = DateTime.UtcNow;
         var currentRace = await _dbContext
@@ -447,5 +507,7 @@ public class TeamService : ITeamService
 
         if (currentRace?.LockDeadline is not null && now >= currentRace.LockDeadline)
             throw new RosterLockedException(currentRace.Name, currentRace.LockDeadline.Value);
+
+        return currentRace;
     }
 }

--- a/docs/plans/44-lineup-snapshots.md
+++ b/docs/plans/44-lineup-snapshots.md
@@ -1,0 +1,259 @@
+# Lineup Snapshots — Implementation Plan (Issue #44)
+
+## Context
+
+Fantasy teams need a per-race record of their lineup at lock time to support scoring and historical views. The live `TeamDriver`/`TeamConstructor` tables are mutable; they cannot serve as a scoring input since changes after the snapshot are valid pre-lock edits.
+
+The solution (Option A from research) is a snapshot table written on every add/remove operation — analogous to how FPL stores picks per gameweek. The roster lock already enforced by `ThrowIfRosterLockedAsync` prevents post-lock writes, so no separate freeze step is needed.
+
+**Approach:** Individual rows per player per team per race. Write (insert) on add, hard-delete on remove. The snapshot always reflects the current team state for the upcoming race.
+
+---
+
+## Schema
+
+> **Parent `Lineups` table considered and deferred.** A parent table would only add value if lineup-level computed fields (e.g., `transfers_used`, `transfer_penalty`) need to be cached. The transfer comparison query operates on individual entry rows regardless of schema (`EXCEPT` set difference on `entity_id + entity_type` filtered by `team_id + race_id`). A parent table can be introduced as an additive migration when the transfer system is built.
+
+```
+lineup_entries
+  id            int PK (serial)
+  team_id       int FK → teams (cascade delete)
+  race_id       int FK → races (restrict delete)
+  entity_id     int    -- driver or constructor id (no FK; polymorphic)
+  entity_type   int    -- 0=Driver, 1=Constructor (C# enum)
+  slot_position int
+  created_at    timestamptz
+  UNIQUE (team_id, race_id, entity_type, slot_position)
+```
+
+**Why slot-based unique key (not entity-based):** The domain allows the same constructor twice on one team. `UNIQUE (team_id, race_id, entity_id, entity_type)` would block this. The slot-based key correctly enforces "one entry per slot per type per team per race."
+
+**Why NOT extend `BaseEntity`:** `BaseEntity` brings `UpdatedAt`, `DeletedAt`, and `IsDeleted` — none of which apply to lineup entries. `IsDeleted` implies soft-delete, but entries are hard-deleted when a player is dropped (always `false`, actively misleading). `UpdatedAt` implies mutability, but entries are write-once per slot. Defining `Id` and `CreatedAt` directly on the entity is more honest about the lifecycle and avoids dead schema columns.
+
+---
+
+## Step 0 — Setup
+
+1. **Write this plan to the repo** as `docs/plans/44-lineup-snapshots.md` (canonical reference for implementation)
+2. **Create a feature branch** from `main`: `feat/lineup-snapshots`
+
+All implementation work happens on that branch. Reference `docs/plans/44-lineup-snapshots.md` during implementation — not this file.
+
+---
+
+## Critical Files
+
+| File | Change |
+|------|--------|
+| `api/F1CompanionApi/Data/Entities/LineupEntityType.cs` | **NEW** — enum |
+| `api/F1CompanionApi/Data/Entities/LineupEntry.cs` | **NEW** — entity |
+| `api/F1CompanionApi/Data/ApplicationDbContext.cs` | Add `DbSet` + FK config in `OnModelCreating` |
+| `api/F1CompanionApi/Data/Migrations/<ts>_AddLineupEntries.cs` | **NEW** — generated migration |
+| `api/F1CompanionApi/Domain/Services/TeamService.cs` | Rename lock method + add snapshot sync |
+| `api/F1CompanionApi.UnitTests/Services/TeamServiceTests.cs` | New snapshot test region |
+
+---
+
+## Commit 1 — Entity, Enum, DbContext, Migration
+
+### `LineupEntityType.cs`
+
+```csharp
+namespace F1CompanionApi.Data.Entities;
+
+public enum LineupEntityType
+{
+    Driver = 0,
+    Constructor = 1,
+}
+```
+
+### `LineupEntry.cs`
+
+```csharp
+using Microsoft.EntityFrameworkCore;
+
+namespace F1CompanionApi.Data.Entities;
+
+/// <summary>
+/// Records a single driver or constructor selection on a fantasy team for a specific race.
+/// Written on every add (insert) and deleted on every remove. Always reflects the team's
+/// current pre-lock lineup for the upcoming race. Used as the scoring engine input.
+/// </summary>
+[Index(nameof(TeamId), nameof(RaceId), nameof(EntityType), nameof(SlotPosition), IsUnique = true)]
+public class LineupEntry
+{
+    public int Id { get; set; }
+    public int TeamId { get; set; }
+    public int RaceId { get; set; }
+    public int EntityId { get; set; }
+    public LineupEntityType EntityType { get; set; }
+    public int SlotPosition { get; set; }
+    public DateTime CreatedAt { get; set; }
+
+    public Team Team { get; set; } = null!;
+    public Race Race { get; set; } = null!;
+}
+```
+
+### `ApplicationDbContext.cs` changes
+
+Add to the DbSet block:
+```csharp
+public DbSet<LineupEntry> LineupEntries => Set<LineupEntry>();
+```
+
+Add to `OnModelCreating`:
+```csharp
+modelBuilder.Entity<LineupEntry>(entity =>
+{
+    entity
+        .HasOne(le => le.Team)
+        .WithMany()
+        .HasForeignKey(le => le.TeamId)
+        .OnDelete(DeleteBehavior.Cascade);
+
+    entity
+        .HasOne(le => le.Race)
+        .WithMany()
+        .HasForeignKey(le => le.RaceId)
+        .OnDelete(DeleteBehavior.Restrict);
+});
+```
+
+Do NOT add to `ConfigureAuditTrailForeignKeys` — `LineupEntry` has no base class and is not a `UserOwnedEntity`.
+
+### Migration
+
+```bash
+dotnet ef migrations add AddLineupEntries --project F1CompanionApi
+```
+
+Review the generated migration for correct column types before committing.
+
+---
+
+## Commit 2 — TeamService Changes + Tests
+
+### Service: Refactor lock check method
+
+Rename `ThrowIfRosterLockedAsync` → `GetCurrentRaceOrThrowIfLockedAsync`, return `Race?`:
+
+```csharp
+private async Task<Race?> GetCurrentRaceOrThrowIfLockedAsync()
+{
+    var now = DateTime.UtcNow;
+    var currentRace = await _dbContext
+        .Races.Where(r => r.RaceDate >= now)
+        .OrderBy(r => r.RaceDate)
+        .FirstOrDefaultAsync();
+
+    if (currentRace?.LockDeadline is not null && now >= currentRace.LockDeadline)
+        throw new RosterLockedException(currentRace.Name, currentRace.LockDeadline.Value);
+
+    return currentRace;
+}
+```
+
+Update all 4 call sites from `await ThrowIfRosterLockedAsync();` to:
+```csharp
+var currentRace = await GetCurrentRaceOrThrowIfLockedAsync();
+```
+
+### Service: Add snapshot sync (after existing validation, before `SaveChangesAsync`)
+
+**AddDriverToTeamAsync** — insert after `_dbContext.TeamDrivers.Add(teamDriver)`:
+```csharp
+if (currentRace is not null)
+{
+    _dbContext.LineupEntries.Add(new LineupEntry
+    {
+        TeamId = teamId,
+        RaceId = currentRace.Id,
+        EntityId = driverId,
+        EntityType = LineupEntityType.Driver,
+        SlotPosition = slotPosition,
+        CreatedAt = DateTime.UtcNow,
+    });
+}
+await _dbContext.SaveChangesAsync();  // single save — atomic
+```
+
+**RemoveDriverFromTeamAsync** — delete after `_dbContext.TeamDrivers.Remove(teamDriver)`:
+```csharp
+if (currentRace is not null)
+{
+    var entry = await _dbContext.LineupEntries.FirstOrDefaultAsync(le =>
+        le.TeamId == teamId &&
+        le.RaceId == currentRace.Id &&
+        le.EntityId == teamDriver.DriverId &&
+        le.EntityType == LineupEntityType.Driver);
+
+    if (entry is not null)
+        _dbContext.LineupEntries.Remove(entry);
+}
+await _dbContext.SaveChangesAsync();
+```
+
+Mirror these changes for `AddConstructorToTeamAsync` (EntityType.Constructor) and `RemoveConstructorFromTeamAsync`.
+
+**Why a single `SaveChangesAsync`:** Keeps the team pick and snapshot atomic — either both land or neither does.
+
+**Why null guard on `entry` in remove:** A snapshot row may not exist (e.g., data seeded before this feature). Removing the team pick still succeeds.
+
+---
+
+### Tests: New region in `TeamServiceTests.cs`
+
+Add `#region Lineup Snapshot Tests` after the existing `RemoveConstructorFromTeamAsync Tests` region.
+
+#### Test cases
+
+| Test name | What it verifies |
+|-----------|-----------------|
+| `AddDriverToTeamAsync_WithUpcomingRace_CreatesLineupEntry` | Entry has correct TeamId, RaceId, EntityId, EntityType.Driver, SlotPosition |
+| `AddDriverToTeamAsync_WithNoUpcomingRace_DoesNotCreateLineupEntry` | No race seeded → driver added, LineupEntries count == 0 |
+| `AddDriverToTeamAsync_RaceHasNoLockDeadline_CreatesLineupEntry` | Null LockDeadline still produces a snapshot |
+| `RemoveDriverFromTeamAsync_WithUpcomingRace_DeletesLineupEntry` | Add then remove → entry is null |
+| `RemoveDriverFromTeamAsync_NoSnapshotExists_StillRemovesDriver` | Driver added directly to context (no snapshot) → remove succeeds, no throw |
+| `AddConstructorToTeamAsync_WithUpcomingRace_CreatesLineupEntry` | EntityType.Constructor, correct EntityId/SlotPosition |
+| `AddConstructorToTeamAsync_WithNoUpcomingRace_DoesNotCreateLineupEntry` | No race → constructor added, LineupEntries count == 0 |
+| `RemoveConstructorFromTeamAsync_WithUpcomingRace_DeletesLineupEntry` | Add then remove → entry is null |
+| `AddConstructorToTeamAsync_SameConstructorTwice_CreatesTwoLineupEntries` | Same constructor in slot 0 and slot 1 → 2 entries, unique constraint not violated |
+| `AddDriverToTeamAsync_AtomicSave_TeamDriverAndLineupEntryBothPersist` | After add: TeamDrivers.Count == 1, LineupEntries.Count == 1 |
+
+**Existing tests that implicitly cover new behavior:** `AddDriverToTeamAsync_ValidRequest_AddsDriverToTeam` has no race seeded — after the change, `currentRace` is null, snapshot is skipped, driver is still added. Test passes unchanged, covering the null-race path.
+
+---
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| No upcoming race in DB | `GetCurrentRaceOrThrowIfLockedAsync` returns null; snapshot skipped; team pick saved |
+| Race exists, no `LockDeadline` | Race returned; snapshot written |
+| Race locked | `RosterLockedException` thrown; no snapshot, no team pick change |
+| Remove with no existing snapshot row | Null guard skips `Remove`; team pick removed normally |
+| Same constructor added to slot 0 and slot 1 | Two distinct `LineupEntry` rows; unique key `(team_id, race_id, entity_type, slot_position)` is not violated |
+
+---
+
+## Verification
+
+```bash
+# Build
+dotnet build F1CompanionApi/F1CompanionApi.csproj
+
+# Run all tests
+dotnet test F1CompanionApi.UnitTests/F1CompanionApi.UnitTests.csproj
+
+# Apply migration to local DB
+dotnet ef database update --project F1CompanionApi
+
+# Manual smoke test
+# 1. Add a driver via POST /me/team/drivers
+# 2. Query DB: SELECT * FROM lineup_entries WHERE team_id = <id>;
+#    → Should see 1 row with correct race_id, entity_id, entity_type=0, slot_position
+# 3. Remove the driver via DELETE /me/team/drivers/{slot}
+# 4. Query DB again → row should be gone
+```

--- a/web/src/components/Team/Team.tsx
+++ b/web/src/components/Team/Team.tsx
@@ -115,7 +115,7 @@ export function Team({ team, activeDrivers, activeConstructors, races, readOnly 
           <CardContent>
             <div className="grid grid-cols-2 gap-4 sm:flex sm:flex-row sm:justify-center">
               <div className="flex flex-col items-center">
-                <p className="text-muted-foreground font-medium">Budget</p>
+                <p className="text-muted-foreground font-medium">Remaining</p>
                 <h1 className="text-lg font-bold">{formatBudget(team.remainingBudget)}</h1>
               </div>
               <div className="flex flex-col items-center">


### PR DESCRIPTION
Closes #44

## Summary

- Introduces `LineupEntry` entity and `LineupEntityType` enum to record per-race team picks
- Adds `LineupEntries` table via EF Core migration with a slot-based unique constraint `(team_id, race_id, entity_type, slot_position)` — allows same constructor in two slots while preventing duplicate slot entries
- Refactors `ThrowIfRosterLockedAsync` → `GetCurrentRaceOrThrowIfLockedAsync` returning `Race?` so the current race can be reused for snapshot writes
- On every add/remove, a `LineupEntry` row is inserted or deleted atomically with the team pick in a single `SaveChangesAsync` call
- Snapshot is skipped when no upcoming race exists (null guard); scoring and historical views will query this table

## Test plan

- [ ] 10 new unit tests covering driver/constructor add/remove snapshot behavior, null-race path, same-constructor-twice, and atomicity
- [ ] All 349 API tests pass
- [ ] All 618 web tests pass
- [ ] Migration reviewed — correct column types, unique index, correct FK delete behaviors (Cascade on Team, Restrict on Race)
- [ ] Manual smoke test: add a driver → verify `lineup_entries` row; remove driver → verify row deleted