### PR TITLE
API key auth for race result ingestion

### DIFF
--- a/api/F1CompanionApi.UnitTests/Authentication/ApiKeyAuthenticationHandlerTests.cs
+++ b/api/F1CompanionApi.UnitTests/Authentication/ApiKeyAuthenticationHandlerTests.cs
@@ -1,0 +1,92 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using F1CompanionApi.Authentication;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace F1CompanionApi.UnitTests.Authentication;
+
+public class ApiKeyAuthenticationHandlerTests
+{
+    private const string ValidApiKey = "test-api-key-12345";
+
+    private static async Task<AuthenticateResult> AuthenticateAsync(
+        string? headerValue,
+        string? configuredKey
+    )
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?> { ["Authentication:ApiKey"] = configuredKey }
+            )
+            .Build();
+
+        var optionsMock = new Mock<IOptionsMonitor<AuthenticationSchemeOptions>>();
+        optionsMock
+            .Setup(o => o.Get(It.IsAny<string>()))
+            .Returns(new AuthenticationSchemeOptions());
+
+        var handler = new ApiKeyAuthenticationHandler(
+            optionsMock.Object,
+            new LoggerFactory(),
+            UrlEncoder.Default,
+            config
+        );
+
+        var scheme = new AuthenticationScheme(
+            ApiKeyAuthenticationHandler.SchemeName,
+            null,
+            typeof(ApiKeyAuthenticationHandler)
+        );
+
+        var context = new DefaultHttpContext();
+        if (headerValue != null)
+            context.Request.Headers[ApiKeyAuthenticationHandler.HeaderName] = headerValue;
+
+        await handler.InitializeAsync(scheme, context);
+        return await handler.AuthenticateAsync();
+    }
+
+    [Fact]
+    public async Task HandleAuthenticateAsync_NoHeader_ReturnsNoResult()
+    {
+        var result = await AuthenticateAsync(null, ValidApiKey);
+
+        Assert.False(result.Succeeded);
+        Assert.Null(result.Failure);
+    }
+
+    [Fact]
+    public async Task HandleAuthenticateAsync_ValidKey_ReturnsSuccessWithAdminClaim()
+    {
+        var result = await AuthenticateAsync(ValidApiKey, ValidApiKey);
+
+        Assert.True(result.Succeeded);
+        Assert.Contains(
+            result.Principal!.Claims,
+            c => c.Type == ClaimTypes.Role && c.Value == "Admin"
+        );
+    }
+
+    [Fact]
+    public async Task HandleAuthenticateAsync_InvalidKey_ReturnsFail()
+    {
+        var result = await AuthenticateAsync("wrong-key", ValidApiKey);
+
+        Assert.False(result.Succeeded);
+        Assert.NotNull(result.Failure);
+    }
+
+    [Fact]
+    public async Task HandleAuthenticateAsync_UnconfiguredKey_ReturnsFail()
+    {
+        var result = await AuthenticateAsync(ValidApiKey, null);
+
+        Assert.False(result.Succeeded);
+        Assert.NotNull(result.Failure);
+    }
+}

--- a/api/F1CompanionApi.UnitTests/Authentication/ApiKeyAuthenticationHandlerTests.cs
+++ b/api/F1CompanionApi.UnitTests/Authentication/ApiKeyAuthenticationHandlerTests.cs
@@ -1,4 +1,3 @@
-using System.Security.Claims;
 using System.Text.Encodings.Web;
 using F1CompanionApi.Authentication;
 using Microsoft.AspNetCore.Authentication;
@@ -61,15 +60,12 @@ public class ApiKeyAuthenticationHandlerTests
     }
 
     [Fact]
-    public async Task HandleAuthenticateAsync_ValidKey_ReturnsSuccessWithAdminClaim()
+    public async Task HandleAuthenticateAsync_ValidKey_ReturnsSuccess()
     {
         var result = await AuthenticateAsync(ValidApiKey, ValidApiKey);
 
         Assert.True(result.Succeeded);
-        Assert.Contains(
-            result.Principal!.Claims,
-            c => c.Type == ClaimTypes.Role && c.Value == "Admin"
-        );
+        Assert.NotNull(result.Principal);
     }
 
     [Fact]

--- a/api/F1CompanionApi/Api/Endpoints/RaceWeekendResultEndpoints.cs
+++ b/api/F1CompanionApi/Api/Endpoints/RaceWeekendResultEndpoints.cs
@@ -18,6 +18,7 @@ public static class RaceWeekendResultEndpoints
 
         resultsGroup
             .MapPut("/qualifying", SubmitQualifyingResultsAsync)
