### PR TITLE
Captain Selection (#47)

### DIFF
--- a/api/F1CompanionApi.UnitTests/Api/Endpoints/MeEndpointsTests.cs
+++ b/api/F1CompanionApi.UnitTests/Api/Endpoints/MeEndpointsTests.cs
@@ -869,6 +869,77 @@ public class MeEndpointsTests
         Assert.Equal("Constructor slot is empty", badRequestResult.Value);
     }
 
+    [Fact]
+    public async Task SetCaptainAsync_Success_ReturnsNoContent()
+    {
+        // Arrange
+        var user = new UserProfileResponse
+        {
+            Id = 1,
+            Email = "test@test.com",
+            CreatedAt = DateTime.UtcNow,
+        };
+        var team = new TeamDetailsResponse
+        {
+            Id = 10,
+            Name = "Team",
+            OwnerId = 1,
+            OwnerName = "User",
+            Drivers = new List<TeamDriverResponse>(),
+            Constructors = new List<TeamConstructorResponse>(),
+        };
+        var request = new SetCaptainRequest { DriverId = 5 };
+
+        _mockUserProfileService
+            .Setup(x => x.GetRequiredCurrentUserProfileAsync())
+            .ReturnsAsync(user);
+
+        _mockTeamService.Setup(x => x.GetUserTeamAsync(user.Id)).ReturnsAsync(team);
+
+        _mockTeamService
+            .Setup(x => x.SetCaptainAsync(team.Id, request.DriverId, user.Id))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await InvokeSetCaptainAsync(request);
+
+        // Assert
+        Assert.IsType<NoContent>(result);
+        _mockTeamService.Verify(
+            x => x.SetCaptainAsync(team.Id, request.DriverId, user.Id),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task SetCaptainAsync_UserHasNoTeam_ReturnsNotFound()
+    {
+        // Arrange
+        var user = new UserProfileResponse
+        {
+            Id = 1,
+            Email = "test@test.com",
+            CreatedAt = DateTime.UtcNow,
+        };
+        var request = new SetCaptainRequest { DriverId = 5 };
+
+        _mockUserProfileService
+            .Setup(x => x.GetRequiredCurrentUserProfileAsync())
+            .ReturnsAsync(user);
+
+        _mockTeamService
+            .Setup(x => x.GetUserTeamAsync(user.Id))
+            .ReturnsAsync((TeamDetailsResponse?)null);
+
+        // Act
+        var result = await InvokeSetCaptainAsync(request);
+
+        // Assert
+        Assert.IsType<ProblemHttpResult>(result);
+        var problemResult = (ProblemHttpResult)result;
+        Assert.Equal(StatusCodes.Status404NotFound, problemResult.StatusCode);
+    }
+
     // Helper methods to invoke private endpoint methods via reflection
     private async Task<IResult> InvokeRegisterUserAsync(MeEndpoints.RegisterUserRequest request)
     {
@@ -1062,6 +1133,29 @@ public class MeEndpointsTests
                     new object[]
                     {
                         slotPosition,
+                        _mockTeamService.Object,
+                        _mockUserProfileService.Object,
+                        _mockLogger.Object,
+                    }
+                )!;
+
+        return await task;
+    }
+
+    private async Task<IResult> InvokeSetCaptainAsync(SetCaptainRequest request)
+    {
+        var method = typeof(MeEndpoints).GetMethod(
+            "SetCaptainAsync",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static
+        );
+
+        var task =
+            (Task<IResult>)
+                method!.Invoke(
+                    null,
+                    new object[]
+                    {
+                        request,
                         _mockTeamService.Object,
                         _mockUserProfileService.Object,
                         _mockLogger.Object,

--- a/api/F1CompanionApi.UnitTests/Services/TeamServiceTests.cs
+++ b/api/F1CompanionApi.UnitTests/Services/TeamServiceTests.cs
@@ -1361,6 +1361,216 @@ public class TeamServiceTests
 
     #endregion
 
+    #region SetCaptainAsync Tests
+
+    [Fact]
+    public async Task SetCaptainAsync_ValidDriver_SetsCaptainFlag()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        var driver = CreateTestDriver(context, "VER", "Max", "Verstappen");
+        var race = CreateTestRace(
+            context,
+            raceDate: DateTime.UtcNow.AddDays(2),
+            lockDeadline: DateTime.UtcNow.AddHours(1)
+        );
+        await service.AddDriverToTeamAsync(team.Id, driver.Id, 0, user.Id);
+
+        // Act
+        await service.SetCaptainAsync(team.Id, driver.Id, user.Id);
+
+        // Assert
+        var entry = await context.LineupEntries.FirstOrDefaultAsync(le =>
+            le.TeamId == team.Id && le.RaceId == race.Id && le.EntityId == driver.Id
+        );
+        Assert.NotNull(entry);
+        Assert.True(entry.IsCaptain);
+    }
+
+    [Fact]
+    public async Task SetCaptainAsync_ExistingCaptain_ClearsExistingAndSetsNew()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        var driver1 = CreateTestDriver(context, "VER", "Max", "Verstappen");
+        var driver2 = CreateTestDriver(context, "NOR", "Lando", "Norris");
+        var race = CreateTestRace(
+            context,
+            raceDate: DateTime.UtcNow.AddDays(2),
+            lockDeadline: DateTime.UtcNow.AddHours(1)
+        );
+        await service.AddDriverToTeamAsync(team.Id, driver1.Id, 0, user.Id);
+        await service.AddDriverToTeamAsync(team.Id, driver2.Id, 1, user.Id);
+        await service.SetCaptainAsync(team.Id, driver1.Id, user.Id);
+
+        // Act
+        await service.SetCaptainAsync(team.Id, driver2.Id, user.Id);
+
+        // Assert
+        var entry1 = await context.LineupEntries.FirstOrDefaultAsync(le =>
+            le.TeamId == team.Id && le.RaceId == race.Id && le.EntityId == driver1.Id
+        );
+        var entry2 = await context.LineupEntries.FirstOrDefaultAsync(le =>
+            le.TeamId == team.Id && le.RaceId == race.Id && le.EntityId == driver2.Id
+        );
+        Assert.NotNull(entry1);
+        Assert.False(entry1.IsCaptain);
+        Assert.NotNull(entry2);
+        Assert.True(entry2.IsCaptain);
+    }
+
+    [Fact]
+    public async Task SetCaptainAsync_NullDriverId_ClearsExistingCaptain()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        var driver = CreateTestDriver(context, "VER", "Max", "Verstappen");
+        var race = CreateTestRace(
+            context,
+            raceDate: DateTime.UtcNow.AddDays(2),
+            lockDeadline: DateTime.UtcNow.AddHours(1)
+        );
+        await service.AddDriverToTeamAsync(team.Id, driver.Id, 0, user.Id);
+        await service.SetCaptainAsync(team.Id, driver.Id, user.Id);
+
+        // Act
+        await service.SetCaptainAsync(team.Id, null, user.Id);
+
+        // Assert
+        var entry = await context.LineupEntries.FirstOrDefaultAsync(le =>
+            le.TeamId == team.Id && le.RaceId == race.Id && le.EntityId == driver.Id
+        );
+        Assert.NotNull(entry);
+        Assert.False(entry.IsCaptain);
+    }
+
+    [Fact]
+    public async Task SetCaptainAsync_ThrowsIfRosterLocked()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        CreateTestRace(
+            context,
+            raceDate: DateTime.UtcNow.AddDays(2),
+            lockDeadline: DateTime.UtcNow.AddHours(-1)
+        );
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<RosterLockedException>(() =>
+            service.SetCaptainAsync(team.Id, 1, user.Id)
+        );
+        Assert.Equal("Test Grand Prix", exception.RaceName);
+    }
+
+    [Fact]
+    public async Task SetCaptainAsync_NoUpcomingRace_ThrowsNoUpcomingRaceException()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        // No race seeded
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NoUpcomingRaceException>(() =>
+            service.SetCaptainAsync(team.Id, 1, user.Id)
+        );
+    }
+
+    [Fact]
+    public async Task SetCaptainAsync_ThrowsIfDriverNotInLineup()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        CreateTestRace(
+            context,
+            raceDate: DateTime.UtcNow.AddDays(2),
+            lockDeadline: DateTime.UtcNow.AddHours(1)
+        );
+
+        // Act & Assert — driver 999 doesn't exist in the lineup
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            service.SetCaptainAsync(team.Id, 999, user.Id)
+        );
+        Assert.Contains("999", exception.Message);
+        Assert.Contains("lineup", exception.Message);
+    }
+
+    [Fact]
+    public async Task GetUserTeamAsync_WithCaptainSet_DriverIsCaptainIsTrue()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        var driver = CreateTestDriver(context, "VER", "Max", "Verstappen");
+        CreateTestRace(
+            context,
+            raceDate: DateTime.UtcNow.AddDays(2),
+            lockDeadline: DateTime.UtcNow.AddHours(1)
+        );
+        await service.AddDriverToTeamAsync(team.Id, driver.Id, 0, user.Id);
+        await service.SetCaptainAsync(team.Id, driver.Id, user.Id);
+
+        // Act
+        var result = await service.GetUserTeamAsync(user.Id);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.Drivers.Single(d => d.Id == driver.Id).IsCaptain);
+    }
+
+    [Fact]
+    public async Task GetUserTeamAsync_NoCaptainSet_AllDriversIsCaptainIsFalse()
+    {
+        // Arrange
+        using var context = CreateInMemoryContext();
+        var service = new TeamService(context, _mockLogger.Object);
+
+        var user = CreateTestUser(context);
+        var team = CreateTestTeam(context, user.Id);
+        var driver = CreateTestDriver(context, "VER", "Max", "Verstappen");
+        CreateTestRace(
+            context,
+            raceDate: DateTime.UtcNow.AddDays(2),
+            lockDeadline: DateTime.UtcNow.AddHours(1)
+        );
+        await service.AddDriverToTeamAsync(team.Id, driver.Id, 0, user.Id);
+
+        // Act
+        var result = await service.GetUserTeamAsync(user.Id);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.All(result.Drivers, d => Assert.False(d.IsCaptain));
+    }
+
+    #endregion
+
     #region Helper Methods
 
     private UserProfile CreateTestUser(ApplicationDbContext context, string email = "user@test.com")

