### PR TITLE
Update team format to 5 drivers + 2 constructors

### DIFF
--- a/api/F1CompanionApi.UnitTests/Services/TeamServiceTests.cs
+++ b/api/F1CompanionApi.UnitTests/Services/TeamServiceTests.cs
@@ -490,7 +490,7 @@ public class TeamServiceTests
 
     [Theory]
     [InlineData(-1)]
-    [InlineData(5)]
+    [InlineData(6)]
     public async Task AddDriverToTeamAsync_InvalidSlotPosition_ThrowsInvalidOperationException(
         int slotPosition
     )
@@ -521,8 +521,8 @@ public class TeamServiceTests
         var user = CreateTestUser(context);
         var team = CreateTestTeam(context, user.Id);
 
-        // Add 4 drivers to fill all slots
-        for (int i = 0; i < 4; i++)
+        // Add 5 drivers to fill all slots
+        for (int i = 0; i < 5; i++)
         {
             var driver = CreateTestDriver(context, $"DR{i}", $"Driver{i}", $"Last{i}");
             await service.AddDriverToTeamAsync(team.Id, driver.Id, i, user.Id);
@@ -535,7 +535,7 @@ public class TeamServiceTests
             service.AddDriverToTeamAsync(team.Id, newDriver.Id, 0, user.Id)
         );
         Assert.Equal(team.Id, exception.TeamId);
-        Assert.Equal(4, exception.MaxSlots);
+        Assert.Equal(5, exception.MaxSlots);
         Assert.Equal("driver", exception.EntityType);
     }
 
@@ -809,7 +809,7 @@ public class TeamServiceTests
 
     [Theory]
     [InlineData(-1)]
-    [InlineData(4)]
+    [InlineData(2)]
     public async Task AddConstructorToTeamAsync_InvalidSlotPosition_ThrowsInvalidOperationException(
         int slotPosition
     )
@@ -840,8 +840,8 @@ public class TeamServiceTests
         var user = CreateTestUser(context);
         var team = CreateTestTeam(context, user.Id);
 
-        // Add 4 constructors to fill all slots
-        for (int i = 0; i < 4; i++)
+        // Add 2 constructors to fill all slots
+        for (int i = 0; i < 2; i++)
         {
             var constructor = CreateTestConstructor(context, $"Constructor{i}");
             await service.AddConstructorToTeamAsync(team.Id, constructor.Id, i, user.Id);
@@ -854,7 +854,7 @@ public class TeamServiceTests
             service.AddConstructorToTeamAsync(team.Id, newConstructor.Id, 0, user.Id)
         );
         Assert.Equal(team.Id, exception.TeamId);
-        Assert.Equal(4, exception.MaxSlots);
+        Assert.Equal(2, exception.MaxSlots);
         Assert.Equal("constructor", exception.EntityType);
     }
 
@@ -881,7 +881,7 @@ public class TeamServiceTests
     }
 
     [Fact]
-    public async Task AddConstructorToTeamAsync_SameConstructorTwice_Succeeds()
+    public async Task AddConstructorToTeamAsync_SameConstructorSecondAdd_ThrowsEntityAlreadyOnTeamException()
     {
         // Arrange
         using var context = CreateInMemoryContext();
@@ -892,36 +892,10 @@ public class TeamServiceTests
         var constructor = CreateTestConstructor(context, "Red Bull Racing");
 
         await service.AddConstructorToTeamAsync(team.Id, constructor.Id, 0, user.Id);
-
-        // Act
-        await service.AddConstructorToTeamAsync(team.Id, constructor.Id, 1, user.Id);
-
-        // Assert
-        var teamConstructors = context
-            .TeamConstructors.Where(tc =>
-                tc.TeamId == team.Id && tc.ConstructorId == constructor.Id
-            )
-            .ToList();
-        Assert.Equal(2, teamConstructors.Count);
-    }
-
-    [Fact]
-    public async Task AddConstructorToTeamAsync_SameConstructorThreeTimes_ThrowsEntityAlreadyOnTeamException()
-    {
-        // Arrange
-        using var context = CreateInMemoryContext();
-        var service = new TeamService(context, _mockLogger.Object);
-
-        var user = CreateTestUser(context);
-        var team = CreateTestTeam(context, user.Id);
-        var constructor = CreateTestConstructor(context, "Red Bull Racing");
-
-        await service.AddConstructorToTeamAsync(team.Id, constructor.Id, 0, user.Id);
-        await service.AddConstructorToTeamAsync(team.Id, constructor.Id, 1, user.Id);
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<EntityAlreadyOnTeamException>(() =>
-            service.AddConstructorToTeamAsync(team.Id, constructor.Id, 2, user.Id)
+            service.AddConstructorToTeamAsync(team.Id, constructor.Id, 1, user.Id)
         );
         Assert.Equal(constructor.Id, exception.EntityId);
         Assert.Equal("constructor", exception.EntityType);
@@ -929,7 +903,7 @@ public class TeamServiceTests
     }
 
     [Fact]