+            .RequireAuthorization("ApiKeyOnly")
             .WithName("SubmitQualifyingResults")
             .WithDescription(
                 "Submit qualifying results for a race weekend, replacing any existing results"
@@ -30,6 +31,7 @@ public static class RaceWeekendResultEndpoints
 
         resultsGroup
             .MapPut("/sprint", SubmitSprintResultsAsync)
+            .RequireAuthorization("ApiKeyOnly")
             .WithName("SubmitSprintResults")
             .WithDescription(
                 "Submit sprint results for a race weekend, replacing any existing results"
@@ -42,6 +44,7 @@ public static class RaceWeekendResultEndpoints
 
         resultsGroup
             .MapPut("/grand-prix", SubmitGrandPrixResultsAsync)
+            .RequireAuthorization("ApiKeyOnly")
             .WithName("SubmitGrandPrixResults")
             .WithDescription(
                 "Submit Grand Prix results for a race weekend, replacing any existing results"

--- a/api/F1CompanionApi/Authentication/ApiKeyAuthenticationHandler.cs
+++ b/api/F1CompanionApi/Authentication/ApiKeyAuthenticationHandler.cs
@@ -24,13 +24,22 @@ public class ApiKeyAuthenticationHandler(
 
         var configuredKey = configuration["Authentication:ApiKey"];
         if (string.IsNullOrEmpty(configuredKey))
+        {
+            Logger.LogWarning("API key authentication failed: no key configured");
             return Task.FromResult(AuthenticateResult.Fail("API key not configured"));
+        }
 
         var providedKeyBytes = Encoding.UTF8.GetBytes(headerValue.ToString());
         var configuredKeyBytes = Encoding.UTF8.GetBytes(configuredKey);
 
         if (!CryptographicOperations.FixedTimeEquals(providedKeyBytes, configuredKeyBytes))
+        {
+            Logger.LogWarning(
+                "API key authentication failed: invalid key from {RemoteIpAddress}",
+                Request.HttpContext.Connection.RemoteIpAddress
+            );
             return Task.FromResult(AuthenticateResult.Fail("Invalid API key"));
+        }
 
         var identity = new ClaimsIdentity(SchemeName);
         var principal = new ClaimsPrincipal(identity);

--- a/api/F1CompanionApi/Authentication/ApiKeyAuthenticationHandler.cs
+++ b/api/F1CompanionApi/Authentication/ApiKeyAuthenticationHandler.cs
@@ -32,8 +32,7 @@ public class ApiKeyAuthenticationHandler(
         if (!CryptographicOperations.FixedTimeEquals(providedKeyBytes, configuredKeyBytes))
             return Task.FromResult(AuthenticateResult.Fail("Invalid API key"));
 
-        var claims = new[] { new Claim(ClaimTypes.Role, "Admin") };
-        var identity = new ClaimsIdentity(claims, SchemeName);
+        var identity = new ClaimsIdentity(SchemeName);
         var principal = new ClaimsPrincipal(identity);
         var ticket = new AuthenticationTicket(principal, SchemeName);
 

--- a/api/F1CompanionApi/Authentication/ApiKeyAuthenticationHandler.cs
+++ b/api/F1CompanionApi/Authentication/ApiKeyAuthenticationHandler.cs
@@ -1,0 +1,42 @@
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Options;
+
+namespace F1CompanionApi.Authentication;
+
+public class ApiKeyAuthenticationHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder,
+    IConfiguration configuration
+) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    public const string SchemeName = "ApiKey";
+    public const string HeaderName = "X-Api-Key";
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue(HeaderName, out var headerValue))
+            return Task.FromResult(AuthenticateResult.NoResult());
+
+        var configuredKey = configuration["Authentication:ApiKey"];
+        if (string.IsNullOrEmpty(configuredKey))
+            return Task.FromResult(AuthenticateResult.Fail("API key not configured"));
+
+        var providedKeyBytes = Encoding.UTF8.GetBytes(headerValue.ToString());
+        var configuredKeyBytes = Encoding.UTF8.GetBytes(configuredKey);
+
+        if (!CryptographicOperations.FixedTimeEquals(providedKeyBytes, configuredKeyBytes))
+            return Task.FromResult(AuthenticateResult.Fail("Invalid API key"));
+
+        var claims = new[] { new Claim(ClaimTypes.Role, "Admin") };
+        var identity = new ClaimsIdentity(claims, SchemeName);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, SchemeName);
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/api/F1CompanionApi/Extensions/ServiceExtensions.cs
+++ b/api/F1CompanionApi/Extensions/ServiceExtensions.cs
@@ -3,7 +3,6 @@ using F1CompanionApi.Data;
 using F1CompanionApi.Domain.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 
@@ -142,14 +141,6 @@ public static class ServiceExtensions
                     policy.AuthenticationSchemes.Add(ApiKeyAuthenticationHandler.SchemeName);
                     policy.RequireAuthenticatedUser();
                 }
-            )
-            .SetDefaultPolicy(
-                new AuthorizationPolicyBuilder(
-                    JwtBearerDefaults.AuthenticationScheme,
-                    ApiKeyAuthenticationHandler.SchemeName
-                )
-                    .RequireAuthenticatedUser()
-                    .Build()
             );
         services.AddHttpContextAccessor();
         services.AddScoped<IConstructorService, ConstructorService>();

