### PR TITLE
Race results ingestion

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -13,39 +13,55 @@ API_PID=""
 
 # Run web checks in background if web source files changed
 if [ -n "$WEB_CHANGED" ]; then
-  {
+  (
+    FAILED=0
     echo "Web: Formatting check..."
-    npm run web:format:check || exit 1
+    if ! npm run web:format:check; then FAILED=1; fi
 
-    echo ""
-    echo "Web: Linting..."
-    npm run web:lint || exit 1
+    if [ $FAILED -eq 0 ]; then
+      echo ""
+      echo "Web: Linting..."
+      if ! npm run web:lint; then FAILED=1; fi
+    fi
 
-    echo ""
-    echo "Web: Building..."
-    npm run web:build || exit 1
+    if [ $FAILED -eq 0 ]; then
+      echo ""
+      echo "Web: Building..."
+      if ! npm run web:build; then FAILED=1; fi
+    fi
 
-    echo ""
-    echo "Web: Testing..."
-    npm run web:test || exit 1
-  } > "$WEB_LOG" 2>&1 &
+    if [ $FAILED -eq 0 ]; then
+      echo ""
+      echo "Web: Testing..."
+      if ! npm run web:test; then FAILED=1; fi
+    fi
+
+    exit $FAILED
+  ) > "$WEB_LOG" 2>&1 &
   WEB_PID=$!
 fi
 
 # Run API checks in background if API source files changed
 if [ -n "$API_CHANGED" ]; then
-  {
+  (
+    FAILED=0
     echo "API: Formatting check..."
-    npm run api:format:check || exit 1
+    if ! npm run api:format:check; then FAILED=1; fi
 
-    echo ""
-    echo "API: Building..."
-    npm run api:build || exit 1
+    if [ $FAILED -eq 0 ]; then
+      echo ""
+      echo "API: Building..."
+      if ! npm run api:build; then FAILED=1; fi
+    fi
 
-    echo ""
-    echo "API: Testing..."
-    npm run api:test || exit 1
-  } > "$API_LOG" 2>&1 &
+    if [ $FAILED -eq 0 ]; then
+      echo ""
+      echo "API: Testing..."
+      if ! npm run api:test; then FAILED=1; fi
+    fi
+
+    exit $FAILED
+  ) > "$API_LOG" 2>&1 &
   API_PID=$!
 fi
 

