### PR TITLE
Race results data model

### DIFF
--- a/api/F1CompanionApi/Api/Mappers/RaceResponseMapper.cs
+++ b/api/F1CompanionApi/Api/Mappers/RaceResponseMapper.cs
@@ -27,6 +27,7 @@ public static class RaceResponseMapper
             RaceDate = race.RaceDate,
             LockDeadline = race.LockDeadline,
             IsCurrent = race.Id == currentRaceId,
+            HasSprint = race.HasSprint,
         };
     }
 }

--- a/api/F1CompanionApi/Api/Models/RaceResponse.cs
+++ b/api/F1CompanionApi/Api/Models/RaceResponse.cs
@@ -12,4 +12,5 @@ public class RaceResponse
     public required DateTime RaceDate { get; set; }
     public DateTime? LockDeadline { get; set; }
     public required bool IsCurrent { get; set; }
+    public bool HasSprint { get; set; }
 }

--- a/api/F1CompanionApi/Data/ApplicationDbContext.cs
+++ b/api/F1CompanionApi/Data/ApplicationDbContext.cs
@@ -25,6 +25,7 @@ public class ApplicationDbContext : DbContext
     public DbSet<LineupEntry> LineupEntries => Set<LineupEntry>();
     public DbSet<UserProfile> UserProfiles => Set<UserProfile>();
     public DbSet<DriverQualifyingResult> DriverQualifyingResults => Set<DriverQualifyingResult>();
