### PR TITLE
Upgrade API to .NET 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.0.x'
       - name: Restore tools
         run: dotnet tool restore
         working-directory: api

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -52,7 +52,7 @@ dotnet ef migrations remove --project F1CompanionApi
 
 ### Key Patterns
 
-**Endpoints**: Private static async methods returning `IResult`, configured with `.RequireAuthorization()`, `.WithName()`, `.WithOpenApi()`, `.WithDescription()`
+**Endpoints**: Private static async methods returning `IResult`, configured with `.RequireAuthorization()`, `.WithName()`, `.WithDescription()`
 
 **Services**: Constructor-injected `ApplicationDbContext`, async operations, use `.Include()` for navigation properties, return response DTOs via mapper extension methods
 
@@ -99,7 +99,7 @@ instance.
 ### Adding a New Endpoint
 
 1. Create `{Feature}Endpoints.cs` in `Api/Endpoints/` with a static `Map{Feature}Endpoints` extension method
-2. Define private static async methods returning `IResult`, chain `.RequireAuthorization()`, `.WithName()`, `.WithOpenApi()`, `.WithDescription()`
+2. Define private static async methods returning `IResult`, chain `.RequireAuthorization()`, `.WithName()`, `.WithDescription()`
 3. Register in `Endpoints.MapEndpoints()` by chaining `.Map{Feature}Endpoints()`
 4. Add request/response DTOs in `Api/Models/`
 5. Add mapper extension method in `Api/Mappers/`

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,10 +1,10 @@
-# Use the official .NET 9 runtime as the base image for production
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
+# Use the official .NET 10 runtime as the base image for production
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 WORKDIR /app
 EXPOSE 8080
 
-# Use the .NET 9 SDK for building the application
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+# Use the .NET 10 SDK for building the application
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Copy the project file and restore dependencies
@@ -20,7 +20,7 @@ RUN dotnet build "F1CompanionApi.csproj" -c Release -o /app/build
 
 # Build the EF migrations bundle
 FROM build AS migrate
-RUN dotnet tool install --global dotnet-ef \
+RUN dotnet tool install --global dotnet-ef --version 10.* \
     && /root/.dotnet/tools/dotnet-ef migrations bundle --self-contained -r linux-x64 -o /app/efbundle
 
 # Publish the application

--- a/api/F1CompanionApi.UnitTests/F1CompanionApi.UnitTests.csproj
+++ b/api/F1CompanionApi.UnitTests/F1CompanionApi.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -21,7 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.15" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/api/F1CompanionApi/Api/Endpoints/ConstructorEndpoints.cs
+++ b/api/F1CompanionApi/Api/Endpoints/ConstructorEndpoints.cs
@@ -13,13 +13,11 @@ public static class ConstructorEndpoints
         app.MapGet("/constructors", GetConstructorsAsync)
             .RequireAuthorization()
             .WithName("GetConstructors")
-            .WithOpenApi()
             .WithDescription("Retrieves a list of constructors");
 
         app.MapGet("/constructors/{id}", GetConstructorByIdAsync)
             .RequireAuthorization()
             .WithName("GetConstructorById")
-            .WithOpenApi()
             .WithDescription("Retrieves a specific constructor by Id");
 
         return app;

--- a/api/F1CompanionApi/Api/Endpoints/DriverEndpoints.cs
+++ b/api/F1CompanionApi/Api/Endpoints/DriverEndpoints.cs
@@ -13,13 +13,11 @@ public static class DriverEndpoints
         app.MapGet("/drivers", GetDriversAsync)
             .RequireAuthorization()
             .WithName("GetDrivers")
-            .WithOpenApi()
             .WithDescription("Retrieves a list of drivers");
 
         app.MapGet("/drivers/{id}", GetDriverByIdAsync)
             .RequireAuthorization()
             .WithName("GetDriverById")
-            .WithOpenApi()
             .WithDescription("Retrieves a specific driver by Id");
 
         return app;