--- a/api/F1CompanionApi/Extensions/ServiceExtensions.cs
+++ b/api/F1CompanionApi/Extensions/ServiceExtensions.cs
@@ -1,6 +1,9 @@
+using F1CompanionApi.Authentication;
 using F1CompanionApi.Data;
 using F1CompanionApi.Domain.Services;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 
@@ -103,7 +106,11 @@ public static class ServiceExtensions
             ?? throw new InvalidOperationException("Supabase auth URL not configured");
 
         services
-            .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+                options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+            })
             .AddJwtBearer(options =>
             {
                 options.Authority = authUrl;
@@ -120,9 +127,30 @@ public static class ServiceExtensions
                     ValidateLifetime = true,
                     ClockSkew = TimeSpan.Zero,
                 };
-            });
+            })
+            .AddScheme<AuthenticationSchemeOptions, ApiKeyAuthenticationHandler>(
+                ApiKeyAuthenticationHandler.SchemeName,
+                _ => { }
+            );
 
-        services.AddAuthorization();
+        services
+            .AddAuthorizationBuilder()
+            .AddPolicy(
+                "ApiKeyOnly",
+                policy =>
+                {
+                    policy.AuthenticationSchemes.Add(ApiKeyAuthenticationHandler.SchemeName);
+                    policy.RequireAuthenticatedUser();
+                }
+            )
+            .SetDefaultPolicy(
+                new AuthorizationPolicyBuilder(
+                    JwtBearerDefaults.AuthenticationScheme,
+                    ApiKeyAuthenticationHandler.SchemeName
+                )
+                    .RequireAuthenticatedUser()
+                    .Build()
+            );
         services.AddHttpContextAccessor();
         services.AddScoped<IConstructorService, ConstructorService>();
         services.AddScoped<IDriverService, DriverService>();

--- a/api/F1CompanionApi/appsettings.json
+++ b/api/F1CompanionApi/appsettings.json
@@ -10,6 +10,9 @@
   "ConnectionStrings": {
     "DefaultConnection": ""
   },
+  "Authentication": {
+    "ApiKey": ""
+  },
   "Supabase": {
     "AuthUrl": ""
   },

--- a/api/scripts/.env.example
+++ b/api/scripts/.env.example
@@ -1,5 +1,2 @@
-F1_SUPABASE_URL=http://127.0.0.1:54321
-F1_SUPABASE_ANON_KEY=<your-anon-key>
-F1_IMPORT_EMAIL=admin@local.example.com
-F1_IMPORT_PASSWORD=<your-password>
+F1_API_KEY=<your-api-key>
 F1_API_URL=http://localhost:5000

--- a/api/scripts/README.md
+++ b/api/scripts/README.md
@@ -24,10 +24,7 @@ cp .env.example .env.prod
 
 ```ini
 # .env.local
-F1_SUPABASE_URL=http://127.0.0.1:54321
-F1_SUPABASE_ANON_KEY=<local-anon-key>
-F1_IMPORT_EMAIL=admin@local.example.com
-F1_IMPORT_PASSWORD=<local-password>
+F1_API_KEY=<local-api-key>
 F1_API_URL=http://localhost:5000
 ```
 
@@ -35,10 +32,7 @@ F1_API_URL=http://localhost:5000
 
 ```ini
 # .env.prod
-F1_SUPABASE_URL=https://cfuccajsckqzecbfyqrv.supabase.co
-F1_SUPABASE_ANON_KEY=<prod-anon-key>
-F1_IMPORT_EMAIL=admin@example.com
-F1_IMPORT_PASSWORD=<prod-password>
+F1_API_KEY=<prod-api-key>
 F1_API_URL=https://f1fantasyapp.fly.dev
 ```
 