+    public DbSet<DriverRaceResult> DriverRaceResults => Set<DriverRaceResult>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -100,6 +101,21 @@ public class ApplicationDbContext : DbContext
                 .HasOne(dqr => dqr.Race)
                 .WithMany()
                 .HasForeignKey(dqr => dqr.RaceId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<DriverRaceResult>(entity =>
+        {
+            entity
+                .HasOne(drr => drr.Driver)
+                .WithMany()
+                .HasForeignKey(drr => drr.DriverId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity
+                .HasOne(drr => drr.Race)
+                .WithMany()
+                .HasForeignKey(drr => drr.RaceId)
                 .OnDelete(DeleteBehavior.Restrict);
         });
 

--- a/api/F1CompanionApi/Data/ApplicationDbContext.cs
+++ b/api/F1CompanionApi/Data/ApplicationDbContext.cs
@@ -26,6 +26,7 @@ public class ApplicationDbContext : DbContext
     public DbSet<UserProfile> UserProfiles => Set<UserProfile>();
     public DbSet<DriverQualifyingResult> DriverQualifyingResults => Set<DriverQualifyingResult>();
     public DbSet<DriverRaceResult> DriverRaceResults => Set<DriverRaceResult>();
+    public DbSet<TeamRaceScore> TeamRaceScores => Set<TeamRaceScore>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -116,6 +117,21 @@ public class ApplicationDbContext : DbContext
                 .HasOne(drr => drr.Race)
                 .WithMany()
                 .HasForeignKey(drr => drr.RaceId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<TeamRaceScore>(entity =>
+        {
+            entity
+                .HasOne(trs => trs.Team)
+                .WithMany()
+                .HasForeignKey(trs => trs.TeamId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity
+                .HasOne(trs => trs.Race)
+                .WithMany()
+                .HasForeignKey(trs => trs.RaceId)
                 .OnDelete(DeleteBehavior.Restrict);
         });
 

--- a/api/F1CompanionApi/Data/ApplicationDbContext.cs
+++ b/api/F1CompanionApi/Data/ApplicationDbContext.cs
@@ -24,6 +24,7 @@ public class ApplicationDbContext : DbContext
     public DbSet<TeamConstructor> TeamConstructors => Set<TeamConstructor>();
     public DbSet<LineupEntry> LineupEntries => Set<LineupEntry>();
     public DbSet<UserProfile> UserProfiles => Set<UserProfile>();
+    public DbSet<DriverQualifyingResult> DriverQualifyingResults => Set<DriverQualifyingResult>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -84,6 +85,21 @@ public class ApplicationDbContext : DbContext
                 .HasOne(e => e.Season)
                 .WithMany(s => s.Races)
                 .HasForeignKey(e => e.SeasonId)
+                .OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<DriverQualifyingResult>(entity =>
+        {
+            entity
+                .HasOne(dqr => dqr.Driver)
+                .WithMany()
+                .HasForeignKey(dqr => dqr.DriverId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            entity
+                .HasOne(dqr => dqr.Race)
+                .WithMany()
+                .HasForeignKey(dqr => dqr.RaceId)
                 .OnDelete(DeleteBehavior.Restrict);
         });
 

--- a/api/F1CompanionApi/Data/Entities/DriverQualifyingResult.cs
+++ b/api/F1CompanionApi/Data/Entities/DriverQualifyingResult.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace F1CompanionApi.Data.Entities;
+
+[Index(nameof(DriverId), nameof(RaceId), IsUnique = true)]
+public class DriverQualifyingResult : BaseEntity
+{
+    public required int DriverId { get; set; }
+    public required int RaceId { get; set; }
+    public required int Position { get; set; }
+
+    public Driver Driver { get; set; } = null!;
+    public Race Race { get; set; } = null!;
+}

--- a/api/F1CompanionApi/Data/Entities/DriverRaceResult.cs
+++ b/api/F1CompanionApi/Data/Entities/DriverRaceResult.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace F1CompanionApi.Data.Entities;
+
+[Index(nameof(DriverId), nameof(RaceId), nameof(SessionType), IsUnique = true)]
+public class DriverRaceResult : BaseEntity
+{
+    public required int DriverId { get; set; }
+    public required int RaceId { get; set; }
+    public required SessionType SessionType { get; set; }
+    public required int GridPosition { get; set; }
+    public int? FinishPosition { get; set; }
+    public required int Overtakes { get; set; }
+    public required bool FastestLap { get; set; }
+    public required RaceStatus Status { get; set; }
+
+    public Driver Driver { get; set; } = null!;
+    public Race Race { get; set; } = null!;
+}

--- a/api/F1CompanionApi/Data/Entities/Race.cs
+++ b/api/F1CompanionApi/Data/Entities/Race.cs
@@ -13,6 +13,7 @@ public class Race : BaseEntity
     public required string Country { get; set; }
     public required DateTime RaceDate { get; set; }
     public DateTime? LockDeadline { get; set; }
+    public bool HasSprint { get; set; }
 
     public Season Season { get; set; } = null!;
 }

--- a/api/F1CompanionApi/Data/Entities/RaceStatus.cs
+++ b/api/F1CompanionApi/Data/Entities/RaceStatus.cs
@@ -1,0 +1,9 @@
+namespace F1CompanionApi.Data.Entities;
+
+public enum RaceStatus
+{
+    Classified = 0,
+    DNF = 1,
+    DSQ = 2,
+    DNS = 3,
+}

--- a/api/F1CompanionApi/Data/Entities/SessionType.cs
+++ b/api/F1CompanionApi/Data/Entities/SessionType.cs
@@ -1,0 +1,7 @@
+namespace F1CompanionApi.Data.Entities;
+
+public enum SessionType
+{
+    Race = 0,
+    Sprint = 1,
+}

--- a/api/F1CompanionApi/Data/Entities/TeamRaceScore.cs
+++ b/api/F1CompanionApi/Data/Entities/TeamRaceScore.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace F1CompanionApi.Data.Entities;
+
+[Index(nameof(TeamId), nameof(RaceId), IsUnique = true)]
+public class TeamRaceScore : BaseEntity
+{
+    public required int TeamId { get; set; }
+    public required int RaceId { get; set; }
+    public required int TotalPoints { get; set; }
+    public required DateTime CalculatedAt { get; set; }
+
+    public Team Team { get; set; } = null!;
+    public Race Race { get; set; } = null!;
+}

--- a/api/F1CompanionApi/Data/Migrations/20260324125720_AddHasSprintToRaceAndEnums.Designer.cs
+++ b/api/F1CompanionApi/Data/Migrations/20260324125720_AddHasSprintToRaceAndEnums.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using F1CompanionApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace F1CompanionApi.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260324125720_AddHasSprintToRaceAndEnums")]
+    partial class AddHasSprintToRaceAndEnums
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/F1CompanionApi/Data/Migrations/20260324125720_AddHasSprintToRaceAndEnums.cs
+++ b/api/F1CompanionApi/Data/Migrations/20260324125720_AddHasSprintToRaceAndEnums.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace F1CompanionApi.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddHasSprintToRaceAndEnums : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "HasSprint",
+                table: "Races",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "HasSprint",
+                table: "Races");
+        }
+    }
+}