-    public async Task AddConstructorToTeamAsync_TwoDifferentConstructorsEachTwice_FillsAllSlots()
+    public async Task AddConstructorToTeamAsync_TwoDifferentConstructors_FillsAllSlots()
     {
         // Arrange
         using var context = CreateInMemoryContext();
@@ -942,15 +916,13 @@ public class TeamServiceTests
 
         // Act
         await service.AddConstructorToTeamAsync(team.Id, constructor1.Id, 0, user.Id);
-        await service.AddConstructorToTeamAsync(team.Id, constructor1.Id, 1, user.Id);
-        await service.AddConstructorToTeamAsync(team.Id, constructor2.Id, 2, user.Id);
-        await service.AddConstructorToTeamAsync(team.Id, constructor2.Id, 3, user.Id);
+        await service.AddConstructorToTeamAsync(team.Id, constructor2.Id, 1, user.Id);
 
         // Assert
         var teamConstructors = context.TeamConstructors.Where(tc => tc.TeamId == team.Id).ToList();
-        Assert.Equal(4, teamConstructors.Count);
-        Assert.Equal(2, teamConstructors.Count(tc => tc.ConstructorId == constructor1.Id));
-        Assert.Equal(2, teamConstructors.Count(tc => tc.ConstructorId == constructor2.Id));
+        Assert.Equal(2, teamConstructors.Count);
+        Assert.Equal(1, teamConstructors.Count(tc => tc.ConstructorId == constructor1.Id));
+        Assert.Equal(1, teamConstructors.Count(tc => tc.ConstructorId == constructor2.Id));
     }
 
     [Fact]
@@ -1312,7 +1284,7 @@ public class TeamServiceTests
     }
 
     [Fact]
-    public async Task AddConstructorToTeamAsync_SameConstructorTwice_CreatesTwoLineupEntries()
+    public async Task AddConstructorToTeamAsync_TwoDifferentConstructors_CreateTwoLineupEntries()
     {
         // Arrange
         using var context = CreateInMemoryContext();
@@ -1320,7 +1292,8 @@ public class TeamServiceTests
 
         var user = CreateTestUser(context);
         var team = CreateTestTeam(context, user.Id);
-        var constructor = CreateTestConstructor(context, "Red Bull Racing");
+        var constructor1 = CreateTestConstructor(context, "Red Bull Racing");
+        var constructor2 = CreateTestConstructor(context, "Ferrari");
         CreateTestRace(
             context,
             raceDate: DateTime.UtcNow.AddDays(2),
@@ -1328,8 +1301,8 @@ public class TeamServiceTests
         );
 
         // Act
-        await service.AddConstructorToTeamAsync(team.Id, constructor.Id, 0, user.Id);
-        await service.AddConstructorToTeamAsync(team.Id, constructor.Id, 1, user.Id);
+        await service.AddConstructorToTeamAsync(team.Id, constructor1.Id, 0, user.Id);
+        await service.AddConstructorToTeamAsync(team.Id, constructor2.Id, 1, user.Id);
 
         // Assert
         Assert.Equal(2, await context.LineupEntries.CountAsync());

--- a/api/F1CompanionApi/Domain/Services/TeamService.cs
+++ b/api/F1CompanionApi/Domain/Services/TeamService.cs
@@ -149,17 +149,17 @@ public class TeamService : ITeamService
         }
 
         // Validate slot position range