@@ -59,11 +53,10 @@ python3 ingest_results.py --round 1 --env prod
 
 The script will:
 
-1. Authenticate with Supabase to get a JWT
-2. Fetch the current season from the API to determine the year and season ID
-3. Fetch the driver list from the API to map abbreviations to IDs
-4. Fetch race weekends to find the round and sprint status
-5. Verify the race date has passed (refuses to run for future races)
-6. Load qualifying results from FastF1 and submit them
-7. If sprint weekend: load sprint results, overtakes, and fastest lap and submit them
-8. Load race results, overtakes, and fastest lap and submit them
+1. Fetch the current season from the API to determine the year and season ID
+2. Fetch the driver list from the API to map abbreviations to IDs
+3. Fetch race weekends to find the round and sprint status
+4. Verify the race date has passed (refuses to run for future races)
+5. Load qualifying results from FastF1 and submit them
+6. If sprint weekend: load sprint results, overtakes, and fastest lap and submit them
+7. Load race results, overtakes, and fastest lap and submit them

--- a/api/scripts/ingest_results.py
+++ b/api/scripts/ingest_results.py
@@ -52,32 +52,14 @@ class ApiError(IngestError):
         super().__init__(f"{action} failed ({status_code}): {body}")
 
 
-def create_api_session(token: str) -> requests.Session:
-    """Create a requests session with authorization headers."""
+def create_api_session(api_key: str) -> requests.Session:
+    """Create a requests session with API key headers."""
     session = requests.Session()
     session.headers.update({
-        "Authorization": f"Bearer {token}",
+        "X-Api-Key": api_key,
         "Content-Type": "application/json",
     })
     return session
-
-
-def authenticate(supabase_url: str, anon_key: str, email: str, password: str) -> str:
-    """Sign in to Supabase and return an access token."""
-    resp = requests.post(
-        f"{supabase_url}/auth/v1/token?grant_type=password",
-        json={"email": email, "password": password},
-        headers={
-            "apikey": anon_key,
-            "Content-Type": "application/json",
-        },
-    )
-    if resp.status_code != 200:
-        raise ApiError("Authentication", resp.status_code, resp.text)
-    token = resp.json().get("access_token")
-    if not token:
-        raise IngestError("Authentication response missing access_token")
-    return token
 
 
 def fetch_driver_mapping(session: requests.Session, api_url: str) -> dict[str, int]:
@@ -322,13 +304,7 @@ def load_config(env: str) -> dict[str, str | None]:
     """Load and validate environment config."""
     env_file = f".env.{env}"
     config = dotenv_values(env_file)
-    required_keys = [
-        "F1_SUPABASE_URL",
-        "F1_SUPABASE_ANON_KEY",
-        "F1_IMPORT_EMAIL",
-        "F1_IMPORT_PASSWORD",
-        "F1_API_URL",
-    ]
+    required_keys = ["F1_API_KEY", "F1_API_URL"]
     missing = [k for k in required_keys if not config.get(k)]
     if missing:
         raise IngestError(f"Missing keys in {env_file}: {', '.join(missing)}")
@@ -352,17 +328,7 @@ def ingest(round_number: int, env: str) -> None:
     os.makedirs(CACHE_DIR, exist_ok=True)
     fastf1.Cache.enable_cache(CACHE_DIR)
 
-    # Authenticate
-    print(f"Authenticating against {config['F1_SUPABASE_URL']}...")
-    token = authenticate(
-        config["F1_SUPABASE_URL"],
-        config["F1_SUPABASE_ANON_KEY"],
-        config["F1_IMPORT_EMAIL"],
-        config["F1_IMPORT_PASSWORD"],
-    )
-    print("  Authenticated")
-
-    api_session = create_api_session(token)
+    api_session = create_api_session(config["F1_API_KEY"])
     api_url = config["F1_API_URL"]
 
     # Fetch current season to get season_id and year for FastF1