--- a/api/F1CompanionApi/Data/Migrations/20260324131013_AddDriverQualifyingResult.Designer.cs
+++ b/api/F1CompanionApi/Data/Migrations/20260324131013_AddDriverQualifyingResult.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using F1CompanionApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace F1CompanionApi.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260324131013_AddDriverQualifyingResult")]
+    partial class AddDriverQualifyingResult
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/F1CompanionApi/Data/Migrations/20260324131013_AddDriverQualifyingResult.cs
+++ b/api/F1CompanionApi/Data/Migrations/20260324131013_AddDriverQualifyingResult.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace F1CompanionApi.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDriverQualifyingResult : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DriverQualifyingResults",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    DriverId = table.Column<int>(type: "integer", nullable: false),
+                    RaceId = table.Column<int>(type: "integer", nullable: false),
+                    Position = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DriverQualifyingResults", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_DriverQualifyingResults_Drivers_DriverId",
+                        column: x => x.DriverId,
+                        principalTable: "Drivers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_DriverQualifyingResults_Races_RaceId",
+                        column: x => x.RaceId,
+                        principalTable: "Races",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DriverQualifyingResults_DriverId_RaceId",
+                table: "DriverQualifyingResults",
+                columns: new[] { "DriverId", "RaceId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DriverQualifyingResults_RaceId",
+                table: "DriverQualifyingResults",
+                column: "RaceId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DriverQualifyingResults");
+        }
+    }
+}

--- a/api/F1CompanionApi/Data/Migrations/20260324131654_AddDriverRaceResult.Designer.cs
+++ b/api/F1CompanionApi/Data/Migrations/20260324131654_AddDriverRaceResult.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using F1CompanionApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace F1CompanionApi.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260324131654_AddDriverRaceResult")]
+    partial class AddDriverRaceResult
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/F1CompanionApi/Data/Migrations/20260324131654_AddDriverRaceResult.cs
+++ b/api/F1CompanionApi/Data/Migrations/20260324131654_AddDriverRaceResult.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace F1CompanionApi.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDriverRaceResult : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DriverRaceResults",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    DriverId = table.Column<int>(type: "integer", nullable: false),
+                    RaceId = table.Column<int>(type: "integer", nullable: false),
+                    SessionType = table.Column<int>(type: "integer", nullable: false),
+                    GridPosition = table.Column<int>(type: "integer", nullable: false),
+                    FinishPosition = table.Column<int>(type: "integer", nullable: true),
+                    Overtakes = table.Column<int>(type: "integer", nullable: false),
+                    FastestLap = table.Column<bool>(type: "boolean", nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DriverRaceResults", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_DriverRaceResults_Drivers_DriverId",
+                        column: x => x.DriverId,
+                        principalTable: "Drivers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_DriverRaceResults_Races_RaceId",
+                        column: x => x.RaceId,
+                        principalTable: "Races",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DriverRaceResults_DriverId_RaceId_SessionType",
+                table: "DriverRaceResults",
+                columns: new[] { "DriverId", "RaceId", "SessionType" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DriverRaceResults_RaceId",
+                table: "DriverRaceResults",
+                column: "RaceId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DriverRaceResults");
+        }
+    }
+}

--- a/api/F1CompanionApi/Data/Migrations/20260324133912_AddTeamRaceScore.Designer.cs
+++ b/api/F1CompanionApi/Data/Migrations/20260324133912_AddTeamRaceScore.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using F1CompanionApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace F1CompanionApi.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260324133912_AddTeamRaceScore")]
+    partial class AddTeamRaceScore
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/F1CompanionApi/Data/Migrations/20260324133912_AddTeamRaceScore.cs
+++ b/api/F1CompanionApi/Data/Migrations/20260324133912_AddTeamRaceScore.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace F1CompanionApi.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTeamRaceScore : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TeamRaceScores",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    TeamId = table.Column<int>(type: "integer", nullable: false),
+                    RaceId = table.Column<int>(type: "integer", nullable: false),
+                    TotalPoints = table.Column<int>(type: "integer", nullable: false),
+                    CalculatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TeamRaceScores", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TeamRaceScores_Races_RaceId",
+                        column: x => x.RaceId,
+                        principalTable: "Races",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_TeamRaceScores_Teams_TeamId",
+                        column: x => x.TeamId,
+                        principalTable: "Teams",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeamRaceScores_RaceId",
+                table: "TeamRaceScores",
+                column: "RaceId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TeamRaceScores_TeamId_RaceId",
+                table: "TeamRaceScores",
+                columns: new[] { "TeamId", "RaceId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TeamRaceScores");
+        }
+    }
+}

