### PR TITLE
Restore .NET 10 docker build and add prevention guardrails

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,3 +78,12 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+
+  - package-ecosystem: "docker"
+    directory: "/api"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,20 @@ jobs:
         run: npm run api:build
       - name: Test
         run: npm run api:test
+
+  api-docker:
+    name: API Docker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v3
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./api
+          file: ./api/Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -22,7 +22,7 @@ RUN dotnet publish "F1CompanionApi.csproj" -c Release --no-restore -o /app/publi
 # Build the EF migrations bundle
 FROM deps AS migrate
 RUN dotnet tool install --global dotnet-ef --version 10.* \
-    && /root/.dotnet/tools/dotnet-ef migrations bundle --self-contained -r linux-x64 --no-build -o /app/efbundle
+    && /root/.dotnet/tools/dotnet-ef migrations bundle --self-contained -r linux-x64 -o /app/efbundle
 
 # Final stage - create the runtime image
 FROM base AS final

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 EXPOSE 8080
 
 # Use the .NET 10 SDK for building the application
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS deps
 WORKDIR /src
 
 # Copy the project file and restore dependencies
@@ -13,19 +13,16 @@ RUN dotnet restore "F1CompanionApi/F1CompanionApi.csproj"
 
 # Copy the rest of the source code
 COPY . .
-WORKDIR "/src/F1CompanionApi"
-
-# Build the application
-RUN dotnet build "F1CompanionApi.csproj" -c Release -o /app/build
-
-# Build the EF migrations bundle
-FROM build AS migrate
-RUN dotnet tool install --global dotnet-ef --version 10.* \
-    && /root/.dotnet/tools/dotnet-ef migrations bundle --self-contained -r linux-x64 -o /app/efbundle
+WORKDIR /src/F1CompanionApi
 
 # Publish the application
-FROM build AS publish
-RUN dotnet publish "F1CompanionApi.csproj" -c Release -o /app/publish /p:UseAppHost=false
+FROM deps AS publish
+RUN dotnet publish "F1CompanionApi.csproj" -c Release --no-restore -o /app/publish /p:UseAppHost=false
+
+# Build the EF migrations bundle
+FROM deps AS migrate
+RUN dotnet tool install --global dotnet-ef --version 10.* \
+    && /root/.dotnet/tools/dotnet-ef migrations bundle --self-contained -r linux-x64 --no-build -o /app/efbundle
 
 # Final stage - create the runtime image
 FROM base AS final
@@ -37,8 +34,7 @@ COPY --from=migrate /app/efbundle ./efbundle
 ENV ASPNETCORE_ENVIRONMENT=Production
 ENV ASPNETCORE_URLS=http://+:8080
 
-# Create a non-root user for security
-RUN adduser --disabled-password --gecos '' appuser && chown -R appuser /app
-USER appuser
+# Run as the non-root user baked into the .NET base image
+USER $APP_UID
 
 CMD ["dotnet", "F1CompanionApi.dll"]


### PR DESCRIPTION
## Summary

- Fix the .NET 10 docker build: the `.NET 10` aspnet base image no longer ships `adduser`, so the `RUN adduser ...` line in `api/Dockerfile` was failing every webhook deploy since PR #106 merged on Apr 17. Switch to the non-root `$APP_UID` user baked into the base image.
- Add an `API Docker` job to CI that builds the Dockerfile on every PR — the existing `API` job only runs `dotnet build`/`test`, which is why CI stayed green while the Docker build silently broke prod for four days.
- Add the `docker` ecosystem to Dependabot (watching `/api`) so base image bumps arrive as isolated PRs that the new `API Docker` CI job can validate before merge. Paired with the existing `global.json` `rollForward: latestMinor` tripwire, a major bump will fail visibly instead of slipping through.
- Drop the redundant `build` stage from the Dockerfile. `dotnet publish` already compiles from the same source; the separate `dotnet build -o /app/build` was producing a dead artifact and doubling compile work. Restructure to a single `deps` stage (restore + source copy) that both `publish` and `migrate` derive from. Added `--no-restore` to publish and `--no-build` to the EF bundle step.

## Test plan

- [ ] Confirm `API Docker` job passes on this PR (this validates the Dockerfile fix end-to-end).
- [ ] Confirm `Web` and `API` jobs still pass.
- [ ] After merge, confirm the Fly webhook deploy succeeds and a new release is created.
- [ ] Verify the running machine on Fly is on the new image and healthy (`fly status -a f1fantasyapp`).