-        if (slotPosition < 0 || slotPosition > 3)
+        if (slotPosition < 0 || slotPosition > 4)
         {
             _logger.LogWarning("Invalid slot position {SlotPosition} for driver", slotPosition);
-            throw new InvalidSlotPositionException(slotPosition, 3, "driver");
+            throw new InvalidSlotPositionException(slotPosition, 4, "driver");
         }
 
         // Validate driver limit
-        if (team.TeamDrivers.Count >= 4)
+        if (team.TeamDrivers.Count >= 5)
         {
             _logger.LogWarning("Team {TeamId} already has maximum drivers", teamId);
-            throw new TeamFullException(teamId, 4, "driver");
+            throw new TeamFullException(teamId, 5, "driver");
         }
 
         // Check if slot is already occupied
@@ -347,20 +347,20 @@ public class TeamService : ITeamService
         }
 
         // Validate slot position range
-        if (slotPosition < 0 || slotPosition > 3)
+        if (slotPosition < 0 || slotPosition > 1)
         {
             _logger.LogWarning(
                 "Invalid slot position {SlotPosition} for constructor",
                 slotPosition
             );
-            throw new InvalidSlotPositionException(slotPosition, 3, "constructor");
+            throw new InvalidSlotPositionException(slotPosition, 1, "constructor");
         }
 
         // Validate constructor limit
-        if (team.TeamConstructors.Count >= 4)
+        if (team.TeamConstructors.Count >= 2)
         {
             _logger.LogWarning("Team {TeamId} already has maximum constructors", teamId);
-            throw new TeamFullException(teamId, 4, "constructor");
+            throw new TeamFullException(teamId, 2, "constructor");
         }
 
         // Check if slot is already occupied
@@ -374,12 +374,11 @@ public class TeamService : ITeamService
             throw new SlotOccupiedException(slotPosition, teamId);
         }
 