--- a/api/F1CompanionApi.UnitTests/Api/Endpoints/RaceResultEndpointsTests.cs
+++ b/api/F1CompanionApi.UnitTests/Api/Endpoints/RaceResultEndpointsTests.cs
@@ -1,0 +1,414 @@
+using F1CompanionApi.Api.Endpoints;
+using F1CompanionApi.Api.Models;
+using F1CompanionApi.Data.Entities;
+using F1CompanionApi.Domain.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace F1CompanionApi.UnitTests.Api.Endpoints;
+
+public class RaceResultEndpointsTests
+{
+    private readonly Mock<ILogger> _mockLogger;
+    private readonly Mock<IRaceResultService> _mockRaceResultService;
+
+    public RaceResultEndpointsTests()
+    {
+        _mockLogger = new Mock<ILogger>();
+        _mockRaceResultService = new Mock<IRaceResultService>();
+    }
+
+    #region SubmitQualifyingResultsAsync Tests
+
+    [Fact]
+    public async Task SubmitQualifyingResultsAsync_ReturnsOk_WithResults()
+    {
+        // Arrange
+        var raceId = 1;
+        var items = new List<QualifyingResultItem>
+        {
+            new QualifyingResultItem { DriverId = 1, Position = 1 },
+            new QualifyingResultItem { DriverId = 2, Position = 2 },
+        };
+        var expected = new List<DriverQualifyingResultResponse>
+        {
+            new DriverQualifyingResultResponse
+            {
+                Id = 1,
+                DriverId = 1,
+                RaceId = raceId,
+                Position = 1,
+            },
+            new DriverQualifyingResultResponse
+            {
+                Id = 2,
+                DriverId = 2,
+                RaceId = raceId,
+                Position = 2,
+            },
+        };
+
+        _mockRaceResultService
+            .Setup(x => x.SubmitQualifyingResultsAsync(raceId, items))
+            .ReturnsAsync(expected);
+
+        // Act
+        var result = await InvokeSubmitQualifyingResultsAsync(raceId, items);
+
+        // Assert
+        Assert.IsType<Ok<IEnumerable<DriverQualifyingResultResponse>>>(result);
+        _mockRaceResultService.Verify(
+            x => x.SubmitQualifyingResultsAsync(raceId, items),
+            Times.Once
+        );
+    }
+
+    #endregion
+
+    #region GetQualifyingResultsAsync Tests
+
+    [Fact]
+    public async Task GetQualifyingResultsAsync_ReturnsOk_WithResults()
+    {
+        // Arrange
+        var raceId = 1;
+        var expected = new List<DriverQualifyingResultResponse>
+        {
+            new DriverQualifyingResultResponse
+            {
+                Id = 1,
+                DriverId = 1,
+                RaceId = raceId,
+                Position = 1,
+            },
+        };
+
+        _mockRaceResultService
+            .Setup(x => x.GetQualifyingResultsAsync(raceId))
+            .ReturnsAsync(expected);
+
+        // Act
+        var result = await InvokeGetQualifyingResultsAsync(raceId);
+
+        // Assert
+        Assert.IsType<Ok<IEnumerable<DriverQualifyingResultResponse>>>(result);
+    }
+
+    #endregion
+
+    #region SubmitRaceResultsAsync Tests
+
+    [Fact]
+    public async Task SubmitRaceResultsAsync_ReturnsOk_WithResults()
+    {
+        // Arrange
+        var raceId = 1;
+        var items = new List<RaceResultItem>
+        {
+            new RaceResultItem
+            {
+                DriverId = 1,
+                GridPosition = 1,
+                FinishPosition = 1,
+                Overtakes = 0,
+                FastestLap = true,
+                Status = RaceStatus.Classified,
+            },
+        };
+        var expected = new List<DriverRaceResultResponse>
+        {
+            new DriverRaceResultResponse
+            {
+                Id = 1,
+                DriverId = 1,
+                RaceId = raceId,
+                SessionType = SessionType.Race,
+                GridPosition = 1,
+                FinishPosition = 1,
+                Overtakes = 0,
+                FastestLap = true,
+                Status = RaceStatus.Classified,
+            },
+        };
+
+        _mockRaceResultService
+            .Setup(x => x.SubmitRaceResultsAsync(raceId, SessionType.Race, items))
+            .ReturnsAsync(expected);
+
+        // Act
+        var result = await InvokeSubmitRaceResultsAsync(raceId, items);
+
+        // Assert
+        Assert.IsType<Ok<IEnumerable<DriverRaceResultResponse>>>(result);
+        _mockRaceResultService.Verify(
+            x => x.SubmitRaceResultsAsync(raceId, SessionType.Race, items),
+            Times.Once
+        );
+    }
+
+    #endregion
+
+    #region GetRaceResultsAsync Tests
+
+    [Fact]
+    public async Task GetRaceResultsAsync_ReturnsOk_WithResults()
+    {
+        // Arrange
+        var raceId = 1;
+        var expected = new List<DriverRaceResultResponse>
+        {
+            new DriverRaceResultResponse
+            {
+                Id = 1,
+                DriverId = 1,
+                RaceId = raceId,
+                SessionType = SessionType.Race,
+                GridPosition = 3,
+                FinishPosition = 1,
+                Overtakes = 2,
+                FastestLap = false,
+                Status = RaceStatus.Classified,
+            },
+        };
+
+        _mockRaceResultService
+            .Setup(x => x.GetRaceResultsAsync(raceId, SessionType.Race))
+            .ReturnsAsync(expected);
+
+        // Act
+        var result = await InvokeGetRaceResultsAsync(raceId);
+
+        // Assert
+        Assert.IsType<Ok<IEnumerable<DriverRaceResultResponse>>>(result);
+        _mockRaceResultService.Verify(
+            x => x.GetRaceResultsAsync(raceId, SessionType.Race),
+            Times.Once
+        );
+    }
+
+    #endregion
+
+    #region SubmitSprintResultsAsync Tests
+
+    [Fact]
+    public async Task SubmitSprintResultsAsync_ReturnsOk_WithResults()
+    {
+        // Arrange
+        var raceId = 2;
+        var items = new List<RaceResultItem>
+        {
+            new RaceResultItem
+            {
+                DriverId = 5,
+                GridPosition = 2,
+                FinishPosition = 2,
+                Overtakes = 1,
+                FastestLap = false,
+                Status = RaceStatus.Classified,
+            },
+        };
+        var expected = new List<DriverRaceResultResponse>
+        {
+            new DriverRaceResultResponse
+            {
+                Id = 10,
+                DriverId = 5,
+                RaceId = raceId,
+                SessionType = SessionType.Sprint,
+                GridPosition = 2,
+                FinishPosition = 2,
+                Overtakes = 1,
+                FastestLap = false,
+                Status = RaceStatus.Classified,
+            },
+        };
+
+        _mockRaceResultService
+            .Setup(x => x.SubmitRaceResultsAsync(raceId, SessionType.Sprint, items))
+            .ReturnsAsync(expected);
+
+        // Act
+        var result = await InvokeSubmitSprintResultsAsync(raceId, items);
+
+        // Assert
+        Assert.IsType<Ok<IEnumerable<DriverRaceResultResponse>>>(result);
+        _mockRaceResultService.Verify(
+            x => x.SubmitRaceResultsAsync(raceId, SessionType.Sprint, items),
+            Times.Once
+        );
+    }
+
+    #endregion
+
+    #region GetSprintResultsAsync Tests
+
+    [Fact]
+    public async Task GetSprintResultsAsync_ReturnsOk_WithResults()
+    {
+        // Arrange
+        var raceId = 2;
+        var expected = new List<DriverRaceResultResponse>
+        {
+            new DriverRaceResultResponse
+            {
+                Id = 10,
+                DriverId = 5,
+                RaceId = raceId,
+                SessionType = SessionType.Sprint,
+                GridPosition = 2,
+                FinishPosition = 2,
+                Overtakes = 1,
+                FastestLap = false,
+                Status = RaceStatus.Classified,
+            },
+        };
+
+        _mockRaceResultService
+            .Setup(x => x.GetRaceResultsAsync(raceId, SessionType.Sprint))
+            .ReturnsAsync(expected);
+
+        // Act
+        var result = await InvokeGetSprintResultsAsync(raceId);
+
+        // Assert
+        Assert.IsType<Ok<IEnumerable<DriverRaceResultResponse>>>(result);
+        _mockRaceResultService.Verify(
+            x => x.GetRaceResultsAsync(raceId, SessionType.Sprint),
+            Times.Once
+        );
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private async Task<IResult> InvokeSubmitQualifyingResultsAsync(
+        int raceId,
+        List<QualifyingResultItem> items
+    )
+    {
+        var method = typeof(RaceResultEndpoints).GetMethod(
+            "SubmitQualifyingResultsAsync",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static
+        );
+
+        var task =
+            (Task<IResult>)
+                method!.Invoke(
+                    null,
+                    new object[]
+                    {
+                        _mockRaceResultService.Object,
+                        raceId,
+                        items,
+                        _mockLogger.Object,
+                    }
+                )!;
+
+        return await task;
+    }
+
+    private async Task<IResult> InvokeGetQualifyingResultsAsync(int raceId)
+    {
+        var method = typeof(RaceResultEndpoints).GetMethod(
+            "GetQualifyingResultsAsync",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static
+        );
+
+        var task =
+            (Task<IResult>)
+                method!.Invoke(
+                    null,
+                    new object[] { _mockRaceResultService.Object, raceId, _mockLogger.Object }
+                )!;
+
+        return await task;
+    }
+
+    private async Task<IResult> InvokeSubmitRaceResultsAsync(int raceId, List<RaceResultItem> items)
+    {
+        var method = typeof(RaceResultEndpoints).GetMethod(
+            "SubmitRaceResultsAsync",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static
+        );
+
+        var task =
+            (Task<IResult>)
+                method!.Invoke(
+                    null,
+                    new object[]
+                    {
+                        _mockRaceResultService.Object,
+                        raceId,
+                        items,
+                        _mockLogger.Object,
+                    }
+                )!;
+
+        return await task;
+    }
+
+    private async Task<IResult> InvokeGetRaceResultsAsync(int raceId)
+    {
+        var method = typeof(RaceResultEndpoints).GetMethod(
+            "GetRaceResultsAsync",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static
+        );
+
+        var task =
+            (Task<IResult>)
+                method!.Invoke(
+                    null,
+                    new object[] { _mockRaceResultService.Object, raceId, _mockLogger.Object }
+                )!;
+
+        return await task;
+    }
+
+    private async Task<IResult> InvokeSubmitSprintResultsAsync(
+        int raceId,
+        List<RaceResultItem> items
+    )
+    {
+        var method = typeof(RaceResultEndpoints).GetMethod(
+            "SubmitSprintResultsAsync",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static
+        );
+
+        var task =
+            (Task<IResult>)
+                method!.Invoke(
+                    null,
+                    new object[]
+                    {
+                        _mockRaceResultService.Object,
+                        raceId,
+                        items,
+                        _mockLogger.Object,
+                    }
+                )!;
+
+        return await task;
+    }
+
+    private async Task<IResult> InvokeGetSprintResultsAsync(int raceId)
+    {
+        var method = typeof(RaceResultEndpoints).GetMethod(
+            "GetSprintResultsAsync",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static
+        );
+
+        var task =
+            (Task<IResult>)
+                method!.Invoke(
+                    null,
+                    new object[] { _mockRaceResultService.Object, raceId, _mockLogger.Object }
+                )!;
+
+        return await task;
+    }
+
+    #endregion
+}

--- a/api/F1CompanionApi.UnitTests/Services/RaceResultServiceTests.cs
+++ b/api/F1CompanionApi.UnitTests/Services/RaceResultServiceTests.cs
@@ -1,0 +1,564 @@
+using F1CompanionApi.Api.Models;
+using F1CompanionApi.Data;
+using F1CompanionApi.Data.Entities;
+using F1CompanionApi.Domain.Exceptions;
+using F1CompanionApi.Domain.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace F1CompanionApi.UnitTests.Services;
+
+public class RaceResultServiceTests
+{
+    private readonly Mock<ILogger<RaceResultService>> _mockLogger;
+
+    public RaceResultServiceTests()
+    {
+        _mockLogger = new Mock<ILogger<RaceResultService>>();
+    }
+
+    private ApplicationDbContext CreateInMemoryContext()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new ApplicationDbContext(options);
+    }
+
+    private static Driver CreateDriver(int id, string abbreviation = "TST") =>
+        new()
+        {
+            Id = id,
+            FirstName = "Test",
+            LastName = "Driver",
+            Abbreviation = abbreviation,
+            CountryAbbreviation = "GB",
+        };
+
+    private static Race CreateRace(int id, bool hasSprint = false) =>
+        new()
+        {
+            Id = id,
+            SeasonId = 1,
+            Round = id,
+            Name = $"Race {id}",
+            Location = "Location",
+            Circuit = "Circuit",
+            Country = "Country",
+            RaceDate = DateTime.UtcNow,
+            HasSprint = hasSprint,
+        };
+
+    private static QualifyingResultItem QualItem(int driverId, int position) =>
+        new() { DriverId = driverId, Position = position };
+
+    private static RaceResultItem RaceItem(
+        int driverId,
+        int grid = 1,
+        int? finish = 1,
+        RaceStatus status = RaceStatus.Classified
+    ) =>
+        new()
+        {
+            DriverId = driverId,
+            GridPosition = grid,
+            FinishPosition = finish,
+            Overtakes = 0,
+            FastestLap = false,
+            Status = status,
+        };
+
+    #region SubmitQualifyingResultsAsync
+
+    [Fact]
+    public async Task SubmitQualifyingResultsAsync_CreatesResults_WhenNoneExist()
+    {
+        using var context = CreateInMemoryContext();
+        context.Drivers.Add(CreateDriver(1, "VER"));
+        context.Drivers.Add(CreateDriver(2, "HAM"));
+        context.Races.Add(CreateRace(10));
+        await context.SaveChangesAsync();
+
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        var result = await service.SubmitQualifyingResultsAsync(
+            10,
+            [QualItem(1, 1), QualItem(2, 2)]
+        );
+
+        Assert.Equal(2, result.Count());
+        Assert.Equal(2, await context.DriverQualifyingResults.CountAsync());
+    }
+
+    [Fact]
+    public async Task SubmitQualifyingResultsAsync_ReplacesExistingResults()
+    {
+        using var context = CreateInMemoryContext();
+        context.Drivers.Add(CreateDriver(1, "VER"));
+        context.Races.Add(CreateRace(10));
+        context.DriverQualifyingResults.Add(
+            new DriverQualifyingResult
+            {
+                DriverId = 1,
+                RaceId = 10,
+                Position = 5,
+            }
+        );
+        await context.SaveChangesAsync();
+
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        await service.SubmitQualifyingResultsAsync(10, [QualItem(1, 1)]);
+
+        var saved = await context.DriverQualifyingResults.SingleAsync();
+        Assert.Equal(1, saved.Position);
+        Assert.Equal(1, await context.DriverQualifyingResults.CountAsync());
+    }
+
+    [Fact]
+    public async Task SubmitQualifyingResultsAsync_ThrowsKeyNotFoundException_WhenRaceNotFound()
+    {
+        using var context = CreateInMemoryContext();
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        await Assert.ThrowsAsync<KeyNotFoundException>(() =>
+            service.SubmitQualifyingResultsAsync(99, [QualItem(1, 1)])
+        );
+    }
+
+    [Fact]
+    public async Task SubmitQualifyingResultsAsync_ThrowsArgumentException_WhenDuplicateDriverIds()
+    {
+        using var context = CreateInMemoryContext();
+        context.Races.Add(CreateRace(10));
+        await context.SaveChangesAsync();
+
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.SubmitQualifyingResultsAsync(10, [QualItem(1, 1), QualItem(1, 2)])
+        );
+    }
+
+    [Fact]
+    public async Task SubmitQualifyingResultsAsync_ThrowsArgumentException_WhenDriverNotFound()
+    {
+        using var context = CreateInMemoryContext();
+        context.Races.Add(CreateRace(10));
+        await context.SaveChangesAsync();
+
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.SubmitQualifyingResultsAsync(10, [QualItem(99, 1)])
+        );
+    }
+
+    [Fact]
+    public async Task SubmitQualifyingResultsAsync_ReturnsEmpty_WhenEmptyBatch()
+    {
+        using var context = CreateInMemoryContext();
+        context.Races.Add(CreateRace(10));
+        await context.SaveChangesAsync();
+
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        var result = await service.SubmitQualifyingResultsAsync(10, []);
+
+        Assert.Empty(result);
+    }
+
+    #endregion
+
+    #region SubmitRaceResultsAsync
+
+    [Fact]
+    public async Task SubmitRaceResultsAsync_CreatesResults_WhenNoneExist()
+    {
+        using var context = CreateInMemoryContext();
+        context.Drivers.Add(CreateDriver(1, "VER"));
+        context.Races.Add(CreateRace(10));
+        await context.SaveChangesAsync();
+
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        var result = await service.SubmitRaceResultsAsync(
+            10,
+            SessionType.Race,
+            [RaceItem(1, grid: 1, finish: 1)]
+        );
+
+        Assert.Single(result);
+        Assert.Equal(1, await context.DriverRaceResults.CountAsync());
+    }
+
+    [Fact]
+    public async Task SubmitRaceResultsAsync_ReplacesExistingResults()
+    {
+        using var context = CreateInMemoryContext();
+        context.Drivers.Add(CreateDriver(1, "VER"));
+        context.Races.Add(CreateRace(10));
+        context.DriverRaceResults.Add(
+            new DriverRaceResult
+            {
+                DriverId = 1,
+                RaceId = 10,
+                SessionType = SessionType.Race,
+                GridPosition = 5,
+                FinishPosition = 3,
+                Overtakes = 2,
+                FastestLap = false,
+                Status = RaceStatus.Classified,
+            }
+        );
+        await context.SaveChangesAsync();
+
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        await service.SubmitRaceResultsAsync(
+            10,
+            SessionType.Race,
+            [RaceItem(1, grid: 1, finish: 1)]
+        );
+
+        var saved = await context.DriverRaceResults.SingleAsync();
+        Assert.Equal(1, saved.GridPosition);
+        Assert.Equal(1, saved.FinishPosition);
+        Assert.Equal(1, await context.DriverRaceResults.CountAsync());
+    }
+
+    [Fact]
+    public async Task SubmitRaceResultsAsync_ThrowsKeyNotFoundException_WhenRaceNotFound()
+    {
+        using var context = CreateInMemoryContext();
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        await Assert.ThrowsAsync<KeyNotFoundException>(() =>
+            service.SubmitRaceResultsAsync(99, SessionType.Race, [RaceItem(1)])
+        );
+    }
+
+    [Fact]
+    public async Task SubmitRaceResultsAsync_ThrowsSprintNotAvailableException_WhenRaceHasNoSprint()
+    {
+        using var context = CreateInMemoryContext();
+        context.Races.Add(CreateRace(10, hasSprint: false));
+        await context.SaveChangesAsync();
+
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        await Assert.ThrowsAsync<SprintNotAvailableException>(() =>
+            service.SubmitRaceResultsAsync(10, SessionType.Sprint, [RaceItem(1)])
+        );
+    }
+
+    [Fact]
+    public async Task SubmitRaceResultsAsync_AllowsSprint_WhenRaceHasSprint()
+    {
+        using var context = CreateInMemoryContext();
+        context.Drivers.Add(CreateDriver(1, "VER"));
+        context.Races.Add(CreateRace(10, hasSprint: true));
+        await context.SaveChangesAsync();
+
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        var result = await service.SubmitRaceResultsAsync(
+            10,
+            SessionType.Sprint,
+            [RaceItem(1, grid: 1, finish: 1)]
+        );
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task SubmitRaceResultsAsync_ThrowsArgumentException_WhenDuplicateDriverIds()
+    {
+        using var context = CreateInMemoryContext();
+        context.Races.Add(CreateRace(10));
+        await context.SaveChangesAsync();
+
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.SubmitRaceResultsAsync(
+                10,
+                SessionType.Race,
+                [RaceItem(1, grid: 1, finish: 1), RaceItem(1, grid: 2, finish: 2)]
+            )
+        );
+    }
+
+    [Fact]
+    public async Task SubmitRaceResultsAsync_ThrowsArgumentException_WhenDriverNotFound()
+    {
+        using var context = CreateInMemoryContext();
+        context.Races.Add(CreateRace(10));
+        await context.SaveChangesAsync();
+
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.SubmitRaceResultsAsync(10, SessionType.Race, [RaceItem(99)])
+        );
+    }
+
+    [Fact]
+    public async Task SubmitRaceResultsAsync_ThrowsArgumentException_WhenMultipleFastestLaps()
+    {
+        using var context = CreateInMemoryContext();
+        context.Races.Add(CreateRace(10));
+        await context.SaveChangesAsync();
+
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        var items = new List<RaceResultItem>
+        {
+            new()
+            {
+                DriverId = 1,
+                GridPosition = 1,
+                FinishPosition = 1,
+                Overtakes = 0,
+                FastestLap = true,
+                Status = RaceStatus.Classified,
+            },
+            new()
+            {
+                DriverId = 2,
+                GridPosition = 2,
+                FinishPosition = 2,
+                Overtakes = 0,
+                FastestLap = true,
+                Status = RaceStatus.Classified,
+            },
+        };
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.SubmitRaceResultsAsync(10, SessionType.Race, items)
+        );
+    }
+
+    [Theory]
+    [InlineData(RaceStatus.DNF)]
+    [InlineData(RaceStatus.DSQ)]
+    [InlineData(RaceStatus.DNS)]
+    public async Task SubmitRaceResultsAsync_ThrowsArgumentException_WhenFinishPositionSetForNonClassified(
+        RaceStatus status
+    )
+    {
+        using var context = CreateInMemoryContext();
+        context.Races.Add(CreateRace(10));
+        await context.SaveChangesAsync();
+
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.SubmitRaceResultsAsync(
+                10,
+                SessionType.Race,
+                [RaceItem(1, grid: 1, finish: 1, status: status)]
+            )
+        );
+    }
+
+    [Fact]
+    public async Task SubmitRaceResultsAsync_ThrowsArgumentException_WhenFinishPositionNullForClassified()
+    {
+        using var context = CreateInMemoryContext();
+        context.Races.Add(CreateRace(10));
+        await context.SaveChangesAsync();
+
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.SubmitRaceResultsAsync(
+                10,
+                SessionType.Race,
+                [RaceItem(1, grid: 1, finish: null, status: RaceStatus.Classified)]
+            )
+        );
+    }
+
+    [Fact]
+    public async Task SubmitRaceResultsAsync_ReturnsEmpty_WhenEmptyBatch()
+    {
+        using var context = CreateInMemoryContext();
+        context.Races.Add(CreateRace(10));
+        await context.SaveChangesAsync();
+
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        var result = await service.SubmitRaceResultsAsync(10, SessionType.Race, []);
+
+        Assert.Empty(result);
+    }
+
+    #endregion
+
+    #region GetQualifyingResultsAsync
+
+    [Fact]
+    public async Task GetQualifyingResultsAsync_ReturnsResults_OrderedByPosition()
+    {
+        using var context = CreateInMemoryContext();
+        context.DriverQualifyingResults.AddRange(
+            new DriverQualifyingResult
+            {
+                DriverId = 2,
+                RaceId = 10,
+                Position = 2,
+            },
+            new DriverQualifyingResult
+            {
+                DriverId = 1,
+                RaceId = 10,
+                Position = 1,
+            }
+        );
+        await context.SaveChangesAsync();
+
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        var result = (await service.GetQualifyingResultsAsync(10)).ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(1, result[0].Position);
+        Assert.Equal(2, result[1].Position);
+    }
+
+    [Fact]
+    public async Task GetQualifyingResultsAsync_ReturnsEmpty_WhenNoResults()
+    {
+        using var context = CreateInMemoryContext();
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        var result = await service.GetQualifyingResultsAsync(10);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetQualifyingResultsAsync_ReturnsOnlyResultsForSpecifiedRace()
+    {
+        using var context = CreateInMemoryContext();
+        context.DriverQualifyingResults.AddRange(
+            new DriverQualifyingResult
+            {
+                DriverId = 1,
+                RaceId = 10,
+                Position = 1,
+            },
+            new DriverQualifyingResult
+            {
+                DriverId = 1,
+                RaceId = 11,
+                Position = 3,
+            }
+        );
+        await context.SaveChangesAsync();
+
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        var result = (await service.GetQualifyingResultsAsync(10)).ToList();
+
+        Assert.Single(result);
+        Assert.Equal(10, result[0].RaceId);
+    }
+
+    #endregion
+
+    #region GetRaceResultsAsync
+
+    [Fact]
+    public async Task GetRaceResultsAsync_ReturnsResults_OrderedByFinishPosition()
+    {
+        using var context = CreateInMemoryContext();
+        context.DriverRaceResults.AddRange(
+            new DriverRaceResult
+            {
+                DriverId = 2,
+                RaceId = 10,
+                SessionType = SessionType.Race,
+                GridPosition = 2,
+                FinishPosition = 2,
+                Overtakes = 0,
+                FastestLap = false,
+                Status = RaceStatus.Classified,
+            },
+            new DriverRaceResult
+            {
+                DriverId = 1,
+                RaceId = 10,
+                SessionType = SessionType.Race,
+                GridPosition = 1,
+                FinishPosition = 1,
+                Overtakes = 0,
+                FastestLap = true,
+                Status = RaceStatus.Classified,
+            }
+        );
+        await context.SaveChangesAsync();
+
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        var result = (await service.GetRaceResultsAsync(10, SessionType.Race)).ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(1, result[0].FinishPosition);
+        Assert.Equal(2, result[1].FinishPosition);
+    }
+
+    [Fact]
+    public async Task GetRaceResultsAsync_ReturnsEmpty_WhenNoResults()
+    {
+        using var context = CreateInMemoryContext();
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        var result = await service.GetRaceResultsAsync(10, SessionType.Race);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetRaceResultsAsync_ReturnsOnlyResultsForSpecifiedSessionType()
+    {
+        using var context = CreateInMemoryContext();
+        context.DriverRaceResults.AddRange(
+            new DriverRaceResult
+            {
+                DriverId = 1,
+                RaceId = 10,
+                SessionType = SessionType.Race,
+                GridPosition = 1,
+                FinishPosition = 1,
+                Overtakes = 0,
+                FastestLap = false,
+                Status = RaceStatus.Classified,
+            },
+            new DriverRaceResult
+            {
+                DriverId = 1,
+                RaceId = 10,
+                SessionType = SessionType.Sprint,
+                GridPosition = 2,
+                FinishPosition = 2,
+                Overtakes = 0,
+                FastestLap = false,
+                Status = RaceStatus.Classified,
+            }
+        );
+        await context.SaveChangesAsync();
+
+        var service = new RaceResultService(context, _mockLogger.Object);
+
+        var result = (await service.GetRaceResultsAsync(10, SessionType.Race)).ToList();
+
+        Assert.Single(result);
+        Assert.Equal(SessionType.Race, result[0].SessionType);
+    }
+
+    #endregion
+}

--- a/api/F1CompanionApi.UnitTests/Services/RaceResultServiceTests.cs
+++ b/api/F1CompanionApi.UnitTests/Services/RaceResultServiceTests.cs
@@ -83,12 +83,8 @@ public class RaceResultServiceTests
 
         var service = new RaceResultService(context, _mockLogger.Object);
 
-        var result = await service.SubmitQualifyingResultsAsync(
-            10,
-            [QualItem(1, 1), QualItem(2, 2)]
-        );
+        await service.SubmitQualifyingResultsAsync(10, [QualItem(1, 1), QualItem(2, 2)]);
 
-        Assert.Equal(2, result.Count());
         Assert.Equal(2, await context.DriverQualifyingResults.CountAsync());
     }
 