--- a/api/F1CompanionApi/Api/Endpoints/MeEndpoints.cs
+++ b/api/F1CompanionApi/Api/Endpoints/MeEndpoints.cs
@@ -75,6 +75,14 @@ public static class MeEndpoints
                 "Remove a constructor from the current user's team at a specific slot position"
             );
 
+        teamGroup
+            .MapPut("/captain", SetCaptainAsync)
+            .WithName("Set Team Captain")
+            .WithOpenApi()
+            .WithDescription(
+                "Set or clear the captain driver for the current race. Pass null driverId to deselect."
+            );
+
         return app;
     }
 
@@ -422,5 +430,34 @@ public static class MeEndpoints
             );
             return Results.BadRequest(ex.Message);
         }
+    }
+
+    private static async Task<IResult> SetCaptainAsync(
+        SetCaptainRequest request,
+        ITeamService teamService,
+        IUserProfileService userProfileService,
+        ILogger logger
+    )
+    {
+        var user = await userProfileService.GetRequiredCurrentUserProfileAsync();
+
+        logger.LogInformation(
+            "User {UserId} setting captain to driver {DriverId}",
+            user.Id,
+            request.DriverId
+        );
+
+        var team = await teamService.GetUserTeamAsync(user.Id);
+        if (team is null)
+        {
+            logger.LogWarning("User {UserId} has no team", user.Id);
+            return Results.Problem(
+                detail: "User has no team",
+                statusCode: StatusCodes.Status404NotFound
+            );
+        }
+
+        await teamService.SetCaptainAsync(team.Id, request.DriverId, user.Id);
+        return Results.NoContent();
     }
 }

--- a/api/F1CompanionApi/Api/Mappers/TeamDriverResponseMapper.cs
+++ b/api/F1CompanionApi/Api/Mappers/TeamDriverResponseMapper.cs
@@ -5,7 +5,10 @@ namespace F1CompanionApi.Api.Mappers;
 
 public static class TeamDriverResponseMapper
 {
-    public static TeamDriverResponse ToResponseModel(this TeamDriver teamDriver)
+    public static TeamDriverResponse ToResponseModel(
+        this TeamDriver teamDriver,
+        int? captainDriverId = null
+    )
     {
         return new TeamDriverResponse
         {
@@ -16,6 +19,7 @@ public static class TeamDriverResponseMapper
             Abbreviation = teamDriver.Driver.Abbreviation,
             CountryAbbreviation = teamDriver.Driver.CountryAbbreviation,
             Price = teamDriver.Driver.Price,
+            IsCaptain = teamDriver.Driver.Id == captainDriverId,
         };
     }
 }

--- a/api/F1CompanionApi/Api/Mappers/TeamResponseMapper.cs
+++ b/api/F1CompanionApi/Api/Mappers/TeamResponseMapper.cs
@@ -18,7 +18,10 @@ public static class TeamResponseMapper
         };
     }
 
-    public static TeamDetailsResponse ToDetailsResponseModel(this Team team)
+    public static TeamDetailsResponse ToDetailsResponseModel(
+        this Team team,
+        int? captainDriverId = null
+    )
     {
         return new TeamDetailsResponse
         {
@@ -32,7 +35,7 @@ public static class TeamResponseMapper
                 - team.TeamConstructors.Sum(tc => tc.Constructor.Price),
             Drivers = team
                 .TeamDrivers.OrderBy(teamDriver => teamDriver.SlotPosition)
-                .Select(teamDriver => teamDriver.ToResponseModel())
+                .Select(teamDriver => teamDriver.ToResponseModel(captainDriverId))
                 .ToList(),
             Constructors = team
                 .TeamConstructors.OrderBy(teamConstructor => teamConstructor.SlotPosition)

--- a/api/F1CompanionApi/Api/Models/SetCaptainRequest.cs
+++ b/api/F1CompanionApi/Api/Models/SetCaptainRequest.cs
@@ -1,0 +1,6 @@
+namespace F1CompanionApi.Api.Models;
+
+public class SetCaptainRequest
+{
+    public int? DriverId { get; set; }
+}

--- a/api/F1CompanionApi/Api/Models/TeamDriverResponse.cs
+++ b/api/F1CompanionApi/Api/Models/TeamDriverResponse.cs
@@ -9,4 +9,5 @@ public class TeamDriverResponse
     public required string Abbreviation { get; set; }
     public required string CountryAbbreviation { get; set; }
     public decimal Price { get; set; }
+    public bool IsCaptain { get; set; }
 }

--- a/api/F1CompanionApi/Data/Entities/LineupEntry.cs
+++ b/api/F1CompanionApi/Data/Entities/LineupEntry.cs
@@ -16,6 +16,7 @@ public class LineupEntry
     public int EntityId { get; set; }
     public LineupEntityType EntityType { get; set; }
     public int SlotPosition { get; set; }
+    public bool IsCaptain { get; set; }
     public DateTime CreatedAt { get; set; }
 
     public Team Team { get; set; } = null!;

--- a/api/F1CompanionApi/Data/Migrations/20260226143935_AddCaptainFlagToLineupEntry.Designer.cs
+++ b/api/F1CompanionApi/Data/Migrations/20260226143935_AddCaptainFlagToLineupEntry.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using F1CompanionApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace F1CompanionApi.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260226143935_AddCaptainFlagToLineupEntry")]
+    partial class AddCaptainFlagToLineupEntry
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/F1CompanionApi/Data/Migrations/20260226143935_AddCaptainFlagToLineupEntry.cs
+++ b/api/F1CompanionApi/Data/Migrations/20260226143935_AddCaptainFlagToLineupEntry.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace F1CompanionApi.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCaptainFlagToLineupEntry : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsCaptain",
+                table: "LineupEntries",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsCaptain",
+                table: "LineupEntries");
+        }
+    }
+}

--- a/api/F1CompanionApi/Domain/Exceptions/GlobalExceptionHandler.cs
+++ b/api/F1CompanionApi/Domain/Exceptions/GlobalExceptionHandler.cs
@@ -122,6 +122,12 @@ public class GlobalExceptionHandler : IExceptionHandler
                 ex.Message
             ),
 
+            NoUpcomingRaceException ex => (
+                StatusCodes.Status409Conflict,
+                "No Upcoming Race",
+                ex.Message
+            ),
+
             // Standard .NET Exceptions (order matters: most specific first)
             ArgumentNullException ex => (
                 StatusCodes.Status400BadRequest,

--- a/api/F1CompanionApi/Domain/Exceptions/NoUpcomingRaceException.cs
+++ b/api/F1CompanionApi/Domain/Exceptions/NoUpcomingRaceException.cs
@@ -1,0 +1,12 @@
+namespace F1CompanionApi.Domain.Exceptions;
+
+/// <summary>
+/// Exception thrown when an operation requires an upcoming race but none exists on the calendar.
+/// This is considered exceptional because the UI should disable race-dependent actions (e.g. setting
+/// a captain) when no upcoming race is scheduled, indicating a client-side bug or race condition.
+/// </summary>
+public class NoUpcomingRaceException : Exception
+{
+    public NoUpcomingRaceException()
+        : base("There is no upcoming race to perform this operation.") { }
+}

--- a/api/F1CompanionApi/Domain/Services/TeamService.cs
+++ b/api/F1CompanionApi/Domain/Services/TeamService.cs
@@ -15,6 +15,7 @@ public interface ITeamService
     Task RemoveDriverFromTeamAsync(int teamId, int slotPosition, int userId);
     Task AddConstructorToTeamAsync(int teamId, int constructorId, int slotPosition, int userId);
     Task RemoveConstructorFromTeamAsync(int teamId, int slotPosition, int userId);
+    Task SetCaptainAsync(int teamId, int? driverId, int userId);
 }
 
 public class TeamService : ITeamService