-        // Check if constructor already at maximum (2) on team
-        var constructorCount = team.TeamConstructors.Count(tc => tc.ConstructorId == constructorId);
-        if (constructorCount >= 2)
+        // Check if constructor already on team
+        if (team.TeamConstructors.Any(tc => tc.ConstructorId == constructorId))
         {
             _logger.LogWarning(
-                "Constructor {ConstructorId} already at maximum (2) on team {TeamId}",
+                "Constructor {ConstructorId} already on team {TeamId}",
                 constructorId,
                 teamId
             );

--- a/docs/plans/95-team-format-5d-2c.md
+++ b/docs/plans/95-team-format-5d-2c.md
@@ -1,0 +1,139 @@
+# 95 — Update team format to 5 drivers + 2 constructors
+
+## Context
+
+The fantasy team composition changed from **4 drivers + 4 constructors** to **5 drivers + 2 constructors**. `docs/research/fantasy-rules/decisions/format.md` already states `5 drivers + 2 constructors` at line 19, but the backend (`TeamService.cs`) still hardcodes the old 4/4 limits — the GitHub issue's claim that "backend already reflects this" is wrong. Scope is being expanded beyond the issue body (#95) to cover the backend so the feature works end-to-end.
+
+Additionally, the current constructor rule allows the same constructor to occupy up to **2** slots (a relic of the 4-slot era). With only 2 slots going forward, constructor **uniqueness** is being introduced — no duplicates in a team — making constructors symmetric with drivers (which are already unique via `TeamService.cs:177`).
+
+The frontend will render 5 driver cards in a centered 2-over-3 grid (top row 2 cards, bottom row 3 cards, all equal width), matching the approved mockup.
+
+## Commit plan
+
+Two self-contained commits. Backend first so the API accepts the new shape before the UI exercises it; both commits independently pass build, lint, tests.
+
+---
+
+### Commit 1 — `feat(api): enforce 5D+2C team shape and unique constructors`
+
+Two coupled backend rule changes: slot/count limits and constructor uniqueness. Bundled because the old `SameConstructorThreeTimes` test stops making sense once the 2-slot cap lands (third add would throw `TeamFullException`, not `EntityAlreadyOnTeamException`).
+
+**`api/F1CompanionApi/Domain/Services/TeamService.cs`**
+
+Driver limits (`AddDriverToTeamAsync`):
+
+- Line 152: `slotPosition > 3` → `slotPosition > 4`
+- Line 155: `InvalidSlotPositionException(slotPosition, 3, "driver")` → `… 4, "driver"`
+- Line 159: `team.TeamDrivers.Count >= 4` → `>= 5`
+- Line 162: `TeamFullException(teamId, 4, "driver")` → `… 5, "driver"`
+
+Constructor limits + uniqueness (`AddConstructorToTeamAsync`):
+
+- Line 350: `slotPosition > 3` → `slotPosition > 1`
+- Line 356: `InvalidSlotPositionException(slotPosition, 3, "constructor")` → `… 1, "constructor"`
+- Line 360: `team.TeamConstructors.Count >= 4` → `>= 2`
+- Line 363: `TeamFullException(teamId, 4, "constructor")` → `… 2, "constructor"`
+- Lines 377–387: replace the `constructorCount >= 2` block with the uniqueness pattern already used for drivers (see `TeamService.cs:177`):
+
+  ```csharp
+  if (team.TeamConstructors.Any(tc => tc.ConstructorId == constructorId))
+  {
+      _logger.LogWarning("Constructor {ConstructorId} already on team {TeamId}", constructorId, teamId);
+      throw new EntityAlreadyOnTeamException(constructorId, "constructor", teamId);
+  }
+  ```
+
+**`api/F1CompanionApi.UnitTests/Services/TeamServiceTests.cs`**
+
+Slot-position bounds:
+
+- Line 492: driver `InlineData(5)` → `InlineData(6)` (first invalid slot above the new max of 4)
+- Line 812: constructor `InlineData(4)` → `InlineData(2)`
+
+Team-full assertions:
+
+- `AddDriverToTeamAsync_TeamHasMaximumDrivers_…` (line 515+): seed 5 drivers instead of 4 (loop to `< 5`, unique slots 0–4; update comment at line 524).
+- `AddConstructorToTeamAsync_TeamHasMaximumConstructors_…` (line 833+): seed 2 *different* constructors instead of 4 (was 4 of the same, which is no longer legal); update comment at line 843.
+
+Constructor uniqueness (replaces old "same constructor up to 2 times" tests):
+
+- Line 883 `AddConstructorToTeamAsync_SameConstructorTwice_Succeeds` — **rewrite** as `…_SameConstructorSecondAdd_ThrowsEntityAlreadyOnTeamException`: add once at slot 0, add again at slot 1 → expect `EntityAlreadyOnTeamException`.
+- Line 908 `AddConstructorToTeamAsync_SameConstructorThreeTimes_Throws…` — **delete** (redundant with the above).
+- Line 931 `AddConstructorToTeamAsync_TwoDifferentConstructorsEachTwice_FillsAllSlots` — **rewrite** as `…_TwoDifferentConstructors_FillsAllSlots`: 2 distinct constructors, slots 0 and 1, assert 2 rows, one per constructor.
+- Line 1314 `AddConstructorToTeamAsync_SameConstructorTwice_CreatesTwoLineupEntries` — **rewrite** as `…_TwoDifferentConstructors_CreateTwoLineupEntries`: 2 distinct constructors, slots 0 and 1, assert 2 `LineupEntry` rows.
+
+**`docs/research/fantasy-rules/decisions/format.md`**
+
+Rewrite the `## Constraints` heading body (currently lines 25–27) so the uniqueness rule applies to both entity types and the old "any combination is valid" claim is corrected:
+
+```
+## Constraints
+
+**Drivers and constructors must each be unique within a team** — a team cannot select the same driver or the same constructor twice.
+
+Beyond uniqueness, there are no roster constraints. Players may pick both drivers from the same constructor. Budget already prevents degenerate stacking by making top-team asset concentration expensive.
+```
+
+The "driver without their constructor" clause from the old body was dropped — it was the default state, not a choice worth calling out.
+
+**Note on stale reference:** `docs/plans/44-lineup-snapshots.md` contains outdated language ("the domain allows the same constructor twice on one team") tied to a completed plan. Leaving it as historical record — updating archived plan docs is out of scope.
+
+**Verification for commit 1:**
+
+- `npm run api:test` — all green.
+- `npm run api:format:check` and `npm run api:build` — clean.
+
+---
+
+### Commit 2 — `feat(web): update team builder UI to 5 drivers + 2 constructors`
+
+Flip picker slot counts, restructure driver grid to centered 2-over-3, update test fixtures.
+
+**`web/src/components/DriverPicker/DriverPicker.tsx`**
+
+- Line 29: `DRIVER_SLOTS = 4` → `5`
+- Line 86: replace the grid container `className` from `grid-cols-1 gap-4 sm:grid-cols-2` to `grid-cols-1 gap-4 sm:grid-cols-6`. On each mapped slot, apply `sm:col-span-2`; on `index === 0`, additionally apply `sm:col-start-2`. Result at sm+: top row has 2 cards occupying cols 2–3 and 4–5 (centered, cols 1 and 6 empty), bottom row has 3 cards across cols 1–2, 3–4, 5–6. All cards equal width. Below sm, `grid-cols-1` stacks all 5 vertically and the col-span classes are no-ops.
+
+**`web/src/components/ConstructorPicker/ConstructorPicker.tsx`**
+
+- Line 27: `CONSTRUCTOR_SLOTS = 4` → `2`
+- Grid unchanged — `sm:grid-cols-2` already fits 2 cards perfectly.
+
+**`web/src/components/DriverPicker/DriverPicker.test.tsx`**
+
+- Line 52: empty fixture `[null, null, null, null]` → 5 nulls
+- Line 60 + 66: rename "4 empty driver slots" → "5 empty driver slots"; `toHaveLength(4)` → `5`
+- Lines 94–102: extend full-lineup fixture to 5 drivers
+- Lines 143–144: repad partial-lineup fixtures to length 5
+
+**`web/src/components/ConstructorPicker/ConstructorPicker.test.tsx`**
+
+- Line 61: empty fixture `[null, null, null, null]` → `[null, null]`
+- Line 81 + 91: rename "4 empty constructor slots" → "2 empty constructor slots"; `toHaveLength(4)` → `2`
+- Lines 119–132: trim full-lineup fixture to 2 constructors
+- Line 447: `'2 / 4'` → `'2 / 2'`
+
+`web/src/hooks/useLineupPicker.test.ts` — no changes (format-agnostic).
+
+**Verification for commit 2:**
+
+- `npm run web:test` — all picker tests green.
+- `npm run web:lint` and `npm run web:format:check` — clean.
+- `npm run web:dev` and load the team builder:
+  - Drivers: 5 empty slots, 2 centered on the top row + 3 full-width on the bottom row at sm/md/lg. Below sm, all 5 stack vertically with no orphan.
+  - Constructors: 2 empty slots side-by-side.
+  - Fill/clear slots → counters read `… / 5` and `… / 2`.
+  - Pick a 5th driver end-to-end (click through to save) and confirm the API accepts `slotPosition: 4` — proves commit 1 wired correctly.
+  - Try to add the same constructor twice in the UI → API rejects with `EntityAlreadyOnTeamException` (409).
+
+---
+
+## Out of scope (confirmed)
+
+- Captain/2× badge — already implemented full-stack (`DriverCard.tsx:71-102`, `Team.tsx:56-99`, backend `setCaptain`).
+- Budget cap — unchanged at $100M per `format.md`.
+- Loading skeletons, Storybook, E2E, snapshot tests — none exist for these components.
+- `useLineupPicker.test.ts` — uses `lineupSize: 4` as a generic parameter; not format-coupled.
+- `web/src/contracts/Team.ts` — open-ended arrays, no length constraints.
+- Driver uniqueness — already enforced (`TeamService.cs:177`).
+- Stale prose in `docs/plans/44-lineup-snapshots.md` — historical record of a completed plan; not updated.

--- a/docs/research/fantasy-rules/decisions/format.md
+++ b/docs/research/fantasy-rules/decisions/format.md
@@ -22,6 +22,6 @@ Matches the official F1 Fantasy format. The 2026 grid has 22 drivers across 11 c
 
 ## Constraints
 
-**No roster constraints — any combination of drivers and constructors is valid.**
+**Drivers and constructors must each be unique within a team** — a team cannot select the same driver or the same constructor twice.
 
-Players can pick both drivers from the same constructor, or a driver without their constructor. Budget already prevents degenerate stacking by making top-team asset concentration expensive.
+Beyond uniqueness, there are no roster constraints. Players may pick both drivers from the same constructor. Budget already prevents degenerate stacking by making top-team asset concentration expensive.

--- a/web/src/components/ConstructorPicker/ConstructorPicker.test.tsx
+++ b/web/src/components/ConstructorPicker/ConstructorPicker.test.tsx
@@ -58,7 +58,7 @@ describe('ConstructorPicker', () => {
     vi.clearAllMocks();
 
     // Default state: empty lineup, all constructors in pool, picker closed
-    mockDisplayLineup = [null, null, null, null];
+    mockDisplayLineup = [null, null];
     mockPool = mockConstructors;
     mockSelectedPosition = null;
     mockIsPending = false;
@@ -78,7 +78,7 @@ describe('ConstructorPicker', () => {
   });
 
   describe('Lineup Rendering', () => {
-    it('renders 4 empty constructor slots by default', () => {
+    it('renders 2 empty constructor slots by default', () => {
       render(
         <ConstructorPicker
           activeConstructors={mockConstructors}
@@ -88,16 +88,13 @@ describe('ConstructorPicker', () => {
       );
 
       const addButtons = screen.getAllByRole('button', { name: /add constructor/i });
-      expect(addButtons).toHaveLength(4);
+      expect(addButtons).toHaveLength(2);
     });
 
     it('displays existing constructors in correct positions', () => {
-      const teamConstructors: TeamConstructor[] = [
-        toTeamConstructor(mockConstructors[0], 0),
-        toTeamConstructor(mockConstructors[1], 1),
-      ];
+      const teamConstructors: TeamConstructor[] = [toTeamConstructor(mockConstructors[0], 0)];
 
-      mockDisplayLineup = [mockConstructors[0], mockConstructors[1], null, null];
+      mockDisplayLineup = [mockConstructors[0], null];
 
       render(
         <ConstructorPicker
@@ -109,27 +106,19 @@ describe('ConstructorPicker', () => {
       );
 
       expect(screen.getByText('McLaren')).toBeInTheDocument();
-      expect(screen.getByText('Ferrari')).toBeInTheDocument();
 
-      // Two filled slots, two empty
+      // One filled slot, one empty
       const addButtons = screen.getAllByRole('button', { name: /add constructor/i });
-      expect(addButtons).toHaveLength(2);
+      expect(addButtons).toHaveLength(1);
     });
 
     it('displays all constructors when lineup is full', () => {
       const teamConstructors: TeamConstructor[] = [
         toTeamConstructor(mockConstructors[0], 0),
         toTeamConstructor(mockConstructors[1], 1),
-        toTeamConstructor(mockConstructors[2], 2),
-        toTeamConstructor(mockConstructors[3], 3),
       ];
 
-      mockDisplayLineup = [
-        mockConstructors[0],
-        mockConstructors[1],
-        mockConstructors[2],
-        mockConstructors[3],
-      ];
+      mockDisplayLineup = [mockConstructors[0], mockConstructors[1]];
 
       render(
         <ConstructorPicker
@@ -142,8 +131,6 @@ describe('ConstructorPicker', () => {
 
       expect(screen.getByText('McLaren')).toBeInTheDocument();
       expect(screen.getByText('Ferrari')).toBeInTheDocument();
-      expect(screen.getByText('Red Bull Racing')).toBeInTheDocument();
-      expect(screen.getByText('Mercedes')).toBeInTheDocument();
 
       // No "Add Constructor" buttons when all slots are filled
       expect(screen.queryByRole('button', { name: /add constructor/i })).not.toBeInTheDocument();
@@ -174,7 +161,7 @@ describe('ConstructorPicker', () => {
     });
 
     it('only displays constructors not in current lineup', () => {
-      mockDisplayLineup = [mockConstructors[0], null, null, null];
+      mockDisplayLineup = [mockConstructors[0], null];
       mockPool = [
         mockConstructors[1],
         mockConstructors[2],
@@ -434,7 +421,7 @@ describe('ConstructorPicker', () => {
     });
 
     it('shows filled count in section header', () => {
-      mockDisplayLineup = [mockConstructors[0], mockConstructors[1], null, null];
+      mockDisplayLineup = [mockConstructors[0], mockConstructors[1]];
 
       render(
         <ConstructorPicker
@@ -444,7 +431,7 @@ describe('ConstructorPicker', () => {
         />,
       );
 
-      expect(screen.getByText('2 / 4')).toBeInTheDocument();
+      expect(screen.getByText('2 / 2')).toBeInTheDocument();
     });
   });
 

--- a/web/src/components/ConstructorPicker/ConstructorPicker.tsx
+++ b/web/src/components/ConstructorPicker/ConstructorPicker.tsx
@@ -24,7 +24,7 @@ interface ConstructorPickerProps {
   remainingBudget: number;
 }
 
-const CONSTRUCTOR_SLOTS = 4;
+const CONSTRUCTOR_SLOTS = 2;
 
 export function ConstructorPicker({
   activeConstructors,

--- a/web/src/components/DriverPicker/DriverPicker.test.tsx
+++ b/web/src/components/DriverPicker/DriverPicker.test.tsx
@@ -49,7 +49,7 @@ describe('DriverPicker', () => {
     vi.clearAllMocks();
 
     // Default state: empty lineup, all drivers in pool, picker closed
-    mockDisplayLineup = [null, null, null, null];
+    mockDisplayLineup = [null, null, null, null, null];
     mockPool = mockDrivers;
     mockSelectedPosition = null;
     mockIsPending = false;
@@ -57,13 +57,13 @@ describe('DriverPicker', () => {
   });
 
   describe('Lineup Rendering', () => {
-    it('renders 4 empty driver slots by default', () => {
+    it('renders 5 empty driver slots by default', () => {
       render(
         <DriverPicker activeDrivers={mockDrivers} readOnly={false} remainingBudget={100_000_000} />,
       );
 
       const addButtons = screen.getAllByRole('button', { name: /add driver/i });
-      expect(addButtons).toHaveLength(4);
+      expect(addButtons).toHaveLength(5);
     });
 
     it('displays existing drivers in correct positions', () => {
@@ -72,7 +72,7 @@ describe('DriverPicker', () => {
         toTeamDriver(mockDrivers[1], 1),
       ];
 
-      mockDisplayLineup = [mockDrivers[0], mockDrivers[1], null, null];
+      mockDisplayLineup = [mockDrivers[0], mockDrivers[1], null, null, null];
 
       render(
         <DriverPicker
@@ -86,9 +86,9 @@ describe('DriverPicker', () => {
       expect(screen.getByText('Oscar Piastri')).toBeInTheDocument();
       expect(screen.getByText('Lando Norris')).toBeInTheDocument();
 
-      // Two filled slots, two empty
+      // Two filled slots, three empty
       const addButtons = screen.getAllByRole('button', { name: /add driver/i });
-      expect(addButtons).toHaveLength(2);
+      expect(addButtons).toHaveLength(3);
     });
 
     it('displays all drivers when lineup is full', () => {
@@ -97,9 +97,16 @@ describe('DriverPicker', () => {
         toTeamDriver(mockDrivers[1], 1),
         toTeamDriver(mockDrivers[2], 2),
         toTeamDriver(mockDrivers[3], 3),
+        toTeamDriver(mockDrivers[4], 4),
       ];
 
-      mockDisplayLineup = [mockDrivers[0], mockDrivers[1], mockDrivers[2], mockDrivers[3]];
+      mockDisplayLineup = [
+        mockDrivers[0],
+        mockDrivers[1],
+        mockDrivers[2],
+        mockDrivers[3],
+        mockDrivers[4],
+      ];
 
       render(
         <DriverPicker
@@ -114,6 +121,7 @@ describe('DriverPicker', () => {
       expect(screen.getByText('Lando Norris')).toBeInTheDocument();
       expect(screen.getByText('Charles Leclerc')).toBeInTheDocument();
       expect(screen.getByText('Max Verstappen')).toBeInTheDocument();
+      expect(screen.getByText('Lewis Hamilton')).toBeInTheDocument();
 
       // No "Add Driver" buttons when all slots are filled
       expect(screen.queryByRole('button', { name: /add driver/i })).not.toBeInTheDocument();
@@ -140,7 +148,7 @@ describe('DriverPicker', () => {
     });
 
     it('only displays drivers not in current lineup', () => {
-      mockDisplayLineup = [mockDrivers[0], null, null, null];
+      mockDisplayLineup = [mockDrivers[0], null, null, null, null];
       mockPool = [mockDrivers[1], mockDrivers[2], mockDrivers[3], mockDrivers[4]];
 
       render(
@@ -251,7 +259,7 @@ describe('DriverPicker', () => {
     });
 
     it('provides aria-label for remove buttons', () => {
-      mockDisplayLineup = [mockDrivers[0], null, null, null];
+      mockDisplayLineup = [mockDrivers[0], null, null, null, null];
 
       render(
         <DriverPicker

--- a/web/src/components/DriverPicker/DriverPicker.tsx
+++ b/web/src/components/DriverPicker/DriverPicker.tsx
@@ -26,7 +26,7 @@ interface DriverPickerProps {
   onSetCaptain?: (driverId: number | null) => void;
 }
 
-const DRIVER_SLOTS = 4;
+const DRIVER_SLOTS = 5;
 
 export function DriverPicker({
   activeDrivers,
@@ -83,21 +83,22 @@ export function DriverPicker({
           {filledCount} / {DRIVER_SLOTS}
         </span>
       </div>
-      <div className="relative grid auto-rows-fr grid-cols-1 gap-4 sm:grid-cols-2">
+      <div className="relative grid auto-rows-fr grid-cols-1 gap-4 sm:grid-cols-6">
         {displayLineup.map((driver, idx) => (
-          <DriverCard
-            key={idx}
-            driver={driver}
-            onOpenPicker={() => openPicker(idx)}
-            onRemove={() => handleRemove(idx)}
-            readOnly={readOnly}
-            isCaptain={driver !== null && driver.id === captainDriverId}
-            onSetCaptain={
-              driver && onSetCaptain
-                ? () => onSetCaptain(driver.id === captainDriverId ? null : driver.id)
-                : undefined
-            }
-          />
+          <div key={idx} className={`sm:col-span-2 ${idx === 0 ? 'sm:col-start-2' : ''}`}>
+            <DriverCard
+              driver={driver}
+              onOpenPicker={() => openPicker(idx)}
+              onRemove={() => handleRemove(idx)}
+              readOnly={readOnly}
+              isCaptain={driver !== null && driver.id === captainDriverId}
+              onSetCaptain={
+                driver && onSetCaptain
+                  ? () => onSetCaptain(driver.id === captainDriverId ? null : driver.id)
+                  : undefined
+              }
+            />
+          </div>
         ))}
 
         {isPending && (


### PR DESCRIPTION
## Summary

- Backend enforces the new team shape: 5 drivers + 2 constructors, with constructor uniqueness (symmetric with drivers) replacing the old "same constructor up to 2 slots" rule.
- Web team builder renders 5 driver cards in a centered 2-over-3 grid and 2 constructor slots, matching the approved mockup.
- Plan written to `docs/plans/95-team-format-5d-2c.md`; `format.md` tweaked to match.

Closes #95. **Breaking change** — existing teams built under the 4D+4C shape will not fit the new limits and need to be reset.

## Test plan

- [ ] `npm run api:test` — backend tests pass with updated slot/count bounds and new uniqueness assertions
- [ ] `npm run web:test` — picker tests pass with the 5D+2C sizing
- [ ] Manual: sign in, open `/my-team`, confirm 5 driver slots + 2 constructor slots render at 1280px and 375px
- [ ] Manual: attempt to add a duplicate constructor → API returns `409 Entity Already on Team`
- [ ] Manual: attempt to exceed 5 drivers or 2 constructors → API returns `400 Team Full`