@@ -184,13 +180,12 @@ public class RaceResultServiceTests
 
         var service = new RaceResultService(context, _mockLogger.Object);
 
-        var result = await service.SubmitRaceResultsAsync(
+        await service.SubmitRaceResultsAsync(
             10,
             SessionType.Race,
             [RaceItem(1, grid: 1, finish: 1)]
         );
 
-        Assert.Single(result);
         Assert.Equal(1, await context.DriverRaceResults.CountAsync());
     }
 
@@ -430,17 +425,6 @@ public class RaceResultServiceTests
     }
 
     [Fact]
-    public async Task GetQualifyingResultsAsync_ReturnsEmpty_WhenNoResults()
-    {
-        using var context = CreateInMemoryContext();
-        var service = new RaceResultService(context, _mockLogger.Object);
-
-        var result = await service.GetQualifyingResultsAsync(10);
-
-        Assert.Empty(result);
-    }
-
-    [Fact]
     public async Task GetQualifyingResultsAsync_ReturnsOnlyResultsForSpecifiedRace()
     {
         using var context = CreateInMemoryContext();
@@ -509,17 +493,6 @@ public class RaceResultServiceTests
         Assert.Equal(2, result.Count);
         Assert.Equal(1, result[0].FinishPosition);
         Assert.Equal(2, result[1].FinishPosition);
-    }
-
-    [Fact]
-    public async Task GetRaceResultsAsync_ReturnsEmpty_WhenNoResults()
-    {
-        using var context = CreateInMemoryContext();
-        var service = new RaceResultService(context, _mockLogger.Object);
-
-        var result = await service.GetRaceResultsAsync(10, SessionType.Race);
-
-        Assert.Empty(result);
     }
 
     [Fact]

--- a/api/F1CompanionApi.UnitTests/Services/SupabaseAuthServiceTests.cs
+++ b/api/F1CompanionApi.UnitTests/Services/SupabaseAuthServiceTests.cs
@@ -1,224 +1,25 @@
-using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
-using System.Text;
 using F1CompanionApi.Domain.Services;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