@@ -93,7 +94,21 @@ public class TeamService : ITeamService
             return null;
         }
 
-        return team.ToDetailsResponseModel();
+        var currentRace = await GetCurrentRaceAsync();
+
+        int? captainDriverId = currentRace is null
+            ? null
+            : await _dbContext
+                .LineupEntries.Where(le =>
+                    le.TeamId == team.Id
+                    && le.RaceId == currentRace.Id
+                    && le.EntityType == LineupEntityType.Driver
+                    && le.IsCaptain
+                )
+                .Select(le => (int?)le.EntityId)
+                .FirstOrDefaultAsync();
+
+        return team.ToDetailsResponseModel(captainDriverId);
     }
 
     public async Task AddDriverToTeamAsync(int teamId, int driverId, int slotPosition, int userId)
@@ -497,14 +512,101 @@ public class TeamService : ITeamService
         );
     }
 
-    private async Task<Race?> GetCurrentRaceOrThrowIfLockedAsync()
+    public async Task SetCaptainAsync(int teamId, int? driverId, int userId)
+    {
+        _logger.LogInformation(
+            "User {UserId} setting captain to driver {DriverId} on team {TeamId}",
+            userId,
+            driverId,
+            teamId
+        );
+
+        var currentRace = await GetCurrentRaceOrThrowIfLockedAsync();
+
+        var team = await _dbContext.Teams.FirstOrDefaultAsync(t => t.Id == teamId);
+
+        if (team is null)
+        {
+            _logger.LogWarning("Team {TeamId} not found", teamId);
+            throw new InvalidOperationException("Team not found");
+        }
+
+        if (team.UserId != userId)
+        {
+            _logger.LogWarning(
+                "User {UserId} attempted to modify team {TeamId} owned by {OwnerId}",
+                userId,
+                teamId,
+                team.UserId
+            );
+            throw new TeamOwnershipException(teamId, team.UserId, userId);
+        }
+
+        if (currentRace is null)
+        {
+            _logger.LogWarning("No upcoming race — cannot set captain for team {TeamId}", teamId);
+            throw new NoUpcomingRaceException();
+        }
+
+        LineupEntry? newCaptainEntry = null;
+
+        if (driverId is not null)
+        {
+            newCaptainEntry = await _dbContext.LineupEntries.FirstOrDefaultAsync(le =>
+                le.TeamId == teamId
+                && le.RaceId == currentRace.Id
+                && le.EntityId == driverId
+                && le.EntityType == LineupEntityType.Driver
+            );
+
+            if (newCaptainEntry is null)
+            {
+                _logger.LogWarning(
+                    "Driver {DriverId} is not in the lineup for team {TeamId} race {RaceId}",
+                    driverId,
+                    teamId,
+                    currentRace.Id
+                );
+                throw new InvalidOperationException(
+                    $"Driver {driverId} is not in the current lineup"
+                );
+            }
+        }
+
+        var existingCaptain = await _dbContext.LineupEntries.FirstOrDefaultAsync(le =>
+            le.TeamId == teamId && le.RaceId == currentRace.Id && le.IsCaptain
+        );
+
+        if (existingCaptain is not null)
+            existingCaptain.IsCaptain = false;
+
+        if (newCaptainEntry is not null)
+            newCaptainEntry.IsCaptain = true;
+
+        await _dbContext.SaveChangesAsync();
+
+        _logger.LogInformation(
+            "Captain set to driver {DriverId} for team {TeamId} race {RaceId}",
+            driverId,
+            teamId,
+            currentRace.Id
+        );
+    }
+
+    private async Task<Race?> GetCurrentRaceAsync()
     {
         var now = DateTime.UtcNow;
-        var currentRace = await _dbContext
+        return await _dbContext
             .Races.Where(r => r.RaceDate >= now)
             .OrderBy(r => r.RaceDate)
             .FirstOrDefaultAsync();
+    }
 
