### PR TITLE
Remove unused Supabase package reference

### DIFF
--- a/api/F1CompanionApi/F1CompanionApi.csproj
+++ b/api/F1CompanionApi/F1CompanionApi.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.14.0" />
     <PackageReference Include="Sentry.AspNetCore" Version="6.3.2" />
-    <PackageReference Include="Supabase" Version="1.1.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- The `Supabase` community SDK (v1.1.1) was referenced in `F1CompanionApi.csproj` but never imported or used in any source file.
- JWT validation is handled by `Microsoft.AspNetCore.Authentication.JwtBearer` against the Supabase JWT secret, and `SupabaseAuthService` reads claims directly from `HttpContext.User` — no SDK calls.
- Removing the reference drops an unmaintained dependency (latest NuGet publish was July 2024) with zero functional impact.

## Test plan
- [x] `npm run api:build` — succeeds
- [x] `npm run api:test` — 440/440 passing
- [ ] Verify auth still works end-to-end after merge