-using Microsoft.IdentityModel.Tokens;
 using Moq;
 
 namespace F1CompanionApi.UnitTests.Services;
 
 public class SupabaseAuthServiceTests
 {
-    private const string TestJwtSecret = "test-secret-key-that-is-long-enough-for-hmac-sha256";
     private const string TestUserId = "test-user-id-123";
     private const string TestUserEmail = "test@example.com";
-
-    private static IConfiguration CreateConfiguration()
-    {
-        var configData = new Dictionary<string, string?>
-        {
-            { "Supabase:JwtSecret", TestJwtSecret },
-        };
-
-        return new ConfigurationBuilder().AddInMemoryCollection(configData).Build();
-    }
-
-    private static string GenerateValidToken(string userId, string email)
-    {
-        var tokenHandler = new JwtSecurityTokenHandler();
-        var key = Encoding.UTF8.GetBytes(TestJwtSecret);
-
-        var tokenDescriptor = new SecurityTokenDescriptor
-        {
-            Subject = new ClaimsIdentity([
-                new Claim(ClaimTypes.NameIdentifier, userId),
-                new Claim(ClaimTypes.Email, email),
-                new Claim("email", email),
-            ]),
-            Expires = DateTime.UtcNow.AddHours(1),
-            SigningCredentials = new SigningCredentials(
-                new SymmetricSecurityKey(key),
-                SecurityAlgorithms.HmacSha256Signature
-            ),
-            Audience = "authenticated",
-        };
-
-        var token = tokenHandler.CreateToken(tokenDescriptor);
-        return tokenHandler.WriteToken(token);
-    }
-
-    private static string GenerateExpiredToken(string userId, string email)
-    {
-        var tokenHandler = new JwtSecurityTokenHandler();
-        var key = Encoding.UTF8.GetBytes(TestJwtSecret);
-
-        var tokenDescriptor = new SecurityTokenDescriptor
-        {
-            Subject = new ClaimsIdentity([
-                new Claim(ClaimTypes.NameIdentifier, userId),
-                new Claim(ClaimTypes.Email, email),
-            ]),
-            NotBefore = DateTime.UtcNow.AddHours(-2),
-            Expires = DateTime.UtcNow.AddHours(-1),
-            SigningCredentials = new SigningCredentials(
-                new SymmetricSecurityKey(key),
-                SecurityAlgorithms.HmacSha256Signature
-            ),
-            Audience = "authenticated",
-        };
-
-        var token = tokenHandler.CreateToken(tokenDescriptor);
-        return tokenHandler.WriteToken(token);
-    }
-
-    [Fact]
-    public void Constructor_MissingJwtSecret_ThrowsInvalidOperationException()
-    {
-        // Arrange
-        var configData = new Dictionary<string, string?>();
-        var config = new ConfigurationBuilder().AddInMemoryCollection(configData).Build();
-
-        var httpContextAccessor = new Mock<IHttpContextAccessor>();
-
-        // Act & Assert
-        var exception = Assert.Throws<InvalidOperationException>(() =>
-            new SupabaseAuthService(config, httpContextAccessor.Object)
-        );
-        Assert.Contains("Supabase JWT secret not configured", exception.Message);
-    }
 
     [Fact]
     public void Constructor_NullHttpContextAccessor_ThrowsArgumentNullException()
     {
-        // Arrange
-        var config = CreateConfiguration();
-
-        // Act & Assert
-        Assert.Throws<ArgumentNullException>(() => new SupabaseAuthService(config, null!));
-    }
-
-    [Fact]
-    public void ValidateToken_ValidToken_ReturnsClaimsPrincipalWithCorrectClaims()
-    {
-        // Arrange
-        var config = CreateConfiguration();
-        var httpContextAccessor = new Mock<IHttpContextAccessor>();
-        var service = new SupabaseAuthService(config, httpContextAccessor.Object);
-
-        var token = GenerateValidToken(TestUserId, TestUserEmail);
-
-        // Act
-        var result = service.ValidateToken(token);
-
-        // Assert
-        Assert.NotNull(result);
-        Assert.Equal(TestUserId, result.FindFirst(ClaimTypes.NameIdentifier)?.Value);
-        Assert.Equal(TestUserEmail, result.FindFirst(ClaimTypes.Email)?.Value);
-    }
-
-    [Fact]
-    public void ValidateToken_ExpiredToken_ReturnsNull()
-    {
-        // Arrange
-        var config = CreateConfiguration();
-        var httpContextAccessor = new Mock<IHttpContextAccessor>();
-        var service = new SupabaseAuthService(config, httpContextAccessor.Object);
-
-        var token = GenerateExpiredToken(TestUserId, TestUserEmail);
-
-        // Act
-        var result = service.ValidateToken(token);
-
-        // Assert
-        Assert.Null(result);
-    }
-
-    [Fact]
-    public void ValidateToken_InvalidSignature_ReturnsNull()
-    {
-        // Arrange
-        var config = CreateConfiguration();
-        var httpContextAccessor = new Mock<IHttpContextAccessor>();
-        var service = new SupabaseAuthService(config, httpContextAccessor.Object);
-
-        var tokenHandler = new JwtSecurityTokenHandler();
-        var wrongKey = Encoding.UTF8.GetBytes("wrong-secret-key-that-is-long-enough-for-hmac");
-
-        var tokenDescriptor = new SecurityTokenDescriptor
-        {
-            Subject = new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, TestUserId)]),
-            Expires = DateTime.UtcNow.AddHours(1),
-            SigningCredentials = new SigningCredentials(
-                new SymmetricSecurityKey(wrongKey),
-                SecurityAlgorithms.HmacSha256Signature
-            ),
-            Audience = "authenticated",
-        };
-
-        var token = tokenHandler.CreateToken(tokenDescriptor);
-        var tokenString = tokenHandler.WriteToken(token);
-
-        // Act
-        var result = service.ValidateToken(tokenString);
-
-        // Assert
-        Assert.Null(result);
-    }
-
-    [Fact]
-    public void ValidateToken_MalformedToken_ReturnsNull()
-    {
-        // Arrange
-        var config = CreateConfiguration();
-        var httpContextAccessor = new Mock<IHttpContextAccessor>();
-        var service = new SupabaseAuthService(config, httpContextAccessor.Object);
-
-        // Act
-        var result = service.ValidateToken("not-a-valid-jwt-token");
-
-        // Assert
-        Assert.Null(result);
-    }
-
-    [Fact]
-    public void ValidateToken_WrongAudience_ReturnsNull()
-    {
-        // Arrange
-        var config = CreateConfiguration();
-        var httpContextAccessor = new Mock<IHttpContextAccessor>();
-        var service = new SupabaseAuthService(config, httpContextAccessor.Object);
-
-        var tokenHandler = new JwtSecurityTokenHandler();
-        var key = Encoding.UTF8.GetBytes(TestJwtSecret);
-
-        var tokenDescriptor = new SecurityTokenDescriptor
-        {
-            Subject = new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, TestUserId)]),
-            Expires = DateTime.UtcNow.AddHours(1),
-            SigningCredentials = new SigningCredentials(
-                new SymmetricSecurityKey(key),
-                SecurityAlgorithms.HmacSha256Signature
-            ),
-            Audience = "wrong-audience",
-        };
-
-        var token = tokenHandler.CreateToken(tokenDescriptor);
-        var tokenString = tokenHandler.WriteToken(token);
-
-        // Act
-        var result = service.ValidateToken(tokenString);
-
-        // Assert
-        Assert.Null(result);
+        Assert.Throws<ArgumentNullException>(() => new SupabaseAuthService(null!));
     }
 
     [Fact]
     public void GetUserId_UserIdClaimExists_ReturnsUserId()
     {
         // Arrange
-        var config = CreateConfiguration();
         var httpContextAccessor = new Mock<IHttpContextAccessor>();
         var httpContext = new DefaultHttpContext();
 
@@ -228,7 +29,7 @@ public class SupabaseAuthServiceTests
 
         httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
-        var service = new SupabaseAuthService(config, httpContextAccessor.Object);
+        var service = new SupabaseAuthService(httpContextAccessor.Object);
 
         // Act
         var result = service.GetUserId();
@@ -241,17 +42,15 @@ public class SupabaseAuthServiceTests
     public void GetUserId_NoUserIdClaim_ReturnsNull()
     {
         // Arrange
-        var config = CreateConfiguration();
         var httpContextAccessor = new Mock<IHttpContextAccessor>();
         var httpContext = new DefaultHttpContext();
 
-        var claims = Array.Empty<Claim>();
-        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var identity = new ClaimsIdentity(Array.Empty<Claim>(), "TestAuth");
         httpContext.User = new ClaimsPrincipal(identity);
 
         httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
-        var service = new SupabaseAuthService(config, httpContextAccessor.Object);
+        var service = new SupabaseAuthService(httpContextAccessor.Object);
 
         // Act
         var result = service.GetUserId();
@@ -264,11 +63,10 @@ public class SupabaseAuthServiceTests
     public void GetUserId_NoHttpContext_ReturnsNull()
     {
         // Arrange
-        var config = CreateConfiguration();
         var httpContextAccessor = new Mock<IHttpContextAccessor>();
         httpContextAccessor.Setup(x => x.HttpContext).Returns((HttpContext?)null);
 
-        var service = new SupabaseAuthService(config, httpContextAccessor.Object);
+        var service = new SupabaseAuthService(httpContextAccessor.Object);
 
         // Act
         var result = service.GetUserId();
@@ -281,7 +79,6 @@ public class SupabaseAuthServiceTests
     public void GetRequiredUserId_UserIdExists_ReturnsUserId()
     {
         // Arrange
-        var config = CreateConfiguration();
         var httpContextAccessor = new Mock<IHttpContextAccessor>();
         var httpContext = new DefaultHttpContext();
 
@@ -291,7 +88,7 @@ public class SupabaseAuthServiceTests
 
         httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
-        var service = new SupabaseAuthService(config, httpContextAccessor.Object);
+        var service = new SupabaseAuthService(httpContextAccessor.Object);
 
         // Act
         var result = service.GetRequiredUserId();
@@ -304,17 +101,15 @@ public class SupabaseAuthServiceTests
     public void GetRequiredUserId_UserIdDoesNotExist_ThrowsInvalidOperationException()
     {
         // Arrange
-        var config = CreateConfiguration();
         var httpContextAccessor = new Mock<IHttpContextAccessor>();
         var httpContext = new DefaultHttpContext();
 
-        var claims = Array.Empty<Claim>();
-        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var identity = new ClaimsIdentity(Array.Empty<Claim>(), "TestAuth");
         httpContext.User = new ClaimsPrincipal(identity);
 
         httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
-        var service = new SupabaseAuthService(config, httpContextAccessor.Object);
+        var service = new SupabaseAuthService(httpContextAccessor.Object);
 
         // Act & Assert
         var exception = Assert.Throws<InvalidOperationException>(() => service.GetRequiredUserId());
@@ -325,7 +120,6 @@ public class SupabaseAuthServiceTests
     public void GetUserEmail_EmailClaimExists_ReturnsEmail()
     {
         // Arrange
-        var config = CreateConfiguration();
         var httpContextAccessor = new Mock<IHttpContextAccessor>();
         var httpContext = new DefaultHttpContext();
 
@@ -335,7 +129,7 @@ public class SupabaseAuthServiceTests
 
         httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
-        var service = new SupabaseAuthService(config, httpContextAccessor.Object);
+        var service = new SupabaseAuthService(httpContextAccessor.Object);
 
         // Act
         var result = service.GetUserEmail();
@@ -348,7 +142,6 @@ public class SupabaseAuthServiceTests
     public void GetUserEmail_FallsBackToLowercaseEmailClaim_ReturnsEmail()
     {
         // Arrange
-        var config = CreateConfiguration();
         var httpContextAccessor = new Mock<IHttpContextAccessor>();
         var httpContext = new DefaultHttpContext();
 
@@ -358,7 +151,7 @@ public class SupabaseAuthServiceTests
 
         httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
-        var service = new SupabaseAuthService(config, httpContextAccessor.Object);
+        var service = new SupabaseAuthService(httpContextAccessor.Object);
 
         // Act
         var result = service.GetUserEmail();
@@ -371,17 +164,15 @@ public class SupabaseAuthServiceTests
     public void GetUserEmail_NoEmailClaim_ReturnsNull()
     {
         // Arrange
-        var config = CreateConfiguration();
         var httpContextAccessor = new Mock<IHttpContextAccessor>();
         var httpContext = new DefaultHttpContext();
 
-        var claims = Array.Empty<Claim>();
-        var identity = new ClaimsIdentity(claims, "TestAuth");
+        var identity = new ClaimsIdentity(Array.Empty<Claim>(), "TestAuth");
         httpContext.User = new ClaimsPrincipal(identity);
 
         httpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
 
-        var service = new SupabaseAuthService(config, httpContextAccessor.Object);
+        var service = new SupabaseAuthService(httpContextAccessor.Object);
 
         // Act
         var result = service.GetUserEmail();
@@ -394,11 +185,10 @@ public class SupabaseAuthServiceTests
     public void GetUserEmail_NoHttpContext_ReturnsNull()
     {
         // Arrange
-        var config = CreateConfiguration();
         var httpContextAccessor = new Mock<IHttpContextAccessor>();
         httpContextAccessor.Setup(x => x.HttpContext).Returns((HttpContext?)null);
 
-        var service = new SupabaseAuthService(config, httpContextAccessor.Object);
+        var service = new SupabaseAuthService(httpContextAccessor.Object);
 
         // Act
         var result = service.GetUserEmail();

--- a/api/F1CompanionApi/Api/Endpoints/Endpoints.cs
+++ b/api/F1CompanionApi/Api/Endpoints/Endpoints.cs
@@ -13,6 +13,7 @@ public static class Endpoints
             .MapLeagueEndpoints()
             .MapMeEndpoints()
             .MapRaceEndpoints()
+            .MapRaceResultEndpoints()
             .MapSeasonEndpoints()
             .MapTeamEndpoints();
 

--- a/api/F1CompanionApi/Api/Endpoints/RaceResultEndpoints.cs
+++ b/api/F1CompanionApi/Api/Endpoints/RaceResultEndpoints.cs
@@ -1,0 +1,141 @@
+using System.Diagnostics.CodeAnalysis;
+using F1CompanionApi.Api.Models;
+using F1CompanionApi.Data.Entities;
+using F1CompanionApi.Domain.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace F1CompanionApi.Api.Endpoints;
+
+public static class RaceResultEndpoints
+{
+    [ExcludeFromCodeCoverage]
+    public static IEndpointRouteBuilder MapRaceResultEndpoints(this IEndpointRouteBuilder app)
+    {
+        var resultsGroup = app.MapGroup("/races/{raceId}/results")
+            .RequireAuthorization()
+            .WithOpenApi();
+
+        resultsGroup
+            .MapPut("/qualifying", SubmitQualifyingResultsAsync)
+            .WithName("SubmitQualifyingResults")
+            .WithDescription(
+                "Submit qualifying results for a race, replacing any existing results"
+            );
+
+        resultsGroup
+            .MapGet("/qualifying", GetQualifyingResultsAsync)
+            .WithName("GetQualifyingResults")
+            .WithDescription("Get qualifying results for a race");
+
+        resultsGroup
+            .MapPut("/race", SubmitRaceResultsAsync)
+            .WithName("SubmitRaceResults")
+            .WithDescription("Submit race results for a race, replacing any existing results");
+
+        resultsGroup
+            .MapGet("/race", GetRaceResultsAsync)
+            .WithName("GetRaceResults")
+            .WithDescription("Get race results for a race");
+
+        resultsGroup
+            .MapPut("/sprint", SubmitSprintResultsAsync)
+            .WithName("SubmitSprintResults")
+            .WithDescription("Submit sprint results for a race, replacing any existing results");
+
+        resultsGroup
+            .MapGet("/sprint", GetSprintResultsAsync)
+            .WithName("GetSprintResults")
+            .WithDescription("Get sprint results for a race");
+
+        return app;
+    }
+
+    private static async Task<IResult> SubmitQualifyingResultsAsync(
+        IRaceResultService raceResultService,
+        int raceId,
+        [FromBody] List<QualifyingResultItem> items,
+        [FromServices] ILogger logger
+    )
+    {
+        logger.LogInformation("Submitting qualifying results for race {RaceId}", raceId);
+
+        var results = await raceResultService.SubmitQualifyingResultsAsync(raceId, items);
+
+        return Results.Ok(results);
+    }
+
+    private static async Task<IResult> GetQualifyingResultsAsync(
+        IRaceResultService raceResultService,
+        int raceId,
+        [FromServices] ILogger logger
+    )
+    {
+        logger.LogDebug("Fetching qualifying results for race {RaceId}", raceId);
+
+        var results = await raceResultService.GetQualifyingResultsAsync(raceId);
+
+        return Results.Ok(results);
+    }
+
+    private static async Task<IResult> SubmitRaceResultsAsync(
+        IRaceResultService raceResultService,
+        int raceId,
+        [FromBody] List<RaceResultItem> items,
+        [FromServices] ILogger logger
+    )
+    {
+        logger.LogInformation("Submitting race results for race {RaceId}", raceId);
+
+        var results = await raceResultService.SubmitRaceResultsAsync(
+            raceId,
+            SessionType.Race,
+            items
+        );
+
+        return Results.Ok(results);
+    }
+
+    private static async Task<IResult> GetRaceResultsAsync(
+        IRaceResultService raceResultService,
+        int raceId,
+        [FromServices] ILogger logger
+    )
+    {
+        logger.LogDebug("Fetching race results for race {RaceId}", raceId);
+
+        var results = await raceResultService.GetRaceResultsAsync(raceId, SessionType.Race);
+
+        return Results.Ok(results);
+    }
+
+    private static async Task<IResult> SubmitSprintResultsAsync(
+        IRaceResultService raceResultService,
+        int raceId,
+        [FromBody] List<RaceResultItem> items,
+        [FromServices] ILogger logger
+    )
+    {
+        logger.LogInformation("Submitting sprint results for race {RaceId}", raceId);
+
+        var results = await raceResultService.SubmitRaceResultsAsync(
+            raceId,
+            SessionType.Sprint,
+            items
+        );
+
+        return Results.Ok(results);
+    }
+
+    private static async Task<IResult> GetSprintResultsAsync(
+        IRaceResultService raceResultService,
+        int raceId,
+        [FromServices] ILogger logger
+    )
+    {
+        logger.LogDebug("Fetching sprint results for race {RaceId}", raceId);
+
+        var results = await raceResultService.GetRaceResultsAsync(raceId, SessionType.Sprint);
+
+        return Results.Ok(results);
+    }
+}

--- a/api/F1CompanionApi/Api/Mappers/DriverQualifyingResultResponseMapper.cs
+++ b/api/F1CompanionApi/Api/Mappers/DriverQualifyingResultResponseMapper.cs
@@ -1,0 +1,25 @@
+using F1CompanionApi.Api.Models;
+using F1CompanionApi.Data.Entities;
+
+namespace F1CompanionApi.Api.Mappers;
+
+public static class DriverQualifyingResultResponseMapper
+{
+    public static IEnumerable<DriverQualifyingResultResponse> ToResponseModel(
+        this IEnumerable<DriverQualifyingResult> results
+    )
+    {
+        return results.Select(r => r.ToResponseModel());
+    }
+
+    public static DriverQualifyingResultResponse ToResponseModel(this DriverQualifyingResult result)
+    {
+        return new DriverQualifyingResultResponse
+        {
+            Id = result.Id,
+            DriverId = result.DriverId,
+            RaceId = result.RaceId,
+            Position = result.Position,
+        };
+    }
+}

--- a/api/F1CompanionApi/Api/Mappers/DriverRaceResultResponseMapper.cs
+++ b/api/F1CompanionApi/Api/Mappers/DriverRaceResultResponseMapper.cs
@@ -1,0 +1,30 @@
+using F1CompanionApi.Api.Models;
+using F1CompanionApi.Data.Entities;
+
+namespace F1CompanionApi.Api.Mappers;
+
+public static class DriverRaceResultResponseMapper
+{
+    public static IEnumerable<DriverRaceResultResponse> ToResponseModel(
+        this IEnumerable<DriverRaceResult> results
+    )
+    {
+        return results.Select(r => r.ToResponseModel());
+    }
+
+    public static DriverRaceResultResponse ToResponseModel(this DriverRaceResult result)
+    {
+        return new DriverRaceResultResponse
+        {
+            Id = result.Id,
+            DriverId = result.DriverId,
+            RaceId = result.RaceId,
+            SessionType = result.SessionType,
+            GridPosition = result.GridPosition,
+            FinishPosition = result.FinishPosition,
+            Overtakes = result.Overtakes,
+            FastestLap = result.FastestLap,
+            Status = result.Status,
+        };
+    }
+}

--- a/api/F1CompanionApi/Api/Models/DriverQualifyingResultResponse.cs
+++ b/api/F1CompanionApi/Api/Models/DriverQualifyingResultResponse.cs
@@ -1,0 +1,9 @@
+namespace F1CompanionApi.Api.Models;
+
+public class DriverQualifyingResultResponse
+{
+    public required int Id { get; set; }
+    public required int DriverId { get; set; }
+    public required int RaceId { get; set; }
+    public required int Position { get; set; }
+}

--- a/api/F1CompanionApi/Api/Models/DriverRaceResultResponse.cs
+++ b/api/F1CompanionApi/Api/Models/DriverRaceResultResponse.cs
@@ -1,0 +1,16 @@
+using F1CompanionApi.Data.Entities;
+
+namespace F1CompanionApi.Api.Models;
+
+public class DriverRaceResultResponse
+{
+    public required int Id { get; set; }
+    public required int DriverId { get; set; }
+    public required int RaceId { get; set; }
+    public required SessionType SessionType { get; set; }
+    public required int GridPosition { get; set; }
+    public int? FinishPosition { get; set; }
+    public required int Overtakes { get; set; }
+    public required bool FastestLap { get; set; }
+    public required RaceStatus Status { get; set; }
+}

--- a/api/F1CompanionApi/Api/Models/QualifyingResultItem.cs
+++ b/api/F1CompanionApi/Api/Models/QualifyingResultItem.cs
@@ -1,0 +1,7 @@
+namespace F1CompanionApi.Api.Models;
+
+public class QualifyingResultItem
+{
+    public required int DriverId { get; set; }
+    public required int Position { get; set; }
+}

--- a/api/F1CompanionApi/Api/Models/RaceResultItem.cs
+++ b/api/F1CompanionApi/Api/Models/RaceResultItem.cs
@@ -1,0 +1,13 @@
+using F1CompanionApi.Data.Entities;
+
+namespace F1CompanionApi.Api.Models;
+
+public class RaceResultItem
+{
+    public required int DriverId { get; set; }
+    public required int GridPosition { get; set; }
+    public int? FinishPosition { get; set; }
+    public required int Overtakes { get; set; }
+    public required bool FastestLap { get; set; }
+    public required RaceStatus Status { get; set; }
+}

--- a/api/F1CompanionApi/Domain/Exceptions/GlobalExceptionHandler.cs
+++ b/api/F1CompanionApi/Domain/Exceptions/GlobalExceptionHandler.cs
@@ -96,6 +96,12 @@ public class GlobalExceptionHandler : IExceptionHandler
             LeagueFullException ex => (StatusCodes.Status409Conflict, "League Full", ex.Message),
 
             // Custom Domain Exceptions - Validation Failures
+            SprintNotAvailableException ex => (
+                StatusCodes.Status400BadRequest,
+                "Sprint Not Available",
+                ex.Message
+            ),
+
             TeamFullException ex => (StatusCodes.Status400BadRequest, "Team Full", ex.Message),
 
             BudgetExceededException ex => (

--- a/api/F1CompanionApi/Domain/Exceptions/SprintNotAvailableException.cs
+++ b/api/F1CompanionApi/Domain/Exceptions/SprintNotAvailableException.cs
@@ -1,0 +1,24 @@
+namespace F1CompanionApi.Domain.Exceptions;
+
+/// <summary>
+/// Exception thrown when attempting to submit sprint results for a race that does not have a sprint session.
+/// This is considered exceptional because callers should check <c>Race.HasSprint</c> before submitting
+/// sprint results, indicating either a client error or a misconfigured race record.
+/// </summary>
+public class SprintNotAvailableException : Exception
+{
+    /// <summary>
+    /// Gets the ID of the race that does not have a sprint session.
+    /// </summary>
+    public int RaceId { get; init; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SprintNotAvailableException"/> class.
+    /// </summary>
+    /// <param name="raceId">The ID of the race that does not have a sprint session.</param>
+    public SprintNotAvailableException(int raceId)
+        : base($"Race {raceId} does not have a sprint session")
+    {
+        RaceId = raceId;
+    }
+}

--- a/api/F1CompanionApi/Domain/Services/RaceResultService.cs
+++ b/api/F1CompanionApi/Domain/Services/RaceResultService.cs
@@ -76,6 +76,7 @@ public class RaceResultService : IRaceResultService
                 DriverId = i.DriverId,
                 RaceId = raceId,
                 Position = i.Position,
+                CreatedAt = DateTime.UtcNow,
             })
             .ToList();
 
@@ -132,6 +133,7 @@ public class RaceResultService : IRaceResultService
                 Overtakes = i.Overtakes,
                 FastestLap = i.FastestLap,
                 Status = i.Status,
+                CreatedAt = DateTime.UtcNow,
             })
             .ToList();
 

--- a/api/F1CompanionApi/Domain/Services/RaceResultService.cs
+++ b/api/F1CompanionApi/Domain/Services/RaceResultService.cs
@@ -1,0 +1,250 @@
+using F1CompanionApi.Api.Mappers;
+using F1CompanionApi.Api.Models;
+using F1CompanionApi.Data;
+using F1CompanionApi.Data.Entities;
+using F1CompanionApi.Domain.Exceptions;
+using Microsoft.EntityFrameworkCore;
+
+namespace F1CompanionApi.Domain.Services;
+
+public interface IRaceResultService
+{
+    Task<IEnumerable<DriverQualifyingResultResponse>> SubmitQualifyingResultsAsync(
+        int raceId,
+        List<QualifyingResultItem> qualifyingItems
+    );
+    Task<IEnumerable<DriverRaceResultResponse>> SubmitRaceResultsAsync(
+        int raceId,
+        SessionType sessionType,
+        List<RaceResultItem> raceItems
+    );
+    Task<IEnumerable<DriverQualifyingResultResponse>> GetQualifyingResultsAsync(int raceId);
+    Task<IEnumerable<DriverRaceResultResponse>> GetRaceResultsAsync(
+        int raceId,
+        SessionType sessionType
+    );
+}
+
+public class RaceResultService : IRaceResultService
+{
+    private readonly ApplicationDbContext _dbContext;
+    private readonly ILogger<RaceResultService> _logger;
+
+    public RaceResultService(ApplicationDbContext dbContext, ILogger<RaceResultService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _dbContext = dbContext;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Saves qualifying results for a race, replacing any previously submitted results.
+    /// Can be safely rerun to apply corrections, such as position changes after a stewards' review.
+    /// </summary>
+    /// <param name="raceId">The ID of the race to submit qualifying results for.</param>
+    /// <param name="qualifyingItems">The qualifying result items to save.</param>
+    public async Task<IEnumerable<DriverQualifyingResultResponse>> SubmitQualifyingResultsAsync(
+        int raceId,
+        List<QualifyingResultItem> qualifyingItems
+    )
+    {
+        _logger.LogInformation(
+            "Submitting {Count} qualifying results for race {RaceId}",
+            qualifyingItems.Count,
+            raceId
+        );
+
+        var race = await _dbContext.Races.FindAsync(raceId);
+
+        if (race is null)
+            throw new KeyNotFoundException($"Race {raceId} not found");
+
+        ValidateQualifyingItems(qualifyingItems);
+        await ValidateDriversExistAsync(qualifyingItems.Select(i => i.DriverId).ToList());
+
+        // Delete any existing results so new ones can be created
+        var existingQualifying = await _dbContext
+            .DriverQualifyingResults.Where(r => r.RaceId == raceId)
+            .ToListAsync();
+        _dbContext.DriverQualifyingResults.RemoveRange(existingQualifying);
+
+        var entities = qualifyingItems
+            .Select(i => new DriverQualifyingResult
+            {
+                DriverId = i.DriverId,
+                RaceId = raceId,
+                Position = i.Position,
+            })
+            .ToList();
+
+        _dbContext.DriverQualifyingResults.AddRange(entities);
+        await _dbContext.SaveChangesAsync();
+
+        return entities.ToResponseModel();
+    }
+
+    /// <summary>
+    /// Saves race or sprint results for a race, replacing any previously submitted results.
+    /// Can be safely rerun to apply corrections, such as status changes after a disqualification.
+    /// </summary>
+    /// <param name="raceId">The ID of the race to submit results for.</param>
+    /// <param name="sessionType">The session type (Race or Sprint).</param>
+    /// <param name="raceItems">The race result items to save.</param>
+    public async Task<IEnumerable<DriverRaceResultResponse>> SubmitRaceResultsAsync(
+        int raceId,
+        SessionType sessionType,
+        List<RaceResultItem> raceItems
+    )
+    {
+        _logger.LogInformation(
+            "Submitting {Count} {SessionType} results for race {RaceId}",
+            raceItems.Count,
+            sessionType,
+            raceId
+        );
+
+        var race = await _dbContext.Races.FindAsync(raceId);
+        if (race is null)
+            throw new KeyNotFoundException($"Race {raceId} not found");
+
+        if (sessionType == SessionType.Sprint && !race.HasSprint)
+            throw new SprintNotAvailableException(raceId);
+
+        ValidateRaceItems(raceItems);
+        await ValidateDriversExistAsync(raceItems.Select(i => i.DriverId).ToList());
+
+        // Delete any existing results so new ones can be created
+        var existingRace = await _dbContext
+            .DriverRaceResults.Where(r => r.RaceId == raceId && r.SessionType == sessionType)
+            .ToListAsync();
+        _dbContext.DriverRaceResults.RemoveRange(existingRace);
+
+        var entities = raceItems
+            .Select(i => new DriverRaceResult
+            {
+                DriverId = i.DriverId,
+                RaceId = raceId,
+                SessionType = sessionType,
+                GridPosition = i.GridPosition,
+                FinishPosition = i.FinishPosition,
+                Overtakes = i.Overtakes,
+                FastestLap = i.FastestLap,
+                Status = i.Status,
+            })
+            .ToList();
+
+        _dbContext.DriverRaceResults.AddRange(entities);
+        await _dbContext.SaveChangesAsync();
+
+        return entities.ToResponseModel();
+    }
+
+    /// <summary>
+    /// Returns all qualifying results for a race, ordered by position.
+    /// </summary>
+    /// <param name="raceId">The ID of the race to retrieve qualifying results for.</param>
+    public async Task<IEnumerable<DriverQualifyingResultResponse>> GetQualifyingResultsAsync(
+        int raceId
+    )
+    {
+        _logger.LogDebug("Fetching qualifying results for race {RaceId}", raceId);
+
+        var results = await _dbContext
+            .DriverQualifyingResults.Where(r => r.RaceId == raceId)
+            .OrderBy(r => r.Position)
+            .ToListAsync();
+
+        return results.ToResponseModel();
+    }
+
+    /// <summary>
+    /// Returns all race or sprint results for a race, ordered by finish position.
+    /// </summary>
+    /// <param name="raceId">The ID of the race to retrieve results for.</param>
+    /// <param name="sessionType">The session type (Race or Sprint).</param>
+    public async Task<IEnumerable<DriverRaceResultResponse>> GetRaceResultsAsync(
+        int raceId,
+        SessionType sessionType
+    )
+    {
+        _logger.LogDebug("Fetching {SessionType} results for race {RaceId}", sessionType, raceId);
+
+        var results = await _dbContext
+            .DriverRaceResults.Where(r => r.RaceId == raceId && r.SessionType == sessionType)
+            .OrderBy(r => r.FinishPosition)
+            .ToListAsync();
+
+        return results.ToResponseModel();
+    }
+
+    /// <summary>
+    /// Validates that no duplicate driverIds appear in the batch.
+    /// </summary>
+    /// <param name="qualifyingItems">The qualifying result items to validate.</param>
+    private static void ValidateQualifyingItems(List<QualifyingResultItem> qualifyingItems)
+    {
+        var duplicates = qualifyingItems
+            .GroupBy(i => i.DriverId)
+            .Where(g => g.Count() > 1)
+            .ToList();
+        if (duplicates.Count > 0)
+            throw new ArgumentException(
+                $"Duplicate driverIds in batch: {string.Join(", ", duplicates.Select(g => g.Key))}"
+            );
+    }
+
+    /// <summary>
+    /// Validates duplicate driverIds, fastest lap count, and FinishPosition/Status consistency.
+    /// </summary>
+    /// <param name="raceItems">The race result items to validate.</param>
+    private static void ValidateRaceItems(List<RaceResultItem> raceItems)
+    {
+        var duplicates = raceItems.GroupBy(i => i.DriverId).Where(g => g.Count() > 1).ToList();
+        if (duplicates.Count > 0)
+            throw new ArgumentException(
+                $"Duplicate driverIds in batch: {string.Join(", ", duplicates.Select(g => g.Key))}"
+            );
+
+        if (raceItems.Count(i => i.FastestLap) > 1)
+            throw new ArgumentException(
+                "At most one driver can have FastestLap = true per session"
+            );
+
+        // Validate finish position is consistent with status for each driver
+        foreach (var item in raceItems)
+        {
+            var finishPositionRequired =
+                item.Status == RaceStatus.Classified && item.FinishPosition is null;
+            var finishPositionForbidden =
+                item.Status != RaceStatus.Classified && item.FinishPosition is not null;
+
+            if (finishPositionRequired)
+                throw new ArgumentException(
+                    $"Driver {item.DriverId}: FinishPosition is required when Status is Classified"
+                );
+
+            if (finishPositionForbidden)
+                throw new ArgumentException(
+                    $"Driver {item.DriverId}: FinishPosition must be null when Status is {item.Status}"
+                );
+        }
+    }
+
+    /// <summary>
+    /// Throws if any driverIds in the batch do not exist in the database.
+    /// </summary>
+    /// <param name="driverIds">The driver IDs to check for existence.</param>
+    private async Task ValidateDriversExistAsync(List<int> driverIds)
+    {
+        var existingIds = await _dbContext
+            .Drivers.Where(d => driverIds.Contains(d.Id))
+            .Select(d => d.Id)
+            .ToListAsync();
+
+        var missing = driverIds.Except(existingIds).ToList();
+        if (missing.Count > 0)
+            throw new ArgumentException($"Driver(s) not found: {string.Join(", ", missing)}");
+    }
+}

--- a/api/F1CompanionApi/Domain/Services/SupabaseAuthService.cs
+++ b/api/F1CompanionApi/Domain/Services/SupabaseAuthService.cs
@@ -1,13 +1,9 @@
-using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
-using System.Text;
-using Microsoft.IdentityModel.Tokens;
 
 namespace F1CompanionApi.Domain.Services;
 
 public interface ISupabaseAuthService
 {
-    ClaimsPrincipal? ValidateToken(string token);
     string? GetUserId();
     string GetRequiredUserId();
     string? GetUserEmail();
@@ -15,48 +11,12 @@ public interface ISupabaseAuthService
 
 public class SupabaseAuthService : ISupabaseAuthService
 {
-    private readonly string _jwtSecret;
-    private readonly JwtSecurityTokenHandler _tokenHandler;
     private readonly IHttpContextAccessor _httpContextAccessor;
 
-    public SupabaseAuthService(
-        IConfiguration configuration,
-        IHttpContextAccessor httpContextAccessor
-    )
+    public SupabaseAuthService(IHttpContextAccessor httpContextAccessor)
     {
-        ArgumentNullException.ThrowIfNull(configuration);
         ArgumentNullException.ThrowIfNull(httpContextAccessor);
-
-        _jwtSecret =
-            configuration["Supabase:JwtSecret"]
-            ?? throw new InvalidOperationException("Supabase JWT secret not configured");
-        _tokenHandler = new JwtSecurityTokenHandler();
         _httpContextAccessor = httpContextAccessor;
-    }
-
-    public ClaimsPrincipal? ValidateToken(string token)
-    {
-        try
-        {
-            var key = Encoding.UTF8.GetBytes(_jwtSecret);
-            var validationParameters = new TokenValidationParameters
-            {
-                ValidateIssuerSigningKey = true,
-                IssuerSigningKey = new SymmetricSecurityKey(key),
-                ValidateIssuer = false,
-                ValidateAudience = true,
-                ValidAudience = "authenticated",
-                ValidateLifetime = true,
-                ClockSkew = TimeSpan.Zero,
-            };
-
-            var principal = _tokenHandler.ValidateToken(token, validationParameters, out _);
-            return principal;
-        }
-        catch
-        {
-            return null;
-        }
     }
 
     public string? GetUserId()

--- a/api/F1CompanionApi/Extensions/ServiceExtensions.cs
+++ b/api/F1CompanionApi/Extensions/ServiceExtensions.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using F1CompanionApi.Data;
 using F1CompanionApi.Domain.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -99,20 +98,22 @@ public static class ServiceExtensions
     {
         services.AddSingleton<ISupabaseAuthService, SupabaseAuthService>();
 
+        var authUrl =
+            configuration["Supabase:AuthUrl"]
+            ?? throw new InvalidOperationException("Supabase auth URL not configured");
+
         services
             .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             .AddJwtBearer(options =>
             {
-                var jwtSecret =
-                    configuration["Supabase:JwtSecret"]
-                    ?? throw new InvalidOperationException("Supabase JWT secret not configured");
-
-                var key = Encoding.UTF8.GetBytes(jwtSecret);
+                options.Authority = authUrl;
+                options.RequireHttpsMetadata = authUrl.StartsWith(
+                    "https://",
+                    StringComparison.OrdinalIgnoreCase
+                );
 
                 options.TokenValidationParameters = new TokenValidationParameters
                 {
-                    ValidateIssuerSigningKey = true,
-                    IssuerSigningKey = new SymmetricSecurityKey(key),
                     ValidateIssuer = false,
                     ValidateAudience = true,
                     ValidAudience = "authenticated",

--- a/api/F1CompanionApi/Extensions/ServiceExtensions.cs
+++ b/api/F1CompanionApi/Extensions/ServiceExtensions.cs
@@ -127,6 +127,7 @@ public static class ServiceExtensions
         services.AddScoped<IDriverService, DriverService>();
         services.AddScoped<ILeagueService, LeagueService>();
         services.AddScoped<ILeagueInviteService, LeagueInviteService>();
+        services.AddScoped<IRaceResultService, RaceResultService>();
         services.AddScoped<IRaceService, RaceService>();
         services.AddScoped<ISeasonService, SeasonService>();
         services.AddScoped<ITeamService, TeamService>();

--- a/api/F1CompanionApi/appsettings.json
+++ b/api/F1CompanionApi/appsettings.json
@@ -11,7 +11,7 @@
     "DefaultConnection": ""
   },
   "Supabase": {
-    "JwtSecret": ""
+    "AuthUrl": ""
   },
   "Sentry": {
     "Dsn": "",

--- a/api/scripts/.env.example
+++ b/api/scripts/.env.example
@@ -1,0 +1,5 @@
+F1_SUPABASE_URL=http://127.0.0.1:54321
+F1_SUPABASE_ANON_KEY=<your-anon-key>
+F1_IMPORT_EMAIL=admin@local.example.com
+F1_IMPORT_PASSWORD=<your-password>
+F1_API_URL=http://localhost:5000

--- a/api/scripts/.gitignore
+++ b/api/scripts/.gitignore
@@ -1,0 +1,4 @@
+.env.local
+.env.prod
+.venv/
+.ff1_cache/

--- a/api/scripts/README.md
+++ b/api/scripts/README.md
@@ -1,0 +1,64 @@
+# F1 Results Import Script
+
+Fetches real F1 results from FastF1 and submits them to the Fantasy API.
+
+## Setup
+
+```bash
+cd api/scripts
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Configuration
+
+Copy `.env.example` to `.env.local` and/or `.env.prod` and fill in the values:
+
+```bash
+cp .env.example .env.local
+cp .env.example .env.prod
+```
+
+### Local
+
+```ini
+# .env.local
+F1_SUPABASE_URL=http://127.0.0.1:54321
+F1_SUPABASE_ANON_KEY=<local-anon-key>
+F1_IMPORT_EMAIL=admin@local.example.com
+F1_IMPORT_PASSWORD=<local-password>
+F1_API_URL=http://localhost:5000
+```
+
+### Production
+
+```ini
+# .env.prod
+F1_SUPABASE_URL=https://cfuccajsckqzecbfyqrv.supabase.co
+F1_SUPABASE_ANON_KEY=<prod-anon-key>
+F1_IMPORT_EMAIL=admin@example.com
+F1_IMPORT_PASSWORD=<prod-password>
+F1_API_URL=https://f1fantasyapp.fly.dev
+```
+
+Both `.env.local` and `.env.prod` are gitignored.
+
+## Usage
+
+```bash
+# Local (default)
+python3 ingest_results.py --year 2026 --round 1
+
+# Production
+python3 ingest_results.py --year 2026 --round 1 --env prod
+```
+
+The script will:
+
+1. Authenticate with Supabase to get a JWT
+2. Fetch the driver list from the API to map abbreviations to IDs
+3. Fetch the race list to find the race ID and sprint status
+4. Load qualifying results from FastF1 and submit them
+5. If sprint weekend: load sprint results + overtakes and submit them
+6. Load race results + overtakes and submit them

--- a/api/scripts/ingest_results.py
+++ b/api/scripts/ingest_results.py
@@ -1,0 +1,405 @@
+"""
+ingest_results.py — Fetch F1 results via FastF1 and submit them to the
+F1 Fantasy API.
+
+Usage:
+    cd api/scripts
+    source .venv/bin/activate
+    python3 ingest_results.py --year 2026 --round 1
+    python3 ingest_results.py --year 2026 --round 1 --env prod
+"""
+
+import argparse
+import os
+import sys
+from enum import IntEnum
+from itertools import combinations
+
+import fastf1
+import pandas as pd
+import requests
+from dotenv import dotenv_values
+
+CACHE_DIR = ".ff1_cache"
+
+# FastF1 status strings that mean the driver finished the race
+_CLASSIFIED_STATUSES = {"Finished"}
+
+
+class RaceStatus(IntEnum):
+    """Mirrors the C# RaceStatus enum in Data/Entities/RaceStatus.cs."""
+
+    CLASSIFIED = 0
+    DNF = 1
+    DSQ = 2
+    DNS = 3
+
+
+class IngestError(Exception):
+    """Raised when the import process encounters a non-recoverable error."""
+
+
+class ApiError(IngestError):
+    """Raised when an API request fails."""
+
+    def __init__(self, action: str, status_code: int, body: str):
+        self.action = action
+        self.status_code = status_code
+        self.body = body
+        super().__init__(f"{action} failed ({status_code}): {body}")
+
+
+def create_api_session(token: str) -> requests.Session:
+    """Create a requests session with authorization headers."""
+    session = requests.Session()
+    session.headers.update({
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    })
+    return session
+
+
+def authenticate(supabase_url: str, anon_key: str, email: str, password: str) -> str:
+    """Sign in to Supabase and return an access token."""
+    resp = requests.post(
+        f"{supabase_url}/auth/v1/token?grant_type=password",
+        json={"email": email, "password": password},
+        headers={
+            "apikey": anon_key,
+            "Content-Type": "application/json",
+        },
+    )
+    if resp.status_code != 200:
+        raise ApiError("Authentication", resp.status_code, resp.text)
+    token = resp.json().get("access_token")
+    if not token:
+        raise IngestError("Authentication response missing access_token")
+    return token
+
+
+def fetch_driver_mapping(session: requests.Session, api_url: str) -> dict[str, int]:
+    """Fetch drivers from the API and return abbreviation -> id mapping."""
+    resp = session.get(f"{api_url}/api/drivers")
+    if resp.status_code >= 400:
+        raise ApiError("Fetch drivers", resp.status_code, resp.text)
+    return {d["abbreviation"]: d["id"] for d in resp.json()}
+
+
+def fetch_races(session: requests.Session, api_url: str) -> list[dict]:
+    """Fetch all races from the API."""
+    resp = session.get(f"{api_url}/api/races")
+    if resp.status_code >= 400:
+        raise ApiError("Fetch races", resp.status_code, resp.text)
+    return resp.json()
+
+
+def find_race(races: list[dict], round_number: int) -> dict:
+    """Find a race by round number."""
+    for race in races:
+        if race["round"] == round_number:
+            return race
+    raise IngestError(f"Race for round {round_number} not found in API")
+
+
+def load_session(year: int, round_number: int, session_name: str):
+    """Load a FastF1 session. Returns the session object, or None on failure."""
+    try:
+        session = fastf1.get_session(year, round_number, session_name)
+        session.load(telemetry=False, weather=False, messages=False)
+        return session
+    except Exception as exc:
+        print(f"  Warning: could not load {session_name} R{round_number}: {exc}")
+        return None
+
+
+def _build_pit_laps(laps) -> set[tuple[str, int]]:
+    """Build a set of (driver, lap_number) tuples where the driver pitted."""
+    pit_laps = set()
+    for _, row in laps.iterrows():
+        if pd.notna(row.get("PitInTime")):
+            pit_laps.add((row["Driver"], int(row["LapNumber"])))
+        if pd.notna(row.get("PitOutTime")):
+            pit_laps.add((row["Driver"], int(row["LapNumber"])))
+    return pit_laps
+
+
+def _either_pitted(
+    driver_a: str, driver_b: str, prev_lap: int, curr_lap: int, pit_laps: set
+) -> bool:
+    """Check if either driver pitted on the previous or current lap."""
+    return (
+        (driver_a, curr_lap) in pit_laps
+        or (driver_a, prev_lap) in pit_laps
+        or (driver_b, curr_lap) in pit_laps
+        or (driver_b, prev_lap) in pit_laps
+    )
+
+
+def count_overtakes(laps) -> dict[str, int]:
+    """Count on-track overtakes per driver from lap-by-lap position data.
+
+    Uses pairwise comparison: an overtake occurs when driver A was behind
+    driver B on lap N-1 but ahead on lap N, and neither driver pitted on
+    those laps.
+
+    Excludes:
+    - Lap 1 (first-lap chaos is captured by grid-to-finish position change)
+    - Laps where either driver in the pair entered or exited the pits
+    """
+    if laps is None or laps.empty:
+        return {}
+
+    pos = laps.pivot_table(index="LapNumber", columns="Driver", values="Position")
+    if pos.empty:
+        return {}
+
+    drivers = list(pos.columns)
+    pit_laps = _build_pit_laps(laps)
+    sorted_laps = sorted(pos.index)
+    overtakes = {driver: 0 for driver in drivers}
+
+    for prev_lap, curr_lap in zip(sorted_laps, sorted_laps[1:]):
+        if prev_lap <= 1:
+            continue
+
+        prev_positions = pos.loc[prev_lap]
+        curr_positions = pos.loc[curr_lap]
+
+        for driver_a, driver_b in combinations(drivers, 2):
+            if _either_pitted(driver_a, driver_b, int(prev_lap), int(curr_lap), pit_laps):
+                continue
+
+            a_prev, a_curr = prev_positions[driver_a], curr_positions[driver_a]
+            b_prev, b_curr = prev_positions[driver_b], curr_positions[driver_b]
+
+            if pd.isna(a_prev) or pd.isna(a_curr) or pd.isna(b_prev) or pd.isna(b_curr):
+                continue
+
+            if a_prev > b_prev and a_curr < b_curr:
+                overtakes[driver_a] += 1
+            elif b_prev > a_prev and b_curr < a_curr:
+                overtakes[driver_b] += 1
+
+    return overtakes
+
+
+def map_status(status_str) -> RaceStatus:
+    """Map a FastF1 status string to a RaceStatus enum value."""
+    if pd.isna(status_str) or status_str is None:
+        return RaceStatus.DNS
+
+    status = str(status_str).strip()
+
+    if status == "Disqualified":
+        return RaceStatus.DSQ
+
+    if status in _CLASSIFIED_STATUSES or "Lap" in status:
+        # "Finished" or lapped (e.g. "+1 Lap", "+2 Laps")
+        return RaceStatus.CLASSIFIED
+
+    # Everything else: "Retired", mechanical failures, accidents, etc.
+    return RaceStatus.DNF
+
+
+def build_qualifying_payload(
+    session, driver_map: dict[str, int]
+) -> tuple[list[dict], list[str]]:
+    """Build the qualifying results payload from a FastF1 qualifying session.
+
+    Returns (payload, warnings) where warnings lists any skipped drivers.
+    """
+    items = []
+    warnings = []
+    for _, row in session.results.iterrows():
+        abbr = row.get("Abbreviation", "")
+        driver_id = driver_map.get(abbr)
+        if driver_id is None:
+            warnings.append(f"Driver '{abbr}' not found in API, skipping")
+            continue
+
+        position = row.get("Position")
+        if pd.isna(position):
+            warnings.append(f"Driver '{abbr}' has no qualifying position, skipping")
+            continue
+
+        items.append({
+            "driverId": driver_id,
+            "position": int(position),
+        })
+    return items, warnings
+
+
+def build_race_payload(
+    session, driver_map: dict[str, int], overtakes: dict[str, int]
+) -> tuple[list[dict], list[str]]:
+    """Build the race/sprint results payload from a FastF1 session.
+
+    Returns (payload, warnings) where warnings lists any skipped drivers.
+    """
+    items = []
+    warnings = []
+    for _, row in session.results.iterrows():
+        abbr = row.get("Abbreviation", "")
+        driver_id = driver_map.get(abbr)
+        if driver_id is None:
+            warnings.append(f"Driver '{abbr}' not found in API, skipping")
+            continue
+
+        status = map_status(row.get("Status", ""))
+
+        grid = row.get("GridPosition")
+        grid = 0 if pd.isna(grid) else int(grid)
+
+        finish = row.get("Position")
+        if pd.isna(finish) or status != RaceStatus.CLASSIFIED:
+            finish_position = None
+        else:
+            finish_position = int(finish)
+
+        fastest_lap = bool(row.get("FastestLap", False))
+
+        items.append({
+            "driverId": driver_id,
+            "gridPosition": grid,
+            "finishPosition": finish_position,
+            "overtakes": overtakes.get(abbr, 0),
+            "fastestLap": fastest_lap,
+            "status": int(status),
+        })
+    return items, warnings
+
+
+def submit_results(
+    session: requests.Session,
+    api_url: str,
+    race_id: int,
+    session_type: str,
+    payload: list[dict],
+) -> None:
+    """PUT results to the API endpoint."""
+    url = f"{api_url}/api/races/{race_id}/results/{session_type}"
+    resp = session.put(url, json=payload)
+    if resp.status_code >= 400:
+        raise ApiError(f"Submit {session_type} results", resp.status_code, resp.text)
+    print(f"  {session_type.capitalize()} results submitted ({len(payload)} drivers)")
+
+
+def load_config(env: str) -> dict[str, str | None]:
+    """Load and validate environment config."""
+    env_file = f".env.{env}"
+    config = dotenv_values(env_file)
+    required_keys = [
+        "F1_SUPABASE_URL",
+        "F1_SUPABASE_ANON_KEY",
+        "F1_IMPORT_EMAIL",
+        "F1_IMPORT_PASSWORD",
+        "F1_API_URL",
+    ]
+    missing = [k for k in required_keys if not config.get(k)]
+    if missing:
+        raise IngestError(f"Missing keys in {env_file}: {', '.join(missing)}")
+    return config
+
+
+def report_warnings(warnings: list[str], session_name: str) -> None:
+    """Print any warnings about skipped drivers."""
+    if not warnings:
+        return
+    print(f"\n  Warnings for {session_name}:")
+    for w in warnings:
+        print(f"    - {w}")
+
+
+def ingest(year: int, round_number: int, env: str) -> None:
+    """Run the full import flow for a single round."""
+    config = load_config(env)
+
+    # Set up FastF1 cache
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    fastf1.Cache.enable_cache(CACHE_DIR)
+
+    # Authenticate
+    print(f"Authenticating against {config['F1_SUPABASE_URL']}...")
+    token = authenticate(
+        config["F1_SUPABASE_URL"],
+        config["F1_SUPABASE_ANON_KEY"],
+        config["F1_IMPORT_EMAIL"],
+        config["F1_IMPORT_PASSWORD"],
+    )
+    print("  Authenticated")
+
+    api_session = create_api_session(token)
+    api_url = config["F1_API_URL"]
+
+    # Fetch driver mapping and race info
+    print("Fetching driver list...")
+    driver_map = fetch_driver_mapping(api_session, api_url)
+    print(f"  Found {len(driver_map)} drivers")
+
+    print("Fetching race list...")
+    races = fetch_races(api_session, api_url)
+    race = find_race(races, round_number)
+    race_id = race["id"]
+    has_sprint = race.get("hasSprint", False)
+    print(f"  Race: {race['name']} (id={race_id}, hasSprint={has_sprint})")
+
+    # Qualifying
+    print(f"Loading qualifying session (R{round_number})...")
+    quali = load_session(year, round_number, "Qualifying")
+    if quali is not None:
+        payload, warnings = build_qualifying_payload(quali, driver_map)
+        report_warnings(warnings, "qualifying")
+        if payload:
+            submit_results(api_session, api_url, race_id, "qualifying", payload)
+    else:
+        print("  Skipping qualifying — session not available")
+
+    # Sprint
+    if has_sprint:
+        print(f"Loading sprint session (R{round_number})...")
+        sprint = load_session(year, round_number, "Sprint")
+        if sprint is not None:
+            sprint_overtakes = count_overtakes(sprint.laps)
+            payload, warnings = build_race_payload(sprint, driver_map, sprint_overtakes)
+            report_warnings(warnings, "sprint")
+            if payload:
+                submit_results(api_session, api_url, race_id, "sprint", payload)
+        else:
+            print("  Skipping sprint — session not available")
+
+    # Race
+    print(f"Loading race session (R{round_number})...")
+    race_session = load_session(year, round_number, "Race")
+    if race_session is not None:
+        race_overtakes = count_overtakes(race_session.laps)
+        payload, warnings = build_race_payload(race_session, driver_map, race_overtakes)
+        report_warnings(warnings, "race")
+        if payload:
+            submit_results(api_session, api_url, race_id, "race", payload)
+    else:
+        print("  Skipping race — session not available")
+
+    print("Done!")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Import F1 results into the Fantasy API")
+    parser.add_argument("--year", type=int, required=True, help="Season year")
+    parser.add_argument("--round", type=int, required=True, help="Round number")
+    parser.add_argument(
+        "--env",
+        choices=["local", "prod"],
+        default="local",
+        help="Environment (default: local)",
+    )
+    args = parser.parse_args()
+
+    try:
+        ingest(args.year, args.round, args.env)
+    except IngestError as exc:
+        print(f"\nError: {exc}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/api/scripts/ingest_results.py
+++ b/api/scripts/ingest_results.py
@@ -12,6 +12,7 @@ Usage:
 import argparse
 import os
 import sys
+from datetime import datetime, timezone
 from enum import IntEnum
 from itertools import combinations
 
@@ -106,7 +107,13 @@ def load_session(year: int, round_number: int, session_name: str):
     try:
         session = fastf1.get_session(year, round_number, session_name)
         session.load(telemetry=False, weather=False, messages=False)
+        if session.results is None or session.results.empty:
+            raise IngestError(
+                f"No data available for {session_name} R{round_number} — session may not have occurred yet"
+            )
         return session
+    except IngestError:
+        raise
     except Exception as exc:
         print(f"  Warning: could not load {session_name} R{round_number}: {exc}")
         return None
@@ -355,7 +362,11 @@ def ingest(year: int, round_number: int, env: str) -> None:
     race = find_race(races, round_number)
     race_id = race["id"]
     has_sprint = race.get("hasSprint", False)
+    race_date = datetime.fromisoformat(race["raceDate"]).replace(tzinfo=timezone.utc)
     print(f"  Race: {race['name']} (id={race_id}, hasSprint={has_sprint})")
+
+    if datetime.now(timezone.utc) < race_date:
+        raise IngestError(f"Race has not occurred yet (scheduled {race_date.date()})")
 
     # Qualifying
     print(f"Loading qualifying session (R{round_number})...")
@@ -400,7 +411,7 @@ def ingest(year: int, round_number: int, env: str) -> None:
 
 def main():
     parser = argparse.ArgumentParser(description="Import F1 results into the Fantasy API")
-    parser.add_argument("--year", type=int, required=True, help="Season year")
+    parser.add_argument("--year", type=int, default=datetime.now().year, help="Season year (default: current year)")
     parser.add_argument("--round", type=int, required=True, help="Round number")
     parser.add_argument(
         "--env",

--- a/api/scripts/ingest_results.py
+++ b/api/scripts/ingest_results.py
@@ -135,6 +135,19 @@ def _either_pitted(
     )
 
 
+def get_fastest_lap_driver(laps) -> str | None:
+    """Return the abbreviation of the driver who set the fastest lap, or None."""
+    if laps is None or laps.empty:
+        return None
+    try:
+        fastest = laps.pick_fastest()
+        if fastest is not None and pd.notna(fastest.get("Driver")):
+            return str(fastest["Driver"])
+    except Exception:
+        pass
+    return None
+
+
 def count_overtakes(laps) -> dict[str, int]:
     """Count on-track overtakes per driver from lap-by-lap position data.
 
@@ -230,7 +243,8 @@ def build_qualifying_payload(
 
 
 def build_race_payload(
-    session, driver_map: dict[str, int], overtakes: dict[str, int]
+    session, driver_map: dict[str, int], overtakes: dict[str, int],
+    fastest_lap_driver: str | None = None,
 ) -> tuple[list[dict], list[str]]:
     """Build the race/sprint results payload from a FastF1 session.
 
@@ -256,7 +270,7 @@ def build_race_payload(
         else:
             finish_position = int(finish)
 
-        fastest_lap = bool(row.get("FastestLap", False))
+        fastest_lap = abbr == fastest_lap_driver
 
         items.append({
             "driverId": driver_id,
@@ -360,7 +374,8 @@ def ingest(year: int, round_number: int, env: str) -> None:
         sprint = load_session(year, round_number, "Sprint")
         if sprint is not None:
             sprint_overtakes = count_overtakes(sprint.laps)
-            payload, warnings = build_race_payload(sprint, driver_map, sprint_overtakes)
+            sprint_fl = get_fastest_lap_driver(sprint.laps)
+            payload, warnings = build_race_payload(sprint, driver_map, sprint_overtakes, sprint_fl)
             report_warnings(warnings, "sprint")
             if payload:
                 submit_results(api_session, api_url, race_id, "sprint", payload)
@@ -372,7 +387,8 @@ def ingest(year: int, round_number: int, env: str) -> None:
     race_session = load_session(year, round_number, "Race")
     if race_session is not None:
         race_overtakes = count_overtakes(race_session.laps)
-        payload, warnings = build_race_payload(race_session, driver_map, race_overtakes)
+        race_fl = get_fastest_lap_driver(race_session.laps)
+        payload, warnings = build_race_payload(race_session, driver_map, race_overtakes, race_fl)
         report_warnings(warnings, "race")
         if payload:
             submit_results(api_session, api_url, race_id, "race", payload)

--- a/api/scripts/requirements.txt
+++ b/api/scripts/requirements.txt
@@ -1,0 +1,4 @@
+fastf1
+requests
+python-dotenv
+pytest

--- a/api/scripts/test_ingest_results.py
+++ b/api/scripts/test_ingest_results.py
@@ -10,6 +10,7 @@ from ingest_results import (
     build_race_payload,
     count_overtakes,
     find_race,
+    get_fastest_lap_driver,
     map_status,
 )
 
@@ -151,6 +152,40 @@ class TestCountOvertakes:
         assert count_overtakes(pd.DataFrame()) == {}
 
 
+# --- get_fastest_lap_driver ---
+
+
+class _FakeLaps:
+    """Minimal mock for FastF1 laps with pick_fastest()."""
+
+    def __init__(self, data, fastest_driver=None):
+        self._df = pd.DataFrame(data)
+        self._fastest_driver = fastest_driver
+        self.empty = self._df.empty
+
+    def pick_fastest(self):
+        if self._fastest_driver is None:
+            return None
+        return pd.Series({"Driver": self._fastest_driver})
+
+
+class TestGetFastestLapDriver:
+    def test_returns_driver_abbreviation(self):
+        laps = _FakeLaps([{"Driver": "VER"}], fastest_driver="VER")
+        assert get_fastest_lap_driver(laps) == "VER"
+
+    def test_returns_none_for_none_laps(self):
+        assert get_fastest_lap_driver(None) is None
+
+    def test_returns_none_for_empty_laps(self):
+        laps = _FakeLaps([])
+        assert get_fastest_lap_driver(laps) is None
+
+    def test_returns_none_when_pick_fastest_returns_none(self):
+        laps = _FakeLaps([{"Driver": "VER"}], fastest_driver=None)
+        assert get_fastest_lap_driver(laps) is None
+
+
 # --- build_qualifying_payload ---
 
 
@@ -204,11 +239,11 @@ class TestBuildRacePayload:
     def test_classified_driver(self):
         session = _make_session([
             {"Abbreviation": "VER", "Status": "Finished", "GridPosition": 1,
-             "Position": 1, "FastestLap": True},
+             "Position": 1},
         ])
         driver_map = {"VER": 10}
         overtakes = {"VER": 3}
-        payload, warnings = build_race_payload(session, driver_map, overtakes)
+        payload, warnings = build_race_payload(session, driver_map, overtakes, fastest_lap_driver="VER")
 
         assert len(payload) == 1
         assert payload[0] == {
@@ -221,10 +256,30 @@ class TestBuildRacePayload:
         }
         assert warnings == []
 
+    def test_fastest_lap_false_when_not_matching(self):
+        session = _make_session([
+            {"Abbreviation": "VER", "Status": "Finished", "GridPosition": 1,
+             "Position": 1},
+        ])
+        driver_map = {"VER": 10}
+        payload, _ = build_race_payload(session, driver_map, {}, fastest_lap_driver="NOR")
+
+        assert payload[0]["fastestLap"] is False
+
+    def test_fastest_lap_false_when_none(self):
+        session = _make_session([
+            {"Abbreviation": "VER", "Status": "Finished", "GridPosition": 1,
+             "Position": 1},
+        ])
+        driver_map = {"VER": 10}
+        payload, _ = build_race_payload(session, driver_map, {})
+
+        assert payload[0]["fastestLap"] is False
+
     def test_dnf_driver_has_null_finish_position(self):
         session = _make_session([
             {"Abbreviation": "NOR", "Status": "Retired", "GridPosition": 3,
-             "Position": float("nan"), "FastestLap": False},
+             "Position": float("nan")},
         ])
         driver_map = {"NOR": 20}
         payload, warnings = build_race_payload(session, driver_map, {})
@@ -235,7 +290,7 @@ class TestBuildRacePayload:
     def test_dsq_driver_has_null_finish_position(self):
         session = _make_session([
             {"Abbreviation": "VER", "Status": "Disqualified", "GridPosition": 1,
-             "Position": 1, "FastestLap": False},
+             "Position": 1},
         ])
         driver_map = {"VER": 10}
         payload, warnings = build_race_payload(session, driver_map, {})
@@ -246,7 +301,7 @@ class TestBuildRacePayload:
     def test_lapped_driver_is_classified(self):
         session = _make_session([
             {"Abbreviation": "VER", "Status": "+1 Lap", "GridPosition": 15,
-             "Position": 12, "FastestLap": False},
+             "Position": 12},
         ])
         driver_map = {"VER": 10}
         payload, warnings = build_race_payload(session, driver_map, {})
@@ -257,7 +312,7 @@ class TestBuildRacePayload:
     def test_skips_unknown_driver_with_warning(self):
         session = _make_session([
             {"Abbreviation": "XXX", "Status": "Finished", "GridPosition": 1,
-             "Position": 1, "FastestLap": False},
+             "Position": 1},
         ])
         payload, warnings = build_race_payload(session, {}, {})
 
@@ -268,7 +323,7 @@ class TestBuildRacePayload:
     def test_missing_overtakes_defaults_to_zero(self):
         session = _make_session([
             {"Abbreviation": "VER", "Status": "Finished", "GridPosition": 1,
-             "Position": 1, "FastestLap": False},
+             "Position": 1},
         ])
         driver_map = {"VER": 10}
         payload, warnings = build_race_payload(session, driver_map, {})
@@ -278,7 +333,7 @@ class TestBuildRacePayload:
     def test_missing_grid_position_defaults_to_zero(self):
         session = _make_session([
             {"Abbreviation": "VER", "Status": "Finished", "GridPosition": float("nan"),
-             "Position": 1, "FastestLap": False},
+             "Position": 1},
         ])
         driver_map = {"VER": 10}
         payload, warnings = build_race_payload(session, driver_map, {})

--- a/api/scripts/test_ingest_results.py
+++ b/api/scripts/test_ingest_results.py
@@ -1,0 +1,286 @@
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from ingest_results import (
+    IngestError,
+    RaceStatus,
+    build_qualifying_payload,
+    build_race_payload,
+    count_overtakes,
+    find_race,
+    map_status,
+)
+
+
+# --- map_status ---
+
+
+class TestMapStatus:
+    def test_finished_returns_classified(self):
+        assert map_status("Finished") == RaceStatus.CLASSIFIED
+
+    def test_lapped_one_lap_returns_classified(self):
+        assert map_status("+1 Lap") == RaceStatus.CLASSIFIED
+
+    def test_lapped_two_laps_returns_classified(self):
+        assert map_status("+2 Laps") == RaceStatus.CLASSIFIED
+
+    def test_retired_returns_dnf(self):
+        assert map_status("Retired") == RaceStatus.DNF
+
+    def test_engine_failure_returns_dnf(self):
+        assert map_status("Engine") == RaceStatus.DNF
+
+    def test_accident_returns_dnf(self):
+        assert map_status("Accident") == RaceStatus.DNF
+
+    def test_disqualified_returns_dsq(self):
+        assert map_status("Disqualified") == RaceStatus.DSQ
+
+    def test_none_returns_dns(self):
+        assert map_status(None) == RaceStatus.DNS
+
+    def test_nan_returns_dns(self):
+        assert map_status(float("nan")) == RaceStatus.DNS
+
+    def test_whitespace_is_stripped(self):
+        assert map_status("  Finished  ") == RaceStatus.CLASSIFIED
+
+
+# --- find_race ---
+
+
+class TestFindRace:
+    def test_returns_matching_race(self):
+        races = [
+            {"round": 1, "id": 10, "name": "Bahrain"},
+            {"round": 2, "id": 20, "name": "Saudi Arabia"},
+        ]
+        result = find_race(races, 2)
+        assert result["id"] == 20
+        assert result["name"] == "Saudi Arabia"
+
+    def test_raises_when_not_found(self):
+        races = [{"round": 1, "id": 10, "name": "Bahrain"}]
+        with pytest.raises(IngestError, match="round 5 not found"):
+            find_race(races, 5)
+
+
+# --- count_overtakes ---
+
+
+def _make_laps(data: list[dict]) -> pd.DataFrame:
+    """Helper to build a laps DataFrame with required columns."""
+    df = pd.DataFrame(data)
+    for col in ["PitInTime", "PitOutTime"]:
+        if col not in df.columns:
+            df[col] = None
+    return df
+
+
+class TestCountOvertakes:
+    def test_simple_overtake(self):
+        # VER passes NOR between lap 2 and lap 3
+        laps = _make_laps([
+            {"Driver": "VER", "LapNumber": 2, "Position": 2},
+            {"Driver": "NOR", "LapNumber": 2, "Position": 1},
+            {"Driver": "VER", "LapNumber": 3, "Position": 1},
+            {"Driver": "NOR", "LapNumber": 3, "Position": 2},
+        ])
+        result = count_overtakes(laps)
+        assert result["VER"] == 1
+        assert result["NOR"] == 0
+
+    def test_no_position_change_means_no_overtake(self):
+        laps = _make_laps([
+            {"Driver": "VER", "LapNumber": 2, "Position": 1},
+            {"Driver": "NOR", "LapNumber": 2, "Position": 2},
+            {"Driver": "VER", "LapNumber": 3, "Position": 1},
+            {"Driver": "NOR", "LapNumber": 3, "Position": 2},
+        ])
+        result = count_overtakes(laps)
+        assert result["VER"] == 0
+        assert result["NOR"] == 0
+
+    def test_lap_1_excluded(self):
+        # Position change between lap 1 and lap 2 should not count
+        laps = _make_laps([
+            {"Driver": "VER", "LapNumber": 1, "Position": 2},
+            {"Driver": "NOR", "LapNumber": 1, "Position": 1},
+            {"Driver": "VER", "LapNumber": 2, "Position": 1},
+            {"Driver": "NOR", "LapNumber": 2, "Position": 2},
+        ])
+        result = count_overtakes(laps)
+        assert result["VER"] == 0
+        assert result["NOR"] == 0
+
+    def test_pit_lap_excluded(self):
+        # VER appears to pass NOR but NOR pitted — should not count
+        laps = _make_laps([
+            {"Driver": "VER", "LapNumber": 2, "Position": 2, "PitInTime": None, "PitOutTime": None},
+            {"Driver": "NOR", "LapNumber": 2, "Position": 1, "PitInTime": None, "PitOutTime": None},
+            {"Driver": "VER", "LapNumber": 3, "Position": 1, "PitInTime": None, "PitOutTime": None},
+            {"Driver": "NOR", "LapNumber": 3, "Position": 2, "PitInTime": pd.Timestamp("2024-01-01"), "PitOutTime": None},
+        ])
+        result = count_overtakes(laps)
+        assert result["VER"] == 0
+        assert result["NOR"] == 0
+
+    def test_multiple_overtakes_across_laps(self):
+        # VER overtakes NOR on lap 3, and PIA on lap 4
+        laps = _make_laps([
+            {"Driver": "VER", "LapNumber": 2, "Position": 3},
+            {"Driver": "NOR", "LapNumber": 2, "Position": 2},
+            {"Driver": "PIA", "LapNumber": 2, "Position": 1},
+            {"Driver": "VER", "LapNumber": 3, "Position": 2},
+            {"Driver": "NOR", "LapNumber": 3, "Position": 3},
+            {"Driver": "PIA", "LapNumber": 3, "Position": 1},
+            {"Driver": "VER", "LapNumber": 4, "Position": 1},
+            {"Driver": "NOR", "LapNumber": 4, "Position": 3},
+            {"Driver": "PIA", "LapNumber": 4, "Position": 2},
+        ])
+        result = count_overtakes(laps)
+        assert result["VER"] == 2
+        assert result["NOR"] == 0
+        assert result["PIA"] == 0
+
+    def test_empty_laps_returns_empty(self):
+        assert count_overtakes(None) == {}
+        assert count_overtakes(pd.DataFrame()) == {}
+
+
+# --- build_qualifying_payload ---
+
+
+def _make_session(results_data: list[dict]) -> SimpleNamespace:
+    """Helper to build a mock session with a results DataFrame."""
+    return SimpleNamespace(results=pd.DataFrame(results_data))
+
+
+class TestBuildQualifyingPayload:
+    def test_builds_payload(self):
+        session = _make_session([
+            {"Abbreviation": "VER", "Position": 1},
+            {"Abbreviation": "NOR", "Position": 2},
+        ])
+        driver_map = {"VER": 10, "NOR": 20}
+        payload, warnings = build_qualifying_payload(session, driver_map)
+
+        assert len(payload) == 2
+        assert payload[0] == {"driverId": 10, "position": 1}
+        assert payload[1] == {"driverId": 20, "position": 2}
+        assert warnings == []
+
+    def test_skips_unknown_driver_with_warning(self):
+        session = _make_session([
+            {"Abbreviation": "VER", "Position": 1},
+            {"Abbreviation": "XXX", "Position": 2},
+        ])
+        driver_map = {"VER": 10}
+        payload, warnings = build_qualifying_payload(session, driver_map)
+
+        assert len(payload) == 1
+        assert len(warnings) == 1
+        assert "XXX" in warnings[0]
+
+    def test_skips_missing_position_with_warning(self):
+        session = _make_session([
+            {"Abbreviation": "VER", "Position": float("nan")},
+        ])
+        driver_map = {"VER": 10}
+        payload, warnings = build_qualifying_payload(session, driver_map)
+
+        assert len(payload) == 0
+        assert len(warnings) == 1
+        assert "VER" in warnings[0]
+
+
+# --- build_race_payload ---
+
+
+class TestBuildRacePayload:
+    def test_classified_driver(self):
+        session = _make_session([
+            {"Abbreviation": "VER", "Status": "Finished", "GridPosition": 1,
+             "Position": 1, "FastestLap": True},
+        ])
+        driver_map = {"VER": 10}
+        overtakes = {"VER": 3}
+        payload, warnings = build_race_payload(session, driver_map, overtakes)
+
+        assert len(payload) == 1
+        assert payload[0] == {
+            "driverId": 10,
+            "gridPosition": 1,
+            "finishPosition": 1,
+            "overtakes": 3,
+            "fastestLap": True,
+            "status": int(RaceStatus.CLASSIFIED),
+        }
+        assert warnings == []
+
+    def test_dnf_driver_has_null_finish_position(self):
+        session = _make_session([
+            {"Abbreviation": "NOR", "Status": "Retired", "GridPosition": 3,
+             "Position": float("nan"), "FastestLap": False},
+        ])
+        driver_map = {"NOR": 20}
+        payload, warnings = build_race_payload(session, driver_map, {})
+
+        assert payload[0]["finishPosition"] is None
+        assert payload[0]["status"] == int(RaceStatus.DNF)
+
+    def test_dsq_driver_has_null_finish_position(self):
+        session = _make_session([
+            {"Abbreviation": "VER", "Status": "Disqualified", "GridPosition": 1,
+             "Position": 1, "FastestLap": False},
+        ])
+        driver_map = {"VER": 10}
+        payload, warnings = build_race_payload(session, driver_map, {})
+
+        assert payload[0]["finishPosition"] is None
+        assert payload[0]["status"] == int(RaceStatus.DSQ)
+
+    def test_lapped_driver_is_classified(self):
+        session = _make_session([
+            {"Abbreviation": "VER", "Status": "+1 Lap", "GridPosition": 15,
+             "Position": 12, "FastestLap": False},
+        ])
+        driver_map = {"VER": 10}
+        payload, warnings = build_race_payload(session, driver_map, {})
+
+        assert payload[0]["finishPosition"] == 12
+        assert payload[0]["status"] == int(RaceStatus.CLASSIFIED)
+
+    def test_skips_unknown_driver_with_warning(self):
+        session = _make_session([
+            {"Abbreviation": "XXX", "Status": "Finished", "GridPosition": 1,
+             "Position": 1, "FastestLap": False},
+        ])
+        payload, warnings = build_race_payload(session, {}, {})
+
+        assert len(payload) == 0
+        assert len(warnings) == 1
+        assert "XXX" in warnings[0]
+
+    def test_missing_overtakes_defaults_to_zero(self):
+        session = _make_session([
+            {"Abbreviation": "VER", "Status": "Finished", "GridPosition": 1,
+             "Position": 1, "FastestLap": False},
+        ])
+        driver_map = {"VER": 10}
+        payload, warnings = build_race_payload(session, driver_map, {})
+
+        assert payload[0]["overtakes"] == 0
+
+    def test_missing_grid_position_defaults_to_zero(self):
+        session = _make_session([
+            {"Abbreviation": "VER", "Status": "Finished", "GridPosition": float("nan"),
+             "Position": 1, "FastestLap": False},
+        ])
+        driver_map = {"VER": 10}
+        payload, warnings = build_race_payload(session, driver_map, {})
+
+        assert payload[0]["gridPosition"] == 0

--- a/api/scripts/test_ingest_results.py
+++ b/api/scripts/test_ingest_results.py
@@ -3,6 +3,8 @@ from types import SimpleNamespace
 import pandas as pd
 import pytest
 
+from unittest.mock import MagicMock, patch
+
 from ingest_results import (
     IngestError,
     RaceStatus,
@@ -11,6 +13,7 @@ from ingest_results import (
     count_overtakes,
     find_race,
     get_fastest_lap_driver,
+    load_session,
     map_status,
 )
 
@@ -48,6 +51,30 @@ class TestMapStatus:
 
     def test_whitespace_is_stripped(self):
         assert map_status("  Finished  ") == RaceStatus.CLASSIFIED
+
+
+# --- load_session ---
+
+
+class TestLoadSession:
+    def test_raises_ingest_error_when_results_empty(self):
+        mock_session = MagicMock()
+        mock_session.results = pd.DataFrame()
+        with patch("ingest_results.fastf1.get_session", return_value=mock_session):
+            with pytest.raises(IngestError, match="may not have occurred yet"):
+                load_session(2026, 7, "Race")
+
+    def test_returns_none_when_session_type_does_not_exist(self):
+        with patch("ingest_results.fastf1.get_session", side_effect=Exception("Session type 'Sprint' does not exist")):
+            result = load_session(2026, 1, "Sprint")
+            assert result is None
+
+    def test_returns_session_when_data_loaded(self):
+        mock_session = MagicMock()
+        mock_session.results = pd.DataFrame([{"Driver": "VER"}])
+        with patch("ingest_results.fastf1.get_session", return_value=mock_session):
+            result = load_session(2026, 1, "Race")
+            assert result is mock_session
 
 
 # --- find_race ---

--- a/api/supabase/config.toml
+++ b/api/supabase/config.toml
@@ -124,7 +124,7 @@ site_url = "http://127.0.0.1:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
 additional_redirect_urls = ["https://127.0.0.1:3000"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
-jwt_expiry = 3600
+jwt_expiry = 604800
 # Path to JWT signing key. DO NOT commit your signing keys file to git.
 # signing_keys_path = "./signing_keys.json"
 # If disabled, the refresh token will never expire.


### PR DESCRIPTION
## Summary

- Adds batch-upsert and read API endpoints for qualifying, race, and sprint results (`PUT`/`GET /api/races/{raceId}/results/{qualifying|race|sprint}`)
- Implements `RaceResultService` with full validation (race existence, driver existence, duplicate drivers, sprint availability, fastest lap uniqueness, finish position / status consistency)
- Adds `SprintNotAvailableException` and wires it to a 400 response in `GlobalExceptionHandler`
- Adds a FastF1 Python ingestion script (`api/scripts/ingest_results.py`) that authenticates via Supabase, fetches live F1 timing data, calculates overtakes from lap-by-lap position data, and submits results to the API

## Test plan

- [ ] `dotnet test` passes with new service and endpoint unit tests
- [ ] Run `ingest_results.py --year 2026 --round 1` against local environment and verify qualifying + race results appear via `GET` endpoints
- [ ] Resubmit the same round and confirm upsert semantics (no duplicates, values updated)
- [ ] Submit sprint results against a non-sprint race and confirm 400 response