+    private async Task<Race?> GetCurrentRaceOrThrowIfLockedAsync()
+    {
+        var currentRace = await GetCurrentRaceAsync();
+
+        var now = DateTime.UtcNow;
         if (currentRace?.LockDeadline is not null && now >= currentRace.LockDeadline)
             throw new RosterLockedException(currentRace.Name, currentRace.LockDeadline.Value);
 

--- a/docs/mockups/captain-badge-mockups.html
+++ b/docs/mockups/captain-badge-mockups.html
@@ -1,0 +1,763 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Captain Badge - Mockups</title>
+  <style>
+    :root {
+      --background: #09090b;
+      --foreground: #fafafa;
+      --card: #18181b;
+      --card-foreground: #fafafa;
+      --secondary: #27272a;
+      --secondary-foreground: #fafafa;
+      --muted: #27272a;
+      --muted-foreground: #a1a1aa;
+      --primary: #1447e6;
+      --primary-foreground: #eff6ff;
+      --border: #3f3f46;
+      --radius: 0.65rem;
+      --gold: #f59e0b;
+      --gold-light: #fde68a;
+      --gold-bg: #451a03;
+      --gold-border: #78350f;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      background: var(--background);
+      color: var(--foreground);
+      padding: 2rem;
+      max-width: 480px;
+      margin: 0 auto;
+    }
+
+    h1 {
+      font-size: 1.25rem;
+      margin-bottom: 0.375rem;
+    }
+
+    .page-desc {
+      font-size: 0.8rem;
+      color: var(--muted-foreground);
+      margin-bottom: 2rem;
+      line-height: 1.5;
+    }
+
+    h2 {
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--muted-foreground);
+      margin-bottom: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    .section {
+      margin-bottom: 2.5rem;
+    }
+
+    .section-title {
+      font-size: 0.85rem;
+      font-weight: 700;
+      color: var(--foreground);
+      margin-bottom: 0.25rem;
+    }
+
+    .section-desc {
+      font-size: 0.75rem;
+      color: var(--muted-foreground);
+      margin-bottom: 0.875rem;
+      line-height: 1.4;
+    }
+
+    /* Two-card grid — captain + regular */
+    .card-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 0.75rem;
+    }
+
+    .card-label {
+      font-size: 0.65rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--muted-foreground);
+      margin-bottom: 0.375rem;
+    }
+
+    /* Base driver card */
+    .driver-card {
+      background: var(--secondary);
+      border-radius: var(--radius);
+      border: 1px solid var(--border);
+      padding: 0.75rem;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .card-inner {
+      display: flex;
+      align-items: center;
+      gap: 0.625rem;
+    }
+
+    .avatar {
+      width: 3.5rem;
+      height: 3.5rem;
+      border-radius: 50%;
+      border: 2px solid var(--border);
+      color: var(--secondary-foreground);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.7rem;
+      font-weight: 700;
+      letter-spacing: 0.05em;
+      flex-shrink: 0;
+      position: relative;
+    }
+
+    .info {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .driver-name {
+      font-size: 0.875rem;
+      font-weight: 700;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      padding-right: 1.25rem; /* space for X button */
+    }
+
+    .driver-meta {
+      font-size: 0.7rem;
+      color: var(--muted-foreground);
+      margin-top: 0.1rem;
+    }
+
+    .divider {
+      height: 1px;
+      background: var(--border);
+      margin: 0.625rem 0;
+    }
+
+    .card-footer {
+      display: flex;
+      justify-content: space-between;
+      font-size: 0.7rem;
+      color: var(--muted-foreground);
+      padding: 0 0.125rem;
+    }
+
+    .remove-btn {
+      position: absolute;
+      top: 0.5rem;
+      right: 0.5rem;
+      width: 1.25rem;
+      height: 1.25rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--muted-foreground);
+      cursor: pointer;
+    }
+
+    .remove-btn svg {
+      width: 0.875rem;
+      height: 0.875rem;
+    }
+
+    /* ================================================
+       OPTION A: Gold "C" circle overlay on avatar top-left
+       ================================================ */
+    .opt-a .avatar {
+      border-color: var(--border);
+    }
+
+    .opt-a.captain-card .avatar {
+      border-color: var(--gold);
+    }
+
+    .captain-overlay {
+      position: absolute;
+      top: -3px;
+      left: -3px;
+      width: 1.1rem;
+      height: 1.1rem;
+      background: var(--gold);
+      border-radius: 50%;
+      border: 2px solid var(--secondary);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.5rem;
+      font-weight: 900;
+      color: #000;
+      line-height: 1;
+    }
+
+    /* ================================================
+       OPTION B: Crown icon top-right corner of card
+       ================================================ */
+    .crown-btn {
+      position: absolute;
+      top: 0.375rem;
+      right: 0.375rem;
+      width: 1.5rem;
+      height: 1.5rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 0.25rem;
+      cursor: pointer;
+    }
+
+    .crown-btn svg {
+      width: 1rem;
+      height: 1rem;
+    }
+
+    .crown-inactive { color: var(--muted-foreground); }
+    .crown-inactive:hover { color: var(--gold); }
+    .crown-active { color: var(--gold); }
+
+    /* X button shifts left when crown present */
+    .opt-b .remove-btn {
+      right: 2.1rem;
+    }
+
+    /* ================================================
+       OPTION C: Gold card border + "CAPTAIN" top strip
+       ================================================ */
+    .opt-c.captain-card {
+      border-color: var(--gold);
+    }
+
+    .captain-strip {
+      background: var(--gold);
+      color: #000;
+      font-size: 0.55rem;
+      font-weight: 800;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      text-align: center;
+      padding: 0.2rem 0;
+      margin: -0.75rem -0.75rem 0.625rem -0.75rem;
+    }
+
+    /* ================================================
+       OPTION D: Avatar turns gold with "C" superscript
+       ================================================ */
+    .opt-d.captain-card .avatar {
+      background: var(--gold-bg);
+      border-color: var(--gold);
+      color: var(--gold-light);
+    }
+
+    .captain-sup {
+      position: absolute;
+      top: -4px;
+      right: -4px;
+      width: 1rem;
+      height: 1rem;
+      background: var(--gold);
+      border-radius: 50%;
+      border: 2px solid var(--secondary);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.5rem;
+      font-weight: 900;
+      color: #000;
+      line-height: 1;
+    }
+
+    /* ================================================
+       OPTION E: Thin gold top-strip banner "Captain ×2"
+       ================================================ */
+    .opt-e.captain-card {
+      border-top-color: var(--gold);
+      border-top-width: 3px;
+      padding-top: calc(0.75rem - 2px); /* compensate for thicker border */
+    }
+
+    .captain-label {
+      position: absolute;
+      top: 0.25rem;
+      right: 0.5rem;
+      font-size: 0.6rem;
+      font-weight: 700;
+      color: var(--gold);
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    /* ================================================
+       OPTION F: Crown/star icon overlay on avatar (top-left)
+       ================================================ */
+    .opt-f.captain-card .avatar {
+      border-color: var(--gold);
+    }
+
+    .crown-overlay {
+      position: absolute;
+      top: -4px;
+      left: -4px;
+      width: 1.2rem;
+      height: 1.2rem;
+      background: var(--gold);
+      border-radius: 50%;
+      border: 2px solid var(--secondary);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .crown-overlay svg {
+      width: 0.6rem;
+      height: 0.6rem;
+      color: #000;
+    }
+
+    /* ================================================
+       OPTION G: Gold "×2" pill badge inline below driver name
+       ================================================ */
+    .captain-pill {
+      display: inline-block;
+      font-size: 0.6rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      background: var(--gold-bg);
+      color: var(--gold);
+      border: 1px solid var(--gold-border);
+      padding: 0.1rem 0.4rem;
+      border-radius: 9999px;
+      margin-top: 0.25rem;
+      line-height: 1.4;
+    }
+
+    /* set-captain tap hint on inactive card */
+    .set-captain-hint {
+      font-size: 0.6rem;
+      color: var(--muted-foreground);
+      text-align: center;
+      margin-top: 0.5rem;
+      font-style: italic;
+    }
+
+    .divider-section {
+      height: 1px;
+      background: var(--border);
+      margin: 2rem 0;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Captain Badge Mockups</h1>
+  <p class="page-desc">
+    Each option shows a captain driver card (left) alongside a regular driver card (right),
+    as they'd appear side-by-side in the team lineup grid. Tap target for set/deselect is noted per option.
+  </p>
+
+  <!-- OPTION A: Gold "C" overlay on avatar top-left -->
+  <div class="section">
+    <div class="section-title">A. Gold "C" Circle on Avatar</div>
+    <div class="section-desc">
+      Small gold "C" badge overlays the top-left of the abbreviation circle. Avatar border turns gold on the captain card.
+      Tap the avatar area to set/deselect captain.
+    </div>
+    <div class="card-grid">
+      <div>
+        <div class="card-label">Captain</div>
+        <div class="driver-card opt-a captain-card">
+          <div class="card-inner">
+            <div class="avatar">
+              VER
+              <div class="captain-overlay">C</div>
+            </div>
+            <div class="info">
+              <div class="driver-name">M. Verstappen</div>
+              <div class="driver-meta">NED</div>
+            </div>
+          </div>
+          <div class="divider"></div>
+          <div class="card-footer">
+            <span>$32.5M</span>
+            <span>-- pts</span>
+          </div>
+          <div class="remove-btn">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+          </div>
+        </div>
+      </div>
+      <div>
+        <div class="card-label">Regular</div>
+        <div class="driver-card opt-a">
+          <div class="card-inner">
+            <div class="avatar">NOR</div>
+            <div class="info">
+              <div class="driver-name">L. Norris</div>
+              <div class="driver-meta">GBR</div>
+            </div>
+          </div>
+          <div class="divider"></div>
+          <div class="card-footer">
+            <span>$28.0M</span>
+            <span>-- pts</span>
+          </div>
+          <div class="remove-btn">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+          </div>
+        </div>
+        <div class="set-captain-hint">tap avatar → set captain</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- OPTION B: Crown icon top-right corner -->
+  <div class="section">
+    <div class="section-title">B. Crown Icon (top-right)</div>
+    <div class="section-desc">
+      A crown SVG icon sits in the top-right corner of the card. Gold when captain is active, muted grey when not.
+      The X remove button shifts left to make room. Tap the crown to toggle.
+    </div>
+    <div class="card-grid">
+      <div>
+        <div class="card-label">Captain</div>
+        <div class="driver-card opt-b">
+          <div class="card-inner">
+            <div class="avatar">VER</div>
+            <div class="info">
+              <div class="driver-name">M. Verstappen</div>
+              <div class="driver-meta">NED</div>
+            </div>
+          </div>
+          <div class="divider"></div>
+          <div class="card-footer">
+            <span>$32.5M</span>
+            <span>-- pts</span>
+          </div>
+          <div class="remove-btn">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+          </div>
+          <!-- Crown: active (gold) -->
+          <div class="crown-btn crown-active" title="Captain (tap to deselect)">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M2 19h20v2H2v-2zm2-5 4-8 4 5 4-3 4 6H4z"/></svg>
+          </div>
+        </div>
+      </div>
+      <div>
+        <div class="card-label">Regular</div>
+        <div class="driver-card opt-b">
+          <div class="card-inner">
+            <div class="avatar">NOR</div>
+            <div class="info">
+              <div class="driver-name">L. Norris</div>
+              <div class="driver-meta">GBR</div>
+            </div>
+          </div>
+          <div class="divider"></div>
+          <div class="card-footer">
+            <span>$28.0M</span>
+            <span>-- pts</span>
+          </div>
+          <div class="remove-btn">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+          </div>
+          <!-- Crown: inactive (muted) -->
+          <div class="crown-btn crown-inactive" title="Set as captain">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M2 19h20v2H2v-2zm2-5 4-8 4 5 4-3 4 6H4z"/></svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- OPTION C: Gold border + CAPTAIN strip -->
+  <div class="section">
+    <div class="section-title">C. Gold Border + "CAPTAIN" Strip</div>
+    <div class="section-desc">
+      The card gets a full gold border, and a narrow gold banner at the top reads "CAPTAIN".
+      High visual weight — very obvious who the captain is. Tap anywhere on the captain card to deselect; tap a regular card to set.
+    </div>
+    <div class="card-grid">
+      <div>
+        <div class="card-label">Captain</div>
+        <div class="driver-card opt-c captain-card">
+          <div class="captain-strip">Captain ×2</div>
+          <div class="card-inner">
+            <div class="avatar">VER</div>
+            <div class="info">
+              <div class="driver-name">M. Verstappen</div>
+              <div class="driver-meta">NED</div>
+            </div>
+          </div>
+          <div class="divider"></div>
+          <div class="card-footer">
+            <span>$32.5M</span>
+            <span>-- pts</span>
+          </div>
+          <div class="remove-btn">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+          </div>
+        </div>
+      </div>
+      <div>
+        <div class="card-label">Regular</div>
+        <div class="driver-card opt-c">
+          <div class="card-inner">
+            <div class="avatar">NOR</div>
+            <div class="info">
+              <div class="driver-name">L. Norris</div>
+              <div class="driver-meta">GBR</div>
+            </div>
+          </div>
+          <div class="divider"></div>
+          <div class="card-footer">
+            <span>$28.0M</span>
+            <span>-- pts</span>
+          </div>
+          <div class="remove-btn">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+          </div>
+        </div>
+        <div class="set-captain-hint">tap card → set captain</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- OPTION D: Avatar circle turns gold + "C" superscript -->
+  <div class="section">
+    <div class="section-title">D. Gold Avatar + "C" Superscript</div>
+    <div class="section-desc">
+      The abbreviation circle turns amber/gold with a subtle dark background tint. A small "C" badge appears at top-right of the avatar.
+      Clean — the distinction is contained within the avatar area. Tap the avatar to toggle.
+    </div>
+    <div class="card-grid">
+      <div>
+        <div class="card-label">Captain</div>
+        <div class="driver-card opt-d captain-card">
+          <div class="card-inner">
+            <div class="avatar">
+              VER
+              <div class="captain-sup">C</div>
+            </div>
+            <div class="info">
+              <div class="driver-name">M. Verstappen</div>
+              <div class="driver-meta">NED</div>
+            </div>
+          </div>
+          <div class="divider"></div>
+          <div class="card-footer">
+            <span>$32.5M</span>
+            <span>-- pts</span>
+          </div>
+          <div class="remove-btn">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+          </div>
+        </div>
+      </div>
+      <div>
+        <div class="card-label">Regular</div>
+        <div class="driver-card opt-d">
+          <div class="card-inner">
+            <div class="avatar">NOR</div>
+            <div class="info">
+              <div class="driver-name">L. Norris</div>
+              <div class="driver-meta">GBR</div>
+            </div>
+          </div>
+          <div class="divider"></div>
+          <div class="card-footer">
+            <span>$28.0M</span>
+            <span>-- pts</span>
+          </div>
+          <div class="remove-btn">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+          </div>
+        </div>
+        <div class="set-captain-hint">tap avatar → set captain</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- OPTION E: Thin gold top-border + "Captain" label -->
+  <div class="section">
+    <div class="section-title">E. Gold Top-Border + Label</div>
+    <div class="section-desc">
+      Thick gold top border on the card with a small gold "Captain" text label in the top-right.
+      Minimal disruption to the card layout — the body stays identical. Tap anywhere on the card to toggle.
+    </div>
+    <div class="card-grid">
+      <div>
+        <div class="card-label">Captain</div>
+        <div class="driver-card opt-e captain-card">
+          <div class="captain-label">Captain</div>
+          <div class="card-inner">
+            <div class="avatar">VER</div>
+            <div class="info">
+              <div class="driver-name">M. Verstappen</div>
+              <div class="driver-meta">NED</div>
+            </div>
+          </div>
+          <div class="divider"></div>
+          <div class="card-footer">
+            <span>$32.5M</span>
+            <span>-- pts</span>
+          </div>
+          <div class="remove-btn" style="top: 1.375rem;">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+          </div>
+        </div>
+      </div>
+      <div>
+        <div class="card-label">Regular</div>
+        <div class="driver-card opt-e">
+          <div class="card-inner">
+            <div class="avatar">NOR</div>
+            <div class="info">
+              <div class="driver-name">L. Norris</div>
+              <div class="driver-meta">GBR</div>
+            </div>
+          </div>
+          <div class="divider"></div>
+          <div class="card-footer">
+            <span>$28.0M</span>
+            <span>-- pts</span>
+          </div>
+          <div class="remove-btn">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+          </div>
+        </div>
+        <div class="set-captain-hint">tap card → set captain</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- OPTION F: Crown icon overlay on avatar -->
+  <div class="section">
+    <div class="section-title">F. Crown Icon on Avatar</div>
+    <div class="section-desc">
+      A tiny crown icon (filled) in a gold circle overlays the top-left of the avatar — same position as A's "C", but uses a recognisable symbol instead of a letter. Avatar border turns gold. Tap the avatar to toggle.
+    </div>
+    <div class="card-grid">
+      <div>
+        <div class="card-label">Captain</div>
+        <div class="driver-card opt-f captain-card">
+          <div class="card-inner">
+            <div class="avatar">
+              VER
+              <div class="crown-overlay">
+                <!-- crown icon -->
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M2 19h20v2H2v-2zm2-5 4-8 4 5 4-3 4 6H4z"/></svg>
+              </div>
+            </div>
+            <div class="info">
+              <div class="driver-name">M. Verstappen</div>
+              <div class="driver-meta">NED</div>
+            </div>
+          </div>
+          <div class="divider"></div>
+          <div class="card-footer">
+            <span>$32.5M</span>
+            <span>-- pts</span>
+          </div>
+          <div class="remove-btn">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+          </div>
+        </div>
+      </div>
+      <div>
+        <div class="card-label">Regular</div>
+        <div class="driver-card opt-f">
+          <div class="card-inner">
+            <div class="avatar">NOR</div>
+            <div class="info">
+              <div class="driver-name">L. Norris</div>
+              <div class="driver-meta">GBR</div>
+            </div>
+          </div>
+          <div class="divider"></div>
+          <div class="card-footer">
+            <span>$28.0M</span>
+            <span>-- pts</span>
+          </div>
+          <div class="remove-btn">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+          </div>
+        </div>
+        <div class="set-captain-hint">tap avatar → set captain</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- OPTION G: Gold "×2" pill inline below driver name -->
+  <div class="section">
+    <div class="section-title">G. Gold "×2" Pill Under Driver Name</div>
+    <div class="section-desc">
+      A small amber pill badge reading "×2 pts" appears directly below the driver name in the info column. No avatar decoration, no card border change — the distinction lives in the text area. Tap the pill to deselect; tap anywhere on a regular card to set captain.
+    </div>
+    <div class="card-grid">
+      <div>
+        <div class="card-label">Captain</div>
+        <div class="driver-card opt-g">
+          <div class="card-inner">
+            <div class="avatar">VER</div>
+            <div class="info">
+              <div class="driver-name">M. Verstappen</div>
+              <div class="driver-meta">NED</div>
+              <div class="captain-pill">×2 pts</div>
+            </div>
+          </div>
+          <div class="divider"></div>
+          <div class="card-footer">
+            <span>$32.5M</span>
+            <span>-- pts</span>
+          </div>
+          <div class="remove-btn">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+          </div>
+        </div>
+      </div>
+      <div>
+        <div class="card-label">Regular</div>
+        <div class="driver-card opt-g">
+          <div class="card-inner">
+            <div class="avatar">NOR</div>
+            <div class="info">
+              <div class="driver-name">L. Norris</div>
+              <div class="driver-meta">GBR</div>
+            </div>
+          </div>
+          <div class="divider"></div>
+          <div class="card-footer">
+            <span>$28.0M</span>
+            <span>-- pts</span>
+          </div>
+          <div class="remove-btn">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+          </div>
+        </div>
+        <div class="set-captain-hint">tap card → set captain</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="divider-section"></div>
+  <p style="font-size: 0.7rem; color: var(--muted-foreground); line-height: 1.5;">
+    <strong style="color: var(--foreground);">Interaction note:</strong>
+    In all options the toggle is non-interactive when the roster is locked (readOnly mode).
+    The badge/indicator remains visible in read-only mode but cannot be tapped.
+  </p>
+
+</body>
+</html>

--- a/docs/plans/47-captain-selection.md
+++ b/docs/plans/47-captain-selection.md
@@ -1,0 +1,218 @@
+# Plan: Captain Selection (Issue #47)
+
+## Context
+
+Users need to designate one driver on their team as captain for each race round. The captain receives 2x points for that round (only if they finish and score). This feature builds on the `LineupEntry` snapshot system added in #46 — the captain flag will live on `LineupEntry` so it's automatically captured in the pre-lock lineup snapshot used by the scoring engine.
+
+**Design decisions confirmed:**
+- Captain can be set when lineup is incomplete (any filled driver slot is eligible)
+- No captain at lock time is valid — user simply forfeits the 2x bonus that round
+- Deselecting captain (tapping again) leaves no captain selected
+
+---
+
+## Step 0 — Feature Branch
+
+```bash
+git checkout -b feat/captain-selection
+```
+
+---
+
+## Commit 1 — Docs & Mockups
+
+Create plan and UI mockup files before any code changes. User reviews mockups and selects badge direction before frontend is implemented.
+
+**Files to create:**
+- `docs/plans/47-captain-selection.md` — copy of this plan
+- `docs/mockups/captain-badge-mockups.html` — 4–5 HTML mockups of the captain badge UI (styled to match existing Tailwind dark-theme cards)
+
+**Mockup options to include:**
+1. Gold "C" circle overlay on top-left of abbreviation circle
+2. Crown icon in top-right corner (Lucide-style SVG)
+3. Gold card border + "CAPTAIN" text label at top
+4. Abbreviation circle turns gold with "C" superscript badge
+5. Thin gold top-strip banner with "Captain" text
+
+Commit: `docs: add captain selection plan and UI mockups`
+
+---
+
+## Commit 2 — Backend: IsCaptain Migration
+
+Add `IsCaptain` bool flag to `LineupEntry` entity and run migration.
+
+**Files to modify:**
+- `api/F1CompanionApi/Data/Entities/LineupEntry.cs` — add `public bool IsCaptain { get; set; }`
+
+**New migration:**
+```bash
+dotnet ef migrations add AddCaptainFlagToLineupEntry --project F1CompanionApi
+dotnet ef database update --project F1CompanionApi
+```
+
+The existing unique index `(TeamId, RaceId, EntityType, SlotPosition)` already prevents duplicate slot entries. The "at most one captain" constraint will be enforced in application logic (the set-captain service method clears any prior captain before setting the new one).
+
+`IsCaptain` defaults to `false` in C#, so **no changes are needed** to `AddDriverToTeamAsync` — every new `LineupEntry` will automatically have `IsCaptain = false`. The flag is only flipped to `true` via the dedicated captain endpoint.
+
+Commit: `feat(api): add IsCaptain flag to LineupEntry`
+
+---
+
+## Commit 3 — Backend: Captain Endpoint + Team Response
+
+New endpoint to set/clear captain. Updated team response to expose current captain.
+
+### Service Layer
+
+Add to `ITeamService` interface and `TeamService`:
+
+```csharp
+Task SetCaptainAsync(int teamId, int? driverId, int userId);
+```
+
+**Logic in `SetCaptainAsync`:**
+1. Call `GetCurrentRaceOrThrowIfLockedAsync()` — rejects if locked
+2. Validate team ownership
+3. If `driverId` is not null: validate driver has a `LineupEntry` for `(TeamId, RaceId, EntityType=Driver)` — i.e., the driver is actually in the current lineup
+4. Clear `IsCaptain` on any existing captain entry for `(TeamId, RaceId)`
+5. If `driverId` is not null: set `IsCaptain = true` on that driver's `LineupEntry`
+6. SaveChanges
+
+**Files to modify:**
+- `api/F1CompanionApi/Domain/Services/TeamService.cs`
+- `api/F1CompanionApi/Domain/Services/ITeamService.cs`
+
+### New Endpoint
+
+Add to `MeEndpoints.cs` (inside the `teamGroup`):
+
+```
+PUT /me/team/captain
+Body: { "driverId": 42 }   // or null to deselect
+Response: 204 NoContent
+```
+
+**Files to modify:**
+- `api/F1CompanionApi/Api/Endpoints/MeEndpoints.cs`
+- `api/F1CompanionApi/Api/Models/SetCaptainRequest.cs` (new)
+
+### Team Response Update
+
+`GET /api/me/team/` must include current captain so the frontend can render the badge.
+
+Add `CaptainDriverId: int?` to `TeamDetailsResponse`. The mapper queries `LineupEntries` for the current race to find the captain:
+
+```csharp
+// In GetUserTeamAsync or mapper:
+var currentRace = await _dbContext.Races
+    .Where(r => r.RaceDate >= now)
+    .OrderBy(r => r.RaceDate)
+    .FirstOrDefaultAsync();
+
+int? captainDriverId = currentRace is null ? null :
+    await _dbContext.LineupEntries
+        .Where(le => le.TeamId == teamId
+                  && le.RaceId == currentRace.Id
+                  && le.EntityType == LineupEntityType.Driver
+                  && le.IsCaptain)
+        .Select(le => (int?)le.EntityId)
+        .FirstOrDefaultAsync();
+```
+
+**Files to modify:**
+- `api/F1CompanionApi/Api/Models/TeamDetailsResponse.cs` — add `CaptainDriverId`
+- `api/F1CompanionApi/Api/Mappers/TeamMapper.cs` — update mapper
+- `api/F1CompanionApi/Domain/Services/TeamService.cs` — update `GetUserTeamAsync`
+
+### Tests
+
+- `TeamService_SetCaptainAsync_SetsFlag` — happy path
+- `TeamService_SetCaptainAsync_ClearsExistingCaptain` — prior captain is cleared
+- `TeamService_SetCaptainAsync_ThrowsIfLocked` — roster locked
+- `TeamService_SetCaptainAsync_ThrowsIfDriverNotInLineup` — driver not in team
+- `TeamService_SetCaptainAsync_WithNullDriverId_ClearsCapitain` — deselect
+- `MeEndpoints_SetCaptain_Returns204`
+- `MeEndpoints_SetCaptain_Returns404WhenNoTeam`
+- `TeamService_GetUserTeam_IncludesCaptainDriverId` — team response includes captain
+
+**Test files:**
+- `api/F1CompanionApi.UnitTests/Services/TeamServiceTests.cs`
+- `api/F1CompanionApi.UnitTests/Api/Endpoints/MeEndpointsTests.cs`
+
+Commit: `feat(api): add captain endpoint and expose captain in team response`
+
+---
+
+## Commit 4 — Frontend: Captain Badge & Toggle
+
+> **Depends on user mockup review.** Badge implementation will follow the approved design direction.
+
+### Contracts
+
+`web/src/contracts/Team.ts`:
+- Add `captainDriverId: number | null` to `Team` interface
+
+### Service
+
+`web/src/services/teamService.ts`:
+- Add `setCaptain(driverId: number | null): Promise<void>` using `apiClient.put('/me/team/captain', { driverId })`
+
+### DriverCard
+
+`web/src/components/DriverCard/DriverCard.tsx`:
+- Add props: `isCaptain: boolean`, `onSetCaptain?: () => void`
+- Render captain badge (per approved mockup design) when `isCaptain`
+- Render "Set as captain" tap target (e.g., the badge area, or the card itself) when `driver` is present and `!readOnly`
+- Tapping the active captain badge deselects (`onSetCaptain` called with `null`)
+- Badge is hidden / non-interactive when `readOnly`
+
+### DriverPicker
+
+`web/src/components/DriverPicker/DriverPicker.tsx`:
+- Accept `captainDriverId: number | null` and `onSetCaptain: (driverId: number | null) => void` props
+- Pass `isCaptain={driver.id === captainDriverId}` and appropriate `onSetCaptain` callback to each `DriverCard`
+
+### Team Page
+
+`web/src/components/Team/Team.tsx`:
+- Read `captainDriverId` from team loader data
+- Wire up `setCaptain` call (via local state + optimistic update or loader invalidation)
+- Pass `onSetCaptain` down to `DriverPicker`
+
+### Tests
+
+- `DriverCard` — renders captain badge when `isCaptain`, calls `onSetCaptain` on click, hides badge in readOnly
+- `DriverPicker` — passes correct `isCaptain` to each slot
+- `teamService.setCaptain` — calls correct endpoint
+
+Commit: `feat(web): add captain badge and selection UI`
+
+---
+
+## Verification
+
+### Manual (End-to-End)
+
+1. Start both servers: `npm run web:dev` + `npm run api:watch`
+2. Navigate to team page — no driver is captain initially
+3. Click a driver card's captain toggle → badge appears, `PUT /me/team/captain` fires with 204
+4. Click another driver → first badge clears, new badge appears
+5. Click captain badge again → badge clears (no captain)
+6. Fast-forward past lock deadline (or wait) → captain toggle is disabled, badge still visible in read-only mode
+7. Remove the captain driver → badge disappears (LineupEntry deleted, no captain)
+
+### Automated
+
+```bash
+npm run api:test   # backend unit tests
+npm run web:test   # frontend unit tests
+npm run test:all   # full suite
+```
+
+### Build
+
+```bash
+npm run web:build
+npm run api:build
+```

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -21,6 +21,8 @@ npm run test:coverage    # Generate coverage reports
 
 # Code Quality
 npm run lint             # Run ESLint
+npm run format:check     # Check Prettier formatting (enforced by pre-commit)
+npx prettier --write .   # Auto-fix formatting issues
 ```
 
 ## Core Technologies

--- a/web/src/components/DriverCard/DriverCard.test.tsx
+++ b/web/src/components/DriverCard/DriverCard.test.tsx
@@ -159,6 +159,89 @@ describe('DriverCard', () => {
     });
   });
 
+  describe('Captain Badge', () => {
+    const driver = createMockDriver({ firstName: 'Max', lastName: 'Verstappen' });
+
+    it('renders captain badge in active state when isCaptain is true', () => {
+      render(
+        <DriverCard
+          driver={driver}
+          onOpenPicker={vi.fn()}
+          onRemove={vi.fn()}
+          readOnly={false}
+          isCaptain={true}
+          onSetCaptain={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: /remove captain/i })).toHaveAttribute(
+        'aria-pressed',
+        'true',
+      );
+    });
+
+    it('renders captain badge in inactive state when isCaptain is false', () => {
+      render(
+        <DriverCard
+          driver={driver}
+          onOpenPicker={vi.fn()}
+          onRemove={vi.fn()}
+          readOnly={false}
+          isCaptain={false}
+          onSetCaptain={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: /set as captain/i })).toHaveAttribute(
+        'aria-pressed',
+        'false',
+      );
+    });
+
+    it('calls onSetCaptain when captain toggle button is clicked', async () => {
+      const user = userEvent.setup();
+      const onSetCaptain = vi.fn();
+
+      render(
+        <DriverCard
+          driver={driver}
+          onOpenPicker={vi.fn()}
+          onRemove={vi.fn()}
+          readOnly={false}
+          isCaptain={false}
+          onSetCaptain={onSetCaptain}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /set as captain/i }));
+
+      expect(onSetCaptain).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render captain toggle when readOnly', () => {
+      render(
+        <DriverCard
+          driver={driver}
+          onOpenPicker={vi.fn()}
+          onRemove={vi.fn()}
+          readOnly={true}
+          isCaptain={false}
+          onSetCaptain={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByRole('button', { name: /captain/i })).not.toBeInTheDocument();
+    });
+
+    it('does not render captain toggle when onSetCaptain is not provided', () => {
+      render(
+        <DriverCard driver={driver} onOpenPicker={vi.fn()} onRemove={vi.fn()} readOnly={false} />,
+      );
+
+      expect(screen.queryByRole('button', { name: /captain/i })).not.toBeInTheDocument();
+    });
+  });
+
   describe('Keyboard Interactions', () => {
     it('allows keyboard interaction with "Add Driver" button in edit mode', async () => {
       const user = userEvent.setup();

--- a/web/src/components/DriverCard/DriverCard.tsx
+++ b/web/src/components/DriverCard/DriverCard.tsx
@@ -1,5 +1,5 @@
 import type { Driver } from '@/contracts/Role';
-import { formatMillions } from '@/lib/utils';
+import { cn, formatMillions } from '@/lib/utils';
 import { CirclePlus, X } from 'lucide-react';
 
 import { Button } from '../ui/button';
@@ -10,11 +10,20 @@ interface DriverCardProps {
   onOpenPicker: () => void;
   onRemove: () => void;
   readOnly: boolean;
+  isCaptain?: boolean;
+  onSetCaptain?: () => void;
 }
 
-export function DriverCard({ driver, onOpenPicker, onRemove, readOnly }: DriverCardProps) {
+export function DriverCard({
+  driver,
+  onOpenPicker,
+  onRemove,
+  readOnly,
+  isCaptain = false,
+  onSetCaptain,
+}: DriverCardProps) {
   return (
-    <Card className="bg-secondary relative p-0">
+    <Card className={cn('bg-secondary relative p-0', isCaptain && 'border-yellow-500')}>
       <CardContent className="px-3 py-4">
         {driver ? (
           <>
@@ -30,8 +39,37 @@ export function DriverCard({ driver, onOpenPicker, onRemove, readOnly }: DriverC
               </div>
             </div>
             <div className="bg-border my-2.5 h-px" />
-            <div className="text-muted-foreground flex justify-between px-1 text-xs">
+            <div className="text-muted-foreground flex items-center justify-between px-1 text-xs">
               <span>${formatMillions(driver.price)}M</span>
+              {!readOnly && onSetCaptain && (
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="group h-6 w-6 p-0 [perspective:600px]"
+                  aria-label={isCaptain ? 'Remove captain' : 'Set as captain'}
+                  aria-pressed={isCaptain}
+                  onClick={onSetCaptain}
+                >
+                  <span
+                    className={cn(
+                      'relative block h-5 w-5 transition-transform duration-300 [transform-style:preserve-3d]',
+                      isCaptain && '[transform:rotateY(180deg)]',
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        'absolute inset-0 flex items-center justify-center rounded-full border-2 text-xs font-black transition-colors [backface-visibility:hidden]',
+                        'border-muted-foreground text-muted-foreground group-hover:border-yellow-700 group-hover:text-yellow-700 dark:group-hover:border-yellow-400 dark:group-hover:text-yellow-400',
+                      )}
+                    >
+                      C
+                    </span>
+                    <span className="absolute inset-0 flex [transform:rotateY(180deg)] items-center justify-center rounded-full border-2 border-yellow-700 bg-yellow-700 text-xs font-black text-white [backface-visibility:hidden] dark:border-yellow-400 dark:bg-yellow-400 dark:text-black">
+                      ×2
+                    </span>
+                  </span>
+                </Button>
+              )}
               <span>-- pts</span>
             </div>
           </>

--- a/web/src/components/DriverPicker/DriverPicker.test.tsx
+++ b/web/src/components/DriverPicker/DriverPicker.test.tsx
@@ -2,6 +2,7 @@ import type { Driver } from '@/contracts/Role';
 import type { TeamDriver } from '@/contracts/Team';
 import { createMockDriver, createMockDriverList } from '@/test-utils/mockFactories';
 import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DriverPicker } from './DriverPicker';
@@ -37,9 +38,10 @@ const mockDrivers: Driver[] = createMockDriverList([
 ]);
 
 // Helper to convert Driver to TeamDriver
-const toTeamDriver = (driver: Driver, slotPosition: number): TeamDriver => ({
+const toTeamDriver = (driver: Driver, slotPosition: number, isCaptain = false): TeamDriver => ({
   ...driver,
   slotPosition,
+  isCaptain,
 });
 
 describe('DriverPicker', () => {
@@ -186,20 +188,6 @@ describe('DriverPicker', () => {
     });
   });
 
-  describe('Loading State', () => {
-    it('keeps picker sheet open during pending operations', () => {
-      mockSelectedPosition = 0; // User tried to open picker
-      mockIsPending = true; // Operation is pending
-
-      render(
-        <DriverPicker activeDrivers={mockDrivers} readOnly={false} remainingBudget={100_000_000} />,
-      );
-
-      // Sheet should remain open during pending operations
-      expect(screen.getByText('Select Driver')).toBeInTheDocument();
-    });
-  });
-
   describe('Error Handling', () => {
     it('displays error message above grid when error occurs', () => {
       mockError = 'Failed to add driver. Please try again.';
@@ -334,6 +322,110 @@ describe('DriverPicker', () => {
 
       // Sheet should not be rendered when picker is closed
       expect(screen.queryByText('Select Driver')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Captain Hint', () => {
+    it('shows hint when onSetCaptain is provided and no captain is selected', () => {
+      render(
+        <DriverPicker
+          activeDrivers={mockDrivers}
+          readOnly={false}
+          remainingBudget={100_000_000}
+          captainDriverId={null}
+          onSetCaptain={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText(/pick a captain/i)).toBeInTheDocument();
+    });
+
+    it('hides hint when a captain is already selected', () => {
+      mockDisplayLineup = [mockDrivers[0], null, null, null];
+
+      render(
+        <DriverPicker
+          activeDrivers={mockDrivers}
+          teamDrivers={[toTeamDriver(mockDrivers[0], 0)]}
+          readOnly={false}
+          remainingBudget={100_000_000}
+          captainDriverId={mockDrivers[0].id}
+          onSetCaptain={vi.fn()}
+        />,
+      );
+
+      // Element stays in DOM (animates to 0 height) but is hidden from assistive tech
+      const hint = screen.getByText(/pick a captain/i);
+      expect(hint.closest('[aria-hidden]')).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('hides hint when onSetCaptain is not provided', () => {
+      render(
+        <DriverPicker activeDrivers={mockDrivers} readOnly={false} remainingBudget={100_000_000} />,
+      );
+
+      expect(screen.queryByText(/pick a captain/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Captain', () => {
+    it('shows Remove captain button for the driver matching captainDriverId', () => {
+      mockDisplayLineup = [mockDrivers[0], null, null, null];
+
+      render(
+        <DriverPicker
+          activeDrivers={mockDrivers}
+          teamDrivers={[toTeamDriver(mockDrivers[0], 0)]}
+          readOnly={false}
+          remainingBudget={100_000_000}
+          captainDriverId={mockDrivers[0].id}
+          onSetCaptain={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: /remove captain/i })).toBeInTheDocument();
+    });
+
+    it('calls onSetCaptain with driver id when Set as captain is clicked', async () => {
+      const user = userEvent.setup();
+      const onSetCaptain = vi.fn();
+      mockDisplayLineup = [mockDrivers[0], null, null, null];
+
+      render(
+        <DriverPicker
+          activeDrivers={mockDrivers}
+          teamDrivers={[toTeamDriver(mockDrivers[0], 0)]}
+          readOnly={false}
+          remainingBudget={100_000_000}
+          captainDriverId={null}
+          onSetCaptain={onSetCaptain}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /set as captain/i }));
+
+      expect(onSetCaptain).toHaveBeenCalledWith(mockDrivers[0].id);
+    });
+
+    it('calls onSetCaptain with null when Remove captain is clicked', async () => {
+      const user = userEvent.setup();
+      const onSetCaptain = vi.fn();
+      mockDisplayLineup = [mockDrivers[0], null, null, null];
+
+      render(
+        <DriverPicker
+          activeDrivers={mockDrivers}
+          teamDrivers={[toTeamDriver(mockDrivers[0], 0, true)]}
+          readOnly={false}
+          remainingBudget={100_000_000}
+          captainDriverId={mockDrivers[0].id}
+          onSetCaptain={onSetCaptain}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /remove captain/i }));
+
+      expect(onSetCaptain).toHaveBeenCalledWith(null);
     });
   });
 

--- a/web/src/components/DriverPicker/DriverPicker.tsx
+++ b/web/src/components/DriverPicker/DriverPicker.tsx
@@ -22,6 +22,8 @@ interface DriverPickerProps {
   teamDrivers?: TeamDriver[];
   readOnly: boolean;
   remainingBudget: number;
+  captainDriverId?: number | null;
+  onSetCaptain?: (driverId: number | null) => void;
 }
 
 const DRIVER_SLOTS = 4;
@@ -31,6 +33,8 @@ export function DriverPicker({
   teamDrivers,
   readOnly,
   remainingBudget,
+  captainDriverId,
+  onSetCaptain,
 }: DriverPickerProps) {
   // build lineup with existing drivers
   const lineup = useMemo(() => {
@@ -69,6 +73,19 @@ export function DriverPicker({
           <InlineError message={error} />
         </div>
       )}
+      {onSetCaptain && (
+        <div
+          aria-hidden={!!captainDriverId}
+          className={`grid transition-[grid-template-rows] duration-300 ${captainDriverId ? 'grid-rows-[0fr]' : 'grid-rows-[1fr]'}`}
+        >
+          <div className="overflow-hidden">
+            <p className="text-muted-foreground pb-3 text-center text-xs">
+              Pick a captain — tap <strong className="text-foreground">C</strong> on any driver for
+              2× points
+            </p>
+          </div>
+        </div>
+      )}
       <div className="relative grid auto-rows-fr grid-cols-1 gap-4 sm:grid-cols-2">
         {displayLineup.map((driver, idx) => (
           <DriverCard
@@ -77,6 +94,12 @@ export function DriverPicker({
             onOpenPicker={() => openPicker(idx)}
             onRemove={() => handleRemove(idx)}
             readOnly={readOnly}
+            isCaptain={driver !== null && driver.id === captainDriverId}
+            onSetCaptain={
+              driver && onSetCaptain
+                ? () => onSetCaptain(driver.id === captainDriverId ? null : driver.id)
+                : undefined
+            }
           />
         ))}
 

--- a/web/src/components/Team/Team.tsx
+++ b/web/src/components/Team/Team.tsx
@@ -2,6 +2,7 @@ import type { Race } from '@/contracts/Race';
 import type { Constructor, Driver } from '@/contracts/Role';
 import type { Team } from '@/contracts/Team';
 import { formatBudget } from '@/lib/utils';
+import { setCaptain } from '@/services/teamService';
 import { useLoaderData } from '@tanstack/react-router';
 import { Lock } from 'lucide-react';
 import { useEffect, useState } from 'react';
@@ -9,6 +10,7 @@ import { useEffect, useState } from 'react';
 import { AppContainer } from '../AppContainer/AppContainer';
 import { ConstructorPicker } from '../ConstructorPicker/ConstructorPicker';
 import { DriverPicker } from '../DriverPicker/DriverPicker';
+import { InlineError } from '../InlineError/InlineError';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
@@ -61,6 +63,10 @@ export function TeamRoute() {
 export function Team({ team, activeDrivers, activeConstructors, races, readOnly }: TeamProps) {
   // Track active tab to control visibility while keeping both tabs mounted
   const [activeTab, setActiveTab] = useState('drivers');
+  const [captainDriverId, setCaptainDriverId] = useState<number | null>(
+    team.drivers.find((d) => d.isCaptain)?.id ?? null,
+  );
+  const [captainError, setCaptainError] = useState<string | null>(null);
   const currentRace = races.find((r) => r.isCurrent) ?? races.at(-1);
   const [selectedRaceId, setSelectedRaceId] = useState<number | undefined>(currentRace?.id);
 
@@ -94,6 +100,18 @@ export function Team({ team, activeDrivers, activeConstructors, races, readOnly 
   }, [lockDeadlineStr]);
 
   const isLocked = lockDeadline != null && now >= lockDeadline;
+
+  const handleSetCaptain = async (driverId: number | null) => {
+    const previous = captainDriverId;
+    setCaptainDriverId(driverId);
+    setCaptainError(null);
+    try {
+      await setCaptain(driverId);
+    } catch (error) {
+      setCaptainDriverId(previous);
+      setCaptainError(error instanceof Error ? error.message : 'Failed to update captain');
+    }
+  };
 
   const msRemaining = lockDeadline && !isLocked ? lockDeadline.getTime() - now.getTime() : 0;
   const totalMins = Math.floor(msRemaining / 60000);
@@ -225,11 +243,18 @@ export function Team({ team, activeDrivers, activeConstructors, races, readOnly 
         >
           <Card className="py-4">
             <CardContent className="px-4">
+              {captainError && (
+                <div className="pb-4">
+                  <InlineError message={captainError} />
+                </div>
+              )}
               <DriverPicker
                 activeDrivers={activeDrivers}
                 teamDrivers={team.drivers}
                 readOnly={readOnly || isLocked}
                 remainingBudget={team.remainingBudget}
+                captainDriverId={captainDriverId}
+                onSetCaptain={readOnly || isLocked ? undefined : handleSetCaptain}
               />
             </CardContent>
           </Card>

--- a/web/src/contracts/Team.ts
+++ b/web/src/contracts/Team.ts
@@ -6,6 +6,7 @@ export interface TeamDriver {
   abbreviation: string;
   countryAbbreviation: string;
   price: number;
+  isCaptain: boolean;
 }
 
 export interface TeamConstructor {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -194,6 +194,14 @@ class ApiClient {
     return this.makeRequest<T, D>(endpoint, { method: 'PATCH', data, errorContext });
   }
 
+  async put<T, D = Record<string, unknown>>(
+    endpoint: string,
+    data: D,
+    errorContext?: string,
+  ): Promise<T> {
+    return this.makeRequest<T, D>(endpoint, { method: 'PUT', data, errorContext });
+  }
+
   async delete<T>(endpoint: string, errorContext?: string): Promise<T> {
     return this.makeRequest<T>(endpoint, { method: 'DELETE', errorContext });
   }

--- a/web/src/services/teamService.test.ts
+++ b/web/src/services/teamService.test.ts
@@ -16,12 +16,14 @@ import {
   getTeams,
   removeConstructorFromTeam,
   removeDriverFromTeam,
+  setCaptain,
 } from './teamService';
 
 vi.mock('@/lib/api', () => ({
   apiClient: {
     get: vi.fn(),
     post: vi.fn(),
+    put: vi.fn(),
     delete: vi.fn(),
   },
 }));
@@ -277,6 +279,38 @@ describe('teamService', () => {
       await expect(removeConstructorFromTeam(slotPosition)).rejects.toThrow(
         'Failed to remove constructor',
       );
+    });
+  });
+
+  describe('setCaptain', () => {
+    it('calls apiClient.put with correct endpoint and driver id', async () => {
+      vi.mocked(apiClient.put).mockResolvedValue(undefined);
+
+      await setCaptain(42);
+
+      expect(apiClient.put).toHaveBeenCalledWith(
+        '/me/team/captain',
+        { driverId: 42 },
+        'set team captain',
+      );
+    });
+
+    it('calls apiClient.put with null to deselect captain', async () => {
+      vi.mocked(apiClient.put).mockResolvedValue(undefined);
+
+      await setCaptain(null);
+
+      expect(apiClient.put).toHaveBeenCalledWith(
+        '/me/team/captain',
+        { driverId: null },
+        'set team captain',
+      );
+    });
+
+    it('propagates API errors when setting captain fails', async () => {
+      vi.mocked(apiClient.put).mockRejectedValue(new Error('Failed to set captain'));
+
+      await expect(setCaptain(1)).rejects.toThrow('Failed to set captain');
     });
   });
 });

--- a/web/src/services/teamService.ts
+++ b/web/src/services/teamService.ts
@@ -92,3 +92,7 @@ export async function removeConstructorFromTeam(slotPosition: number): Promise<v
     slotPosition,
   });
 }
+
+export async function setCaptain(driverId: number | null): Promise<void> {
+  await apiClient.put('/me/team/captain', { driverId }, 'set team captain');
+}

--- a/web/src/test-utils/mockFactories.ts
+++ b/web/src/test-utils/mockFactories.ts
@@ -117,6 +117,7 @@ export function createMockTeamDriver(overrides: Partial<TeamDriver> = {}): TeamD
     abbreviation: 'TDR',
     countryAbbreviation: 'TST',
     price: 1_000_000,
+    isCaptain: false,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

- Adds `IsCaptain` flag to `LineupEntry` entity with EF Core migration
- New `PUT /me/team/captain` endpoint to set/clear the captain for the current race; rejects if roster is locked
- `GET /me/team/` response now includes `captainDriverId` so the frontend can render the badge on load
- Driver cards show a C badge that flips to ×2 on click, with a gold card border when active
- Hint text above the driver grid slides in/out to prompt captain selection when none is set

## Test plan

- [ ] Navigate to team page — no captain badge active initially, hint text visible
- [ ] Tap C on a driver — badge flips to ×2, card border turns gold, hint slides away, `PUT /me/team/captain` returns 204
- [ ] Tap another driver's C — previous captain clears, new one activates
- [ ] Tap the active ×2 badge — captain deselected, hint reappears
- [ ] Remove the captain driver — badge disappears with the card
- [ ] Verify captain persists on page refresh (loaded from `captainDriverId` in team response)
- [ ] Past lock deadline — captain badge visible in read-only mode, toggle not rendered
- [ ] All frontend and backend tests pass