--- a/api/scripts/test_ingest_results.py
+++ b/api/scripts/test_ingest_results.py
@@ -7,11 +7,11 @@ from unittest.mock import MagicMock, patch
 
 from ingest_results import (
     IngestError,
-    RaceStatus,
+    RacingStatus as RaceStatus,
     build_qualifying_payload,
     build_race_payload,
     count_overtakes,
-    find_race,
+    find_race_weekend as find_race,
     get_fastest_lap_driver,
     load_session,
     map_status,

--- a/api/scripts/test_ingest_results.py
+++ b/api/scripts/test_ingest_results.py
@@ -7,11 +7,11 @@ from unittest.mock import MagicMock, patch
 
 from ingest_results import (
     IngestError,
-    RacingStatus as RaceStatus,
+    RacingStatus,
     build_qualifying_payload,
     build_race_payload,
     count_overtakes,
-    find_race_weekend as find_race,
+    find_race_weekend,
     get_fastest_lap_driver,
     load_session,
     map_status,
@@ -23,34 +23,34 @@ from ingest_results import (
 
 class TestMapStatus:
     def test_finished_returns_classified(self):
-        assert map_status("Finished") == RaceStatus.CLASSIFIED
+        assert map_status("Finished") == RacingStatus.CLASSIFIED
 
     def test_lapped_one_lap_returns_classified(self):
-        assert map_status("+1 Lap") == RaceStatus.CLASSIFIED
+        assert map_status("+1 Lap") == RacingStatus.CLASSIFIED
 
     def test_lapped_two_laps_returns_classified(self):
-        assert map_status("+2 Laps") == RaceStatus.CLASSIFIED
+        assert map_status("+2 Laps") == RacingStatus.CLASSIFIED
 
     def test_retired_returns_dnf(self):
-        assert map_status("Retired") == RaceStatus.DNF
+        assert map_status("Retired") == RacingStatus.DNF
 
     def test_engine_failure_returns_dnf(self):
-        assert map_status("Engine") == RaceStatus.DNF
+        assert map_status("Engine") == RacingStatus.DNF
 
     def test_accident_returns_dnf(self):
-        assert map_status("Accident") == RaceStatus.DNF
+        assert map_status("Accident") == RacingStatus.DNF
 
     def test_disqualified_returns_dsq(self):
-        assert map_status("Disqualified") == RaceStatus.DSQ
+        assert map_status("Disqualified") == RacingStatus.DSQ
 
     def test_none_returns_dns(self):
-        assert map_status(None) == RaceStatus.DNS
+        assert map_status(None) == RacingStatus.DNS
 
     def test_nan_returns_dns(self):
-        assert map_status(float("nan")) == RaceStatus.DNS
+        assert map_status(float("nan")) == RacingStatus.DNS
 
     def test_whitespace_is_stripped(self):
-        assert map_status("  Finished  ") == RaceStatus.CLASSIFIED
+        assert map_status("  Finished  ") == RacingStatus.CLASSIFIED
 
 
 # --- load_session ---
@@ -86,14 +86,14 @@ class TestFindRace:
             {"round": 1, "id": 10, "name": "Bahrain"},
             {"round": 2, "id": 20, "name": "Saudi Arabia"},
         ]
-        result = find_race(races, 2)
+        result = find_race_weekend(races, 2)
         assert result["id"] == 20
         assert result["name"] == "Saudi Arabia"
 
     def test_raises_when_not_found(self):
         races = [{"round": 1, "id": 10, "name": "Bahrain"}]
         with pytest.raises(IngestError, match="round 5 not found"):
-            find_race(races, 5)
+            find_race_weekend(races, 5)
 
 
 # --- count_overtakes ---
@@ -279,7 +279,7 @@ class TestBuildRacePayload:
             "finishPosition": 1,
             "overtakes": 3,
             "fastestLap": True,
-            "status": int(RaceStatus.CLASSIFIED),
+            "status": int(RacingStatus.CLASSIFIED),
         }
         assert warnings == []
 
@@ -312,7 +312,7 @@ class TestBuildRacePayload:
         payload, warnings = build_race_payload(session, driver_map, {})
 
         assert payload[0]["finishPosition"] is None
-        assert payload[0]["status"] == int(RaceStatus.DNF)
+        assert payload[0]["status"] == int(RacingStatus.DNF)
 
     def test_dsq_driver_has_null_finish_position(self):
         session = _make_session([
@@ -323,7 +323,7 @@ class TestBuildRacePayload:
         payload, warnings = build_race_payload(session, driver_map, {})
 
         assert payload[0]["finishPosition"] is None
-        assert payload[0]["status"] == int(RaceStatus.DSQ)
+        assert payload[0]["status"] == int(RacingStatus.DSQ)
 
     def test_lapped_driver_is_classified(self):
         session = _make_session([
@@ -334,7 +334,7 @@ class TestBuildRacePayload:
         payload, warnings = build_race_payload(session, driver_map, {})
 
         assert payload[0]["finishPosition"] == 12
-        assert payload[0]["status"] == int(RaceStatus.CLASSIFIED)
+        assert payload[0]["status"] == int(RacingStatus.CLASSIFIED)
 
     def test_skips_unknown_driver_with_warning(self):
         session = _make_session([

--- a/docs/plans/63-api-key-auth-for-ingestion.md
+++ b/docs/plans/63-api-key-auth-for-ingestion.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-PR #62 code review identified that the race result submission endpoints (`PUT /api/races/{raceId}/results/*`) use `.RequireAuthorization()` with no policy, meaning any authenticated Supabase user can submit/overwrite results. These endpoints should only be callable by the ingestion script.
+PR #62 code review identified that the race result submission endpoints (`PUT /api/seasons/{seasonId}/race-weekends/{round}/results/*`) use `.RequireAuthorization()` with no policy, meaning any authenticated Supabase user can submit/overwrite results. These endpoints should only be callable by the ingestion script.
 
 The current ingestion script authenticates via a Supabase email/password user. This is awkward because it's a service, not a user — it requires a bogus admin account with an email address just to satisfy Supabase's user model. A static API key is a better fit: it's the standard pattern for backend scripts and admin tooling, integrates cleanly with ASP.NET Core's multi-scheme auth, and removes the Supabase user dependency entirely.
 
@@ -64,13 +64,13 @@ cd api && dotnet test F1CompanionApi.UnitTests/F1CompanionApi.UnitTests.csproj
 
 ### Modified files
 
-**`api/F1CompanionApi/Api/Endpoints/RaceResultEndpoints.cs`**
+**`api/F1CompanionApi/Api/Endpoints/RaceWeekendResultEndpoints.cs`**
 - Split the single `resultsGroup` into two groups sharing the same route prefix:
   - `readGroup` with `.RequireAuthorization()` (default policy — JWT or API key)
   - `writeGroup` with `.RequireAuthorization("ApiKeyOnly")`
 - Handler methods (private static) unchanged
 
-Existing `RaceResultEndpointsTests.cs` invokes handler methods via reflection and doesn't test auth — no changes needed.
+Existing `RaceWeekendResultEndpointsTests.cs` invokes handler methods via reflection and doesn't test auth — no changes needed.
 
 ### Verify
 ```bash
@@ -124,7 +124,7 @@ F1_API_URL=https://f1fantasyapp.fly.dev
 | `api/F1CompanionApi/Authentication/ApiKeyAuthenticationHandler.cs` | New auth handler |
 | `api/F1CompanionApi.UnitTests/Authentication/ApiKeyAuthenticationHandlerTests.cs` | Handler tests |
 | `api/F1CompanionApi/Extensions/ServiceExtensions.cs` | Auth/policy registration |
-| `api/F1CompanionApi/Api/Endpoints/RaceResultEndpoints.cs` | Endpoint auth split |
+| `api/F1CompanionApi/Api/Endpoints/RaceWeekendResultEndpoints.cs` | Endpoint auth split |
 | `api/F1CompanionApi/appsettings.json` | Config placeholder |
 | `api/scripts/ingest_results.py` | Script simplification |
 | `api/scripts/.env.example` | Updated config template |


### PR DESCRIPTION
## Summary

- Adds a custom `ApiKeyAuthenticationHandler` as a second auth scheme alongside JWT Bearer, accepting an `X-Api-Key` header
- Registers an `"ApiKeyOnly"` policy and applies it directly to the three PUT result endpoints (`/qualifying`, `/sprint`, `/grand-prix`), restricting them to the ingestion script
- Switches the Python ingestion script from Supabase email/password auth to the new API key, removing the bogus admin account dependency

Closes #63

## Test plan

- [ ] Verify PUT result endpoints reject requests without `X-Api-Key` (expect 401)
- [ ] Verify PUT result endpoints reject requests with an invalid key (expect 401)
- [ ] Verify PUT result endpoints accept requests with a valid `X-Api-Key`
- [ ] Verify GET result endpoints still accept JWT-authenticated requests
- [ ] Run ingestion script locally with `python3 ingest_results.py --round <n>` and confirm results are submitted
- [ ] Deploy to production: `fly secrets set Authentication__ApiKey="<key>" -a f1fantasyapp`, update `.env.prod`, and run script against prod