--- a/api/supabase/seed.sql
+++ b/api/supabase/seed.sql
@@ -170,35 +170,37 @@ BEGIN
   ON CONFLICT ("SeasonId", "DriverId") DO NOTHING;
 
   -- Insert all races for 2026 season
+  -- Sprint races: China, Miami, Canada, Great Britain, Netherlands, Singapore
   INSERT INTO "Races"
-    ("SeasonId", "Round", "Name", "Location", "Circuit", "Country", "RaceDate", "LockDeadline", "IsDeleted", "CreatedAt", "UpdatedAt", "DeletedAt")
+    ("SeasonId", "Round", "Name", "Location", "Circuit", "Country", "RaceDate", "LockDeadline", "HasSprint", "IsDeleted", "CreatedAt", "UpdatedAt", "DeletedAt")
   VALUES
-    (season_id, 1, 'Australian Grand Prix', 'Melbourne', 'Melbourne Grand Prix Circuit', 'Australia', '2026-03-08 04:00:00+00', '2026-03-07 05:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 2, 'Chinese Grand Prix', 'Shanghai', 'Shanghai International Circuit', 'China', '2026-03-15 07:00:00+00', '2026-03-14 07:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 3, 'Japanese Grand Prix', 'Suzuka', 'Suzuka Circuit', 'Japan', '2026-03-29 05:00:00+00', '2026-03-28 06:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 4, 'Bahrain Grand Prix', 'Sakhir', 'Bahrain International Circuit', 'Bahrain', '2026-04-12 15:00:00+00', '2026-04-11 16:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 5, 'Saudi Arabian Grand Prix', 'Jeddah', 'Jeddah Corniche Circuit', 'Saudi Arabia', '2026-04-19 17:00:00+00', '2026-04-18 17:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 6, 'Miami Grand Prix', 'Miami', 'Miami International Autodrome', 'United States', '2026-05-03 20:00:00+00', '2026-05-02 20:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 7, 'Canadian Grand Prix', 'Montreal', 'Circuit Gilles Villeneuve', 'Canada', '2026-05-24 20:00:00+00', '2026-05-23 20:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 8, 'Monaco Grand Prix', 'Monte Carlo', 'Circuit de Monaco', 'Monaco', '2026-06-07 13:00:00+00', '2026-06-06 14:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 9, 'Spanish Grand Prix', 'Barcelona', 'Circuit de Barcelona-Catalunya', 'Spain', '2026-06-14 13:00:00+00', '2026-06-13 14:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 10, 'Austrian Grand Prix', 'Spielberg', 'Red Bull Ring', 'Austria', '2026-06-28 13:00:00+00', '2026-06-27 14:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 11, 'British Grand Prix', 'Silverstone', 'Silverstone Circuit', 'United Kingdom', '2026-07-05 14:00:00+00', '2026-07-04 15:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 12, 'Belgian Grand Prix', 'Spa', 'Circuit de Spa-Francorchamps', 'Belgium', '2026-07-19 13:00:00+00', '2026-07-18 14:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 13, 'Hungarian Grand Prix', 'Budapest', 'Hungaroring', 'Hungary', '2026-07-26 13:00:00+00', '2026-07-25 14:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 14, 'Dutch Grand Prix', 'Zandvoort', 'Circuit Zandvoort', 'Netherlands', '2026-08-23 13:00:00+00', '2026-08-22 14:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 15, 'Italian Grand Prix', 'Monza', 'Autodromo Nazionale di Monza', 'Italy', '2026-09-06 13:00:00+00', '2026-09-05 14:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 16, 'Madrid Grand Prix', 'Madrid', 'Madrid Street Circuit', 'Spain', '2026-09-13 13:00:00+00', '2026-09-12 14:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 17, 'Azerbaijan Grand Prix', 'Baku', 'Baku City Circuit', 'Azerbaijan', '2026-09-26 11:00:00+00', '2026-09-25 12:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 18, 'Singapore Grand Prix', 'Singapore', 'Marina Bay Street Circuit', 'Singapore', '2026-10-11 12:00:00+00', '2026-10-10 13:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 19, 'United States Grand Prix', 'Austin', 'Circuit of the Americas', 'United States', '2026-10-25 20:00:00+00', '2026-10-24 21:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 20, 'Mexico City Grand Prix', 'Mexico City', 'Autódromo Hermanos Rodríguez', 'Mexico', '2026-11-01 20:00:00+00', '2026-10-31 21:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 21, 'São Paulo Grand Prix', 'São Paulo', 'Autódromo José Carlos Pace', 'Brazil', '2026-11-08 17:00:00+00', '2026-11-07 18:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 22, 'Las Vegas Grand Prix', 'Las Vegas', 'Las Vegas Street Circuit', 'United States', '2026-11-22 04:00:00+00', '2026-11-21 04:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 23, 'Qatar Grand Prix', 'Lusail', 'Lusail International Circuit', 'Qatar', '2026-11-29 16:00:00+00', '2026-11-28 18:00:00+00', false, NOW(), NOW(), NULL),
-    (season_id, 24, 'Abu Dhabi Grand Prix', 'Abu Dhabi', 'Yas Marina Circuit', 'United Arab Emirates', '2026-12-06 13:00:00+00', '2026-12-05 14:00:00+00', false, NOW(), NOW(), NULL)
+    (season_id, 1, 'Australian Grand Prix', 'Melbourne', 'Melbourne Grand Prix Circuit', 'Australia', '2026-03-08 04:00:00+00', '2026-03-07 05:00:00+00', false, false, NOW(), NOW(), NULL),
+    (season_id, 2, 'Chinese Grand Prix', 'Shanghai', 'Shanghai International Circuit', 'China', '2026-03-15 07:00:00+00', '2026-03-14 07:00:00+00', true, false, NOW(), NOW(), NULL),
+    (season_id, 3, 'Japanese Grand Prix', 'Suzuka', 'Suzuka Circuit', 'Japan', '2026-03-29 05:00:00+00', '2026-03-28 06:00:00+00', false, false, NOW(), NOW(), NULL),
+    (season_id, 4, 'Bahrain Grand Prix', 'Sakhir', 'Bahrain International Circuit', 'Bahrain', '2026-04-12 15:00:00+00', '2026-04-11 16:00:00+00', false, false, NOW(), NOW(), NULL),
+    (season_id, 5, 'Saudi Arabian Grand Prix', 'Jeddah', 'Jeddah Corniche Circuit', 'Saudi Arabia', '2026-04-19 17:00:00+00', '2026-04-18 17:00:00+00', false, false, NOW(), NOW(), NULL),
+    (season_id, 6, 'Miami Grand Prix', 'Miami', 'Miami International Autodrome', 'United States', '2026-05-03 20:00:00+00', '2026-05-02 20:00:00+00', true, false, NOW(), NOW(), NULL),
+    (season_id, 7, 'Canadian Grand Prix', 'Montreal', 'Circuit Gilles Villeneuve', 'Canada', '2026-05-24 20:00:00+00', '2026-05-23 20:00:00+00', true, false, NOW(), NOW(), NULL),
+    (season_id, 8, 'Monaco Grand Prix', 'Monte Carlo', 'Circuit de Monaco', 'Monaco', '2026-06-07 13:00:00+00', '2026-06-06 14:00:00+00', false, false, NOW(), NOW(), NULL),
+    (season_id, 9, 'Spanish Grand Prix', 'Barcelona', 'Circuit de Barcelona-Catalunya', 'Spain', '2026-06-14 13:00:00+00', '2026-06-13 14:00:00+00', false, false, NOW(), NOW(), NULL),
+    (season_id, 10, 'Austrian Grand Prix', 'Spielberg', 'Red Bull Ring', 'Austria', '2026-06-28 13:00:00+00', '2026-06-27 14:00:00+00', false, false, NOW(), NOW(), NULL),
+    (season_id, 11, 'British Grand Prix', 'Silverstone', 'Silverstone Circuit', 'United Kingdom', '2026-07-05 14:00:00+00', '2026-07-04 15:00:00+00', true, false, NOW(), NOW(), NULL),
+    (season_id, 12, 'Belgian Grand Prix', 'Spa', 'Circuit de Spa-Francorchamps', 'Belgium', '2026-07-19 13:00:00+00', '2026-07-18 14:00:00+00', false, false, NOW(), NOW(), NULL),
+    (season_id, 13, 'Hungarian Grand Prix', 'Budapest', 'Hungaroring', 'Hungary', '2026-07-26 13:00:00+00', '2026-07-25 14:00:00+00', false, false, NOW(), NOW(), NULL),
+    (season_id, 14, 'Dutch Grand Prix', 'Zandvoort', 'Circuit Zandvoort', 'Netherlands', '2026-08-23 13:00:00+00', '2026-08-22 14:00:00+00', true, false, NOW(), NOW(), NULL),
+    (season_id, 15, 'Italian Grand Prix', 'Monza', 'Autodromo Nazionale di Monza', 'Italy', '2026-09-06 13:00:00+00', '2026-09-05 14:00:00+00', false, false, NOW(), NOW(), NULL),
+    (season_id, 16, 'Madrid Grand Prix', 'Madrid', 'Madrid Street Circuit', 'Spain', '2026-09-13 13:00:00+00', '2026-09-12 14:00:00+00', false, false, NOW(), NOW(), NULL),
+    (season_id, 17, 'Azerbaijan Grand Prix', 'Baku', 'Baku City Circuit', 'Azerbaijan', '2026-09-26 11:00:00+00', '2026-09-25 12:00:00+00', false, false, NOW(), NOW(), NULL),
+    (season_id, 18, 'Singapore Grand Prix', 'Singapore', 'Marina Bay Street Circuit', 'Singapore', '2026-10-11 12:00:00+00', '2026-10-10 13:00:00+00', true, false, NOW(), NOW(), NULL),
+    (season_id, 19, 'United States Grand Prix', 'Austin', 'Circuit of the Americas', 'United States', '2026-10-25 20:00:00+00', '2026-10-24 21:00:00+00', false, false, NOW(), NOW(), NULL),
+    (season_id, 20, 'Mexico City Grand Prix', 'Mexico City', 'Autódromo Hermanos Rodríguez', 'Mexico', '2026-11-01 20:00:00+00', '2026-10-31 21:00:00+00', false, false, NOW(), NOW(), NULL),
+    (season_id, 21, 'São Paulo Grand Prix', 'São Paulo', 'Autódromo José Carlos Pace', 'Brazil', '2026-11-08 17:00:00+00', '2026-11-07 18:00:00+00', false, false, NOW(), NOW(), NULL),
+    (season_id, 22, 'Las Vegas Grand Prix', 'Las Vegas', 'Las Vegas Street Circuit', 'United States', '2026-11-22 04:00:00+00', '2026-11-21 04:00:00+00', false, false, NOW(), NOW(), NULL),
+    (season_id, 23, 'Qatar Grand Prix', 'Lusail', 'Lusail International Circuit', 'Qatar', '2026-11-29 16:00:00+00', '2026-11-28 18:00:00+00', false, false, NOW(), NOW(), NULL),
+    (season_id, 24, 'Abu Dhabi Grand Prix', 'Abu Dhabi', 'Yas Marina Circuit', 'United Arab Emirates', '2026-12-06 13:00:00+00', '2026-12-05 14:00:00+00', false, false, NOW(), NOW(), NULL)
   ON CONFLICT ("SeasonId", "Round") DO UPDATE SET
     "RaceDate" = EXCLUDED."RaceDate",
     "LockDeadline" = EXCLUDED."LockDeadline",
+    "HasSprint" = EXCLUDED."HasSprint",
     "UpdatedAt" = NOW();
 END $$;


### PR DESCRIPTION
## Summary

- Adds `HasSprint` flag to `Race` entity and defines session enums
- Adds `DriverQualifyingResult`, `DriverRaceResult`, and `TeamRaceScore` entities to support the scoring data model
- Seeds `HasSprint=true` for the 6 official 2026 sprint weekends: China, Miami, Canada, Great Britain, Netherlands, Singapore

## Test plan

- [ ] Migrations apply cleanly against a local database
- [ ] Seed script runs without errors and correctly flags sprint races