--- a/api/F1CompanionApi/Api/Endpoints/LeagueEndpoints.cs
+++ b/api/F1CompanionApi/Api/Endpoints/LeagueEndpoints.cs
@@ -10,7 +10,7 @@ public static class LeagueEndpoints
     [ExcludeFromCodeCoverage]
     public static IEndpointRouteBuilder MapLeagueEndpoints(this IEndpointRouteBuilder app)
     {
-        var leaguesGroup = app.MapGroup("/leagues").WithOpenApi();
+        var leaguesGroup = app.MapGroup("/leagues");
 
         leaguesGroup
             .MapPost("/", CreateLeagueAsync)

--- a/api/F1CompanionApi/Api/Endpoints/MeEndpoints.cs
+++ b/api/F1CompanionApi/Api/Endpoints/MeEndpoints.cs
@@ -16,25 +16,21 @@ public static class MeEndpoints
         meGroup
             .MapGet("/profile", GetUserProfileAsync)
             .WithName("Get User Profile")
-            .WithOpenApi()
             .WithDescription("Gets user profile");
 
         meGroup
             .MapPost("/register", RegisterUserAsync)
             .WithName("Register User")
-            .WithOpenApi()
             .WithDescription("Creates user account and profile");
 
         meGroup
             .MapPatch("/profile", UpdateUserProfileAsync)
             .WithName("Update User Profile")
-            .WithOpenApi()
             .WithDescription("Updates user profile");
 
         meGroup
             .MapGet("/leagues", GetMyLeaguesAsync)
             .WithName("Get My Leagues")
-            .WithOpenApi()
             .WithDescription("Gets leagues owned by the authenticated user");
 
         var teamGroup = meGroup.MapGroup("/team");
@@ -42,19 +38,16 @@ public static class MeEndpoints
         teamGroup
             .MapGet("/", GetMyTeamAsync)
             .WithName("Get My Team")
-            .WithOpenApi()
             .WithDescription("Get current user's team or null if none exists");
 
         teamGroup
             .MapPost("/drivers", AddDriverToTeamAsync)
             .WithName("Add Driver to Team")
-            .WithOpenApi()
             .WithDescription("Add a driver to the current user's team at a specific slot position");
 
         teamGroup
             .MapDelete("/drivers/{slotPosition}", RemoveDriverFromTeamAsync)
             .WithName("Remove Driver from Team")
-            .WithOpenApi()
             .WithDescription(
                 "Remove a driver from the current user's team at a specific slot position"
             );
@@ -62,7 +55,6 @@ public static class MeEndpoints
         teamGroup
             .MapPost("/constructors", AddConstructorToTeamAsync)
             .WithName("Add Constructor to Team")
-            .WithOpenApi()
             .WithDescription(
                 "Add a constructor to the current user's team at a specific slot position"
             );
@@ -70,7 +62,6 @@ public static class MeEndpoints
         teamGroup
             .MapDelete("/constructors/{slotPosition}", RemoveConstructorFromTeamAsync)
             .WithName("Remove Constructor from Team")
-            .WithOpenApi()
             .WithDescription(
                 "Remove a constructor from the current user's team at a specific slot position"
             );
@@ -78,7 +69,6 @@ public static class MeEndpoints
         teamGroup
             .MapPut("/captain", SetCaptainAsync)
             .WithName("Set Team Captain")
-            .WithOpenApi()
             .WithDescription(
                 "Set or clear the captain driver for the current race. Pass null driverId to deselect."
             );

--- a/api/F1CompanionApi/Api/Endpoints/RaceWeekendEndpoints.cs
+++ b/api/F1CompanionApi/Api/Endpoints/RaceWeekendEndpoints.cs
@@ -10,8 +10,7 @@ public static class RaceWeekendEndpoints
     public static IEndpointRouteBuilder MapRaceWeekendEndpoints(this IEndpointRouteBuilder app)
     {
         var raceWeekendsGroup = app.MapGroup("/seasons/{seasonId}/race-weekends")
-            .RequireAuthorization()
-            .WithOpenApi();
+            .RequireAuthorization();
 
         raceWeekendsGroup
             .MapGet("/", GetRaceWeekendsBySeasonAsync)

--- a/api/F1CompanionApi/Api/Endpoints/RaceWeekendResultEndpoints.cs
+++ b/api/F1CompanionApi/Api/Endpoints/RaceWeekendResultEndpoints.cs
@@ -14,8 +14,7 @@ public static class RaceWeekendResultEndpoints
     )
     {
         var resultsGroup = app.MapGroup("/seasons/{seasonId}/race-weekends/{round}/results")
-            .RequireAuthorization()
-            .WithOpenApi();
+            .RequireAuthorization();
 
         resultsGroup
             .MapPut("/qualifying", SubmitQualifyingResultsAsync)

--- a/api/F1CompanionApi/Api/Endpoints/SeasonEndpoints.cs
+++ b/api/F1CompanionApi/Api/Endpoints/SeasonEndpoints.cs
@@ -10,7 +10,7 @@ public static class SeasonEndpoints
     [ExcludeFromCodeCoverage]
     public static IEndpointRouteBuilder MapSeasonEndpoints(this IEndpointRouteBuilder app)
     {
-        var seasonsGroup = app.MapGroup("/seasons").RequireAuthorization().WithOpenApi();
+        var seasonsGroup = app.MapGroup("/seasons").RequireAuthorization();
 
         seasonsGroup
             .MapGet("/", GetSeasonsAsync)

--- a/api/F1CompanionApi/Api/Endpoints/TeamEndpoints.cs
+++ b/api/F1CompanionApi/Api/Endpoints/TeamEndpoints.cs
@@ -16,17 +16,12 @@ public static class TeamEndpoints
         app.MapPost("/teams", CreateTeamAsync)
             .RequireAuthorization()
             .WithName("CreateTeam")
-            .WithOpenApi()
             .WithDescription("Create a new team for the current user");
 
-        app.MapGet("/teams", GetTeamsAsync)
-            .WithName("GetTeams")
-            .WithOpenApi()
-            .WithDescription("Gets all teams");
+        app.MapGet("/teams", GetTeamsAsync).WithName("GetTeams").WithDescription("Gets all teams");
 
         app.MapGet("/teams/{id}", GetTeamByIdAsync)
             .WithName("GetTeamById")
-            .WithOpenApi()
             .WithDescription("Get Team By Id");
 
         return app;

--- a/api/F1CompanionApi/F1CompanionApi.csproj
+++ b/api/F1CompanionApi/F1CompanionApi.csproj
@@ -14,7 +14,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.14.0" />
     <PackageReference Include="Sentry.AspNetCore" Version="6.4.0" />

--- a/api/F1CompanionApi/F1CompanionApi.csproj
+++ b/api/F1CompanionApi/F1CompanionApi.csproj
@@ -1,23 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>8ba71e5a-ea40-4fa1-b621-2a9e20d3556f</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.15" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.15" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.15" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.15">
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.14.0" />
-    <PackageReference Include="Sentry.AspNetCore" Version="6.3.2" />
+    <PackageReference Include="Sentry.AspNetCore" Version="6.4.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.14.0" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestMinor"
+  }
+}


### PR DESCRIPTION
## Summary
- Bumps both csproj files to `net10.0` and upgrades all packages per the matrix in #105 (EF Core 10.0.4, Npgsql EF 10.0.1, AspNetCore 10.0.0, Sentry 6.4.0)
- Updates Dockerfile base images to `aspnet:10.0` / `sdk:10.0` and pins the `dotnet-ef` install to `10.*`
- Bumps CI `setup-dotnet` to `10.0.x`
- Resolves the two new-in-.NET-10 warnings: drops the redundant `Microsoft.Extensions.Configuration.Json` package reference (now in the shared framework, `NU1510`) and removes all `.WithOpenApi()` calls (obsolete, `ASPDEPR002` — endpoint discovery is automatic via `AddOpenApi`/`MapOpenApi`)
- Adds `global.json` with `rollForward: latestMinor` pinning to .NET 10 — acts as a tripwire forcing CI + Dockerfile updates on the next major SDK upgrade (same role as `.nvmrc`)

Closes #105.

## Verification
- `npm run api:build` — succeeds with **0 warnings, 0 errors**
- `npm run api:test` — 440/440 passing on `net10.0`
- `npm run api:format:check` — clean
- `dotnet ef migrations add TestDotnet10Upgrade` locally produced an empty migration (only a `ProductVersion` annotation diff in the snapshot) — confirms EF Core 10 introduces no model snapshot drift
- `/openapi/v1.json` and `/scalar/v1` smoke-tested locally — Scalar renders the .NET 10 OpenAPI 3.1 document correctly
- Pre-existing MSB3277 transitive-EFCore.Relational conflict in the test project is resolved by the upgrade

## Test plan
- [ ] CI passes on `10.0.x`
- [ ] Fly.io build succeeds against `mcr.microsoft.com/dotnet/aspnet:10.0`
- [ ] Post-deploy: smoke test auth + initial page load requests