### PR TITLE
Enforce constructor uniqueness in picker UI

### DIFF
--- a/web/src/components/ConstructorPicker/ConstructorPicker.test.tsx
+++ b/web/src/components/ConstructorPicker/ConstructorPicker.test.tsx
@@ -13,7 +13,6 @@ vi.mock('@/hooks/useLineupPicker', () => ({
 }));
 
 // Mock data - will be set in beforeEach or individual tests
-let mockDisplayLineup: (Constructor | null)[];
 let mockPool: Constructor[];
 let mockSelectedPosition: number | null;
 let mockIsPending: boolean;
@@ -58,14 +57,12 @@ describe('ConstructorPicker', () => {
     vi.clearAllMocks();
 
     // Default state: empty lineup, all constructors in pool, picker closed
-    mockDisplayLineup = [null, null];
     mockPool = mockConstructors;
     mockSelectedPosition = null;
     mockIsPending = false;
     mockError = null;
 
     mockUseLineupPicker.mockImplementation(() => ({
-      displayLineup: mockDisplayLineup,
       pool: mockPool,
       selectedPosition: mockSelectedPosition,
       isPending: mockIsPending,
@@ -94,8 +91,6 @@ describe('ConstructorPicker', () => {
     it('displays existing constructors in correct positions', () => {
       const teamConstructors: TeamConstructor[] = [toTeamConstructor(mockConstructors[0], 0)];
 
-      mockDisplayLineup = [mockConstructors[0], null];
-
       render(
         <ConstructorPicker
           activeConstructors={mockConstructors}
@@ -117,8 +112,6 @@ describe('ConstructorPicker', () => {
         toTeamConstructor(mockConstructors[0], 0),
         toTeamConstructor(mockConstructors[1], 1),
       ];
-
-      mockDisplayLineup = [mockConstructors[0], mockConstructors[1]];
 
       render(
         <ConstructorPicker
@@ -161,7 +154,6 @@ describe('ConstructorPicker', () => {
     });
 
     it('only displays constructors not in current lineup', () => {
-      mockDisplayLineup = [mockConstructors[0], null];
       mockPool = [
         mockConstructors[1],
         mockConstructors[2],
@@ -305,8 +297,6 @@ describe('ConstructorPicker', () => {
     });
 
     it('provides aria-label for remove buttons', () => {
-      mockDisplayLineup = [mockConstructors[0], null, null, null];
-
       render(
         <ConstructorPicker
           activeConstructors={mockConstructors}
@@ -318,22 +308,6 @@ describe('ConstructorPicker', () => {
 
       const removeButton = screen.getByRole('button', { name: /remove constructor/i });
       expect(removeButton).toHaveAccessibleName('Remove constructor');
-    });
-  });
-
-  describe('Duplicate Constructors', () => {
-    it('passes maxDuplicates: 2 to useLineupPicker', () => {
-      render(
-        <ConstructorPicker
-          activeConstructors={mockConstructors}
-          readOnly={false}
-          remainingBudget={100_000_000}
-        />,
-      );
-
-      expect(mockUseLineupPicker).toHaveBeenCalledWith(
-        expect.objectContaining({ maxDuplicates: 2 }),
-      );
     });
   });
 
@@ -359,8 +333,6 @@ describe('ConstructorPicker', () => {
         toTeamConstructor(mockConstructors[0], 0),
         toTeamConstructor(mockConstructors[1], 1),
       ];
-
-      mockDisplayLineup = [mockConstructors[0], mockConstructors[1], null, null];
 
       render(
         <ConstructorPicker
@@ -421,11 +393,13 @@ describe('ConstructorPicker', () => {
     });
 
     it('shows filled count in section header', () => {
-      mockDisplayLineup = [mockConstructors[0], mockConstructors[1]];
-
       render(
         <ConstructorPicker
           activeConstructors={mockConstructors}
+          teamConstructors={[
+            toTeamConstructor(mockConstructors[0], 0),
+            toTeamConstructor(mockConstructors[1], 1),
+          ]}
           readOnly={false}
           remainingBudget={100_000_000}
         />,

--- a/web/src/components/ConstructorPicker/ConstructorPicker.tsx
+++ b/web/src/components/ConstructorPicker/ConstructorPicker.tsx
@@ -44,7 +44,6 @@ export function ConstructorPicker({
   }, [teamConstructors]);
 
   const {
-    displayLineup,
     pool,
     selectedPosition,
     isPending,
@@ -56,14 +55,12 @@ export function ConstructorPicker({
   } = useLineupPicker({
     items: activeConstructors,
     lineup,
-    lineupSize: CONSTRUCTOR_SLOTS,
     itemType: 'constructor',
     addToTeam: addConstructorToTeam,
     removeFromTeam: removeConstructorFromTeam,
-    maxDuplicates: 2,
   });
 
-  const filledCount = displayLineup.filter(Boolean).length;
+  const filledCount = lineup.filter(Boolean).length;
 
   return (
     <>
@@ -81,7 +78,7 @@ export function ConstructorPicker({
         </span>
       </div>
       <div className="relative grid auto-rows-fr grid-cols-1 gap-4 sm:grid-cols-2">
-        {displayLineup.map((constructor, idx) => (
+        {lineup.map((constructor, idx) => (
           <ConstructorCard
             key={idx}
             constructor={constructor}
@@ -105,9 +102,7 @@ export function ConstructorPicker({
           <SheetContent className="bg-card flex h-full flex-col sm:max-w-md">
             <SheetHeader>
               <SheetTitle>Select Constructor</SheetTitle>
-              <SheetDescription>
-                Choose a constructor to add to your team (you can pick the same one twice).
-              </SheetDescription>
+              <SheetDescription>Choose a constructor to add to your team.</SheetDescription>
             </SheetHeader>
             <ScrollArea className="h-full min-h-0 flex-1 pr-4 pl-4">
               <ul className="divide-border divide-y">

--- a/web/src/components/DriverPicker/DriverPicker.test.tsx
+++ b/web/src/components/DriverPicker/DriverPicker.test.tsx
@@ -10,7 +10,6 @@ import { DriverPicker } from './DriverPicker';
 // Mock useLineupPicker hook
 vi.mock('@/hooks/useLineupPicker', () => ({
   useLineupPicker: () => ({
-    displayLineup: mockDisplayLineup,
     pool: mockPool,
     selectedPosition: mockSelectedPosition,
     isPending: mockIsPending,
@@ -23,7 +22,6 @@ vi.mock('@/hooks/useLineupPicker', () => ({
 }));
 
 // Mock data - will be set in beforeEach or individual tests
-let mockDisplayLineup: (Driver | null)[];
 let mockPool: Driver[];
 let mockSelectedPosition: number | null;
 let mockIsPending: boolean;
@@ -49,7 +47,6 @@ describe('DriverPicker', () => {
     vi.clearAllMocks();
 
     // Default state: empty lineup, all drivers in pool, picker closed
-    mockDisplayLineup = [null, null, null, null, null];
     mockPool = mockDrivers;
     mockSelectedPosition = null;
     mockIsPending = false;
@@ -71,8 +68,6 @@ describe('DriverPicker', () => {
         toTeamDriver(mockDrivers[0], 0),
         toTeamDriver(mockDrivers[1], 1),
       ];
-
-      mockDisplayLineup = [mockDrivers[0], mockDrivers[1], null, null, null];
 
       render(
         <DriverPicker
@@ -98,14 +93,6 @@ describe('DriverPicker', () => {
         toTeamDriver(mockDrivers[2], 2),
         toTeamDriver(mockDrivers[3], 3),
         toTeamDriver(mockDrivers[4], 4),
-      ];
-
-      mockDisplayLineup = [
-        mockDrivers[0],
-        mockDrivers[1],
-        mockDrivers[2],
-        mockDrivers[3],
-        mockDrivers[4],
       ];
 
       render(
@@ -148,7 +135,6 @@ describe('DriverPicker', () => {
     });
 
     it('only displays drivers not in current lineup', () => {
-      mockDisplayLineup = [mockDrivers[0], null, null, null, null];
       mockPool = [mockDrivers[1], mockDrivers[2], mockDrivers[3], mockDrivers[4]];
 
       render(
@@ -259,8 +245,6 @@ describe('DriverPicker', () => {
     });
 
     it('provides aria-label for remove buttons', () => {
-      mockDisplayLineup = [mockDrivers[0], null, null, null, null];
-
       render(
         <DriverPicker
           activeDrivers={mockDrivers}
@@ -293,8 +277,6 @@ describe('DriverPicker', () => {
         toTeamDriver(mockDrivers[0], 0),
         toTeamDriver(mockDrivers[1], 1),
       ];
-
-      mockDisplayLineup = [mockDrivers[0], mockDrivers[1], null, null];
 
       render(
         <DriverPicker
@@ -335,8 +317,6 @@ describe('DriverPicker', () => {
 
   describe('Captain', () => {
     it('shows active captain button for the driver matching captainDriverId', () => {
-      mockDisplayLineup = [mockDrivers[0], null, null, null];
-
       render(
         <DriverPicker
           activeDrivers={mockDrivers}
@@ -354,7 +334,6 @@ describe('DriverPicker', () => {
     it('calls onSetCaptain with driver id when Set as captain is clicked', async () => {
       const user = userEvent.setup();
       const onSetCaptain = vi.fn();
-      mockDisplayLineup = [mockDrivers[0], null, null, null];
 
       render(
         <DriverPicker
@@ -375,7 +354,6 @@ describe('DriverPicker', () => {
     it('calls onSetCaptain with null when active captain button is clicked', async () => {
       const user = userEvent.setup();
       const onSetCaptain = vi.fn();
-      mockDisplayLineup = [mockDrivers[0], null, null, null];
 
       render(
         <DriverPicker

--- a/web/src/components/DriverPicker/DriverPicker.tsx
+++ b/web/src/components/DriverPicker/DriverPicker.tsx
@@ -48,7 +48,6 @@ export function DriverPicker({
   }, [teamDrivers]);
 
   const {
-    displayLineup,
     pool,
     selectedPosition,
     isPending,
@@ -60,13 +59,12 @@ export function DriverPicker({
   } = useLineupPicker({
     items: activeDrivers,
     lineup,
-    lineupSize: DRIVER_SLOTS,
     itemType: 'driver',
     addToTeam: addDriverToTeam,
     removeFromTeam: removeDriverFromTeam,
   });
 
-  const filledCount = displayLineup.filter(Boolean).length;
+  const filledCount = lineup.filter(Boolean).length;
 
   return (
     <>
@@ -84,7 +82,7 @@ export function DriverPicker({
         </span>
       </div>
       <div className="relative grid auto-rows-fr grid-cols-1 gap-4 sm:grid-cols-6">
-        {displayLineup.map((driver, idx) => (
+        {lineup.map((driver, idx) => (
           <div key={idx} className={`sm:col-span-2 ${idx === 0 ? 'sm:col-start-2' : ''}`}>
             <DriverCard
               driver={driver}

--- a/web/src/hooks/useLineupPicker.test.ts
+++ b/web/src/hooks/useLineupPicker.test.ts
@@ -42,65 +42,12 @@ describe('useLineupPicker', () => {
     mockRemoveFromTeam.mockResolvedValue(undefined);
   });
 
-  describe('displayLineup', () => {
-    it('pads lineup with nulls when lineup is shorter than lineupSize', () => {
-      const { result } = renderHook(() =>
-        useLineupPicker({
-          items: mockItems,
-          lineup: [mockItems[0], mockItems[1]],
-          lineupSize: 4,
-          itemType: 'driver',
-          addToTeam: mockAddToTeam,
-          removeFromTeam: mockRemoveFromTeam,
-        }),
-      );
-
-      expect(result.current.displayLineup).toEqual([mockItems[0], mockItems[1], null, null]);
-    });
-
-    it('returns lineup as-is when it matches lineupSize', () => {
-      const { result } = renderHook(() =>
-        useLineupPicker({
-          items: mockItems,
-          lineup: [mockItems[0], mockItems[1], mockItems[2], mockItems[3]],
-          lineupSize: 4,
-          itemType: 'driver',
-          addToTeam: mockAddToTeam,
-          removeFromTeam: mockRemoveFromTeam,
-        }),
-      );
-
-      expect(result.current.displayLineup).toEqual([
-        mockItems[0],
-        mockItems[1],
-        mockItems[2],
-        mockItems[3],
-      ]);
-    });
-
-    it('handles empty lineup', () => {
-      const { result } = renderHook(() =>
-        useLineupPicker({
-          items: mockItems,
-          lineup: [],
-          lineupSize: 4,
-          itemType: 'driver',
-          addToTeam: mockAddToTeam,
-          removeFromTeam: mockRemoveFromTeam,
-        }),
-      );
-
-      expect(result.current.displayLineup).toEqual([null, null, null, null]);
-    });
-  });
-
   describe('pool', () => {
     it('returns all items when lineup is empty', () => {
       const { result } = renderHook(() =>
         useLineupPicker({
           items: mockItems,
-          lineup: [],
-          lineupSize: 4,
+          lineup: [null, null, null, null],
           itemType: 'driver',
           addToTeam: mockAddToTeam,
           removeFromTeam: mockRemoveFromTeam,
@@ -110,12 +57,11 @@ describe('useLineupPicker', () => {
       expect(result.current.pool).toEqual(mockItems);
     });
 
-    it('filters out items already in lineup', () => {
+    it('excludes items already in the lineup from the pool', () => {
       const { result } = renderHook(() =>
         useLineupPicker({
           items: mockItems,
-          lineup: [mockItems[0], mockItems[2]],
-          lineupSize: 4,
+          lineup: [mockItems[0], mockItems[2], null, null],
           itemType: 'driver',
           addToTeam: mockAddToTeam,
           removeFromTeam: mockRemoveFromTeam,
@@ -130,7 +76,6 @@ describe('useLineupPicker', () => {
         useLineupPicker({
           items: mockItems.slice(0, 4),
           lineup: mockItems.slice(0, 4),
-          lineupSize: 4,
           itemType: 'driver',
           addToTeam: mockAddToTeam,
           removeFromTeam: mockRemoveFromTeam,
@@ -139,58 +84,6 @@ describe('useLineupPicker', () => {
 
       expect(result.current.pool).toEqual([]);
     });
-
-    it('keeps items in pool below maxDuplicates threshold', () => {
-      const { result } = renderHook(() =>
-        useLineupPicker({
-          items: mockItems,
-          lineup: [mockItems[0], null, null, null],
-          lineupSize: 4,
-          itemType: 'constructor',
-          addToTeam: mockAddToTeam,
-          removeFromTeam: mockRemoveFromTeam,
-          maxDuplicates: 2,
-        }),
-      );
-
-      // Item 1 is in lineup once but maxDuplicates is 2, so it should still be in pool
-      expect(result.current.pool).toContainEqual(mockItems[0]);
-    });
-
-    it('removes items from pool at maxDuplicates threshold', () => {
-      const { result } = renderHook(() =>
-        useLineupPicker({
-          items: mockItems,
-          lineup: [mockItems[0], mockItems[0], null, null],
-          lineupSize: 4,
-          itemType: 'constructor',
-          addToTeam: mockAddToTeam,
-          removeFromTeam: mockRemoveFromTeam,
-          maxDuplicates: 2,
-        }),
-      );
-
-      // Item 1 is in lineup twice and maxDuplicates is 2, so it should be removed from pool
-      expect(result.current.pool).not.toContainEqual(mockItems[0]);
-      // Other items should still be available
-      expect(result.current.pool).toContainEqual(mockItems[1]);
-    });
-
-    it('defaults maxDuplicates to 1 when not specified', () => {
-      const { result } = renderHook(() =>
-        useLineupPicker({
-          items: mockItems,
-          lineup: [mockItems[0], null, null, null],
-          lineupSize: 4,
-          itemType: 'driver',
-          addToTeam: mockAddToTeam,
-          removeFromTeam: mockRemoveFromTeam,
-        }),
-      );
-
-      // Without maxDuplicates, items used once should be excluded (default maxDuplicates=1)
-      expect(result.current.pool).not.toContainEqual(mockItems[0]);
-    });
   });
 
   describe('openPicker', () => {
@@ -198,8 +91,7 @@ describe('useLineupPicker', () => {
       const { result } = renderHook(() =>
         useLineupPicker({
           items: mockItems,
-          lineup: [],
-          lineupSize: 4,
+          lineup: [null, null, null, null],
           itemType: 'driver',
           addToTeam: mockAddToTeam,
           removeFromTeam: mockRemoveFromTeam,
@@ -235,8 +127,7 @@ describe('useLineupPicker', () => {
       const { result } = renderHook(() =>
         useLineupPicker({
           items: mockItems,
-          lineup: [],
-          lineupSize: 4,
+          lineup: [null, null, null, null],
           itemType: 'driver',
           addToTeam: mockAddToTeam,
           removeFromTeam: mockRemoveFromTeam,
@@ -269,8 +160,7 @@ describe('useLineupPicker', () => {
       const { result } = renderHook(() =>
         useLineupPicker({
           items: mockItems,
-          lineup: [],
-          lineupSize: 4,
+          lineup: [null, null, null, null],
           itemType: 'driver',
           addToTeam: mockAddToTeam,
           removeFromTeam: mockRemoveFromTeam,
@@ -288,8 +178,7 @@ describe('useLineupPicker', () => {
       const { result } = renderHook(() =>
         useLineupPicker({
           items: mockItems,
-          lineup: [],
-          lineupSize: 4,
+          lineup: [null, null, null, null],
           itemType: 'driver',
           addToTeam: mockAddToTeam,
           removeFromTeam: mockRemoveFromTeam,
@@ -307,8 +196,7 @@ describe('useLineupPicker', () => {
       const { result } = renderHook(() =>
         useLineupPicker({
           items: mockItems,
-          lineup: [],
-          lineupSize: 4,
+          lineup: [null, null, null, null],
           itemType: 'driver',
           addToTeam: mockAddToTeam,
           removeFromTeam: mockRemoveFromTeam,
@@ -338,8 +226,7 @@ describe('useLineupPicker', () => {
       const { result } = renderHook(() =>
         useLineupPicker({
           items: mockItems,
-          lineup: [],
-          lineupSize: 4,
+          lineup: [null, null, null, null],
           itemType: 'driver',
           addToTeam: mockAddToTeam,
           removeFromTeam: mockRemoveFromTeam,
@@ -371,8 +258,7 @@ describe('useLineupPicker', () => {
       const { result } = renderHook(() =>
         useLineupPicker({
           items: mockItems,
-          lineup: [],
-          lineupSize: 4,
+          lineup: [null, null, null, null],
           itemType: 'driver',
           addToTeam: mockAddToTeam,
           removeFromTeam: mockRemoveFromTeam,
@@ -396,8 +282,7 @@ describe('useLineupPicker', () => {
       const { result } = renderHook(() =>
         useLineupPicker({
           items: mockItems,
-          lineup: [],
-          lineupSize: 4,
+          lineup: [null, null, null, null],
           itemType: 'driver',
           addToTeam: mockAddToTeam,
           removeFromTeam: mockRemoveFromTeam,
@@ -421,8 +306,7 @@ describe('useLineupPicker', () => {
       const { result } = renderHook(() =>
         useLineupPicker({
           items: mockItems,
-          lineup: [],
-          lineupSize: 4,
+          lineup: [null, null, null, null],
           itemType: 'driver',
           addToTeam: mockAddToTeam,
           removeFromTeam: mockRemoveFromTeam,
@@ -448,8 +332,7 @@ describe('useLineupPicker', () => {
       const { result } = renderHook(() =>
         useLineupPicker({
           items: mockItems,
-          lineup: [mockItems[0]],
-          lineupSize: 4,
+          lineup: [mockItems[0], null, null, null],
           itemType: 'driver',
           addToTeam: mockAddToTeam,
           removeFromTeam: mockRemoveFromTeam,
@@ -467,8 +350,7 @@ describe('useLineupPicker', () => {
       const { result } = renderHook(() =>
         useLineupPicker({
           items: mockItems,
-          lineup: [mockItems[0]],
-          lineupSize: 4,
+          lineup: [mockItems[0], null, null, null],
           itemType: 'driver',
           addToTeam: mockAddToTeam,
           removeFromTeam: mockRemoveFromTeam,
@@ -493,8 +375,7 @@ describe('useLineupPicker', () => {
       const { result } = renderHook(() =>
         useLineupPicker({
           items: mockItems,
-          lineup: [mockItems[0]],
-          lineupSize: 4,
+          lineup: [mockItems[0], null, null, null],
           itemType: 'driver',
           addToTeam: mockAddToTeam,
           removeFromTeam: mockRemoveFromTeam,
@@ -526,8 +407,7 @@ describe('useLineupPicker', () => {
       const { result } = renderHook(() =>
         useLineupPicker({
           items: mockItems,
-          lineup: [mockItems[0]],
-          lineupSize: 4,
+          lineup: [mockItems[0], null, null, null],
           itemType: 'driver',
           addToTeam: mockAddToTeam,
           removeFromTeam: mockRemoveFromTeam,
@@ -547,8 +427,7 @@ describe('useLineupPicker', () => {
       const { result } = renderHook(() =>
         useLineupPicker({
           items: mockItems,
-          lineup: [mockItems[0]],
-          lineupSize: 4,
+          lineup: [mockItems[0], null, null, null],
           itemType: 'driver',
           addToTeam: mockAddToTeam,
           removeFromTeam: mockRemoveFromTeam,
@@ -576,8 +455,7 @@ describe('useLineupPicker', () => {
       const { result } = renderHook(() =>
         useLineupPicker({
           items: mockItems,
-          lineup: [],
-          lineupSize: 4,
+          lineup: [null, null, null, null],
           itemType: 'constructor',
           addToTeam: mockAddToTeam,
           removeFromTeam: mockRemoveFromTeam,
@@ -597,8 +475,7 @@ describe('useLineupPicker', () => {
       const { result } = renderHook(() =>
         useLineupPicker({
           items: mockItems,
-          lineup: [mockItems[0]],
-          lineupSize: 4,
+          lineup: [mockItems[0], null, null, null],
           itemType: 'constructor',
           addToTeam: mockAddToTeam,
           removeFromTeam: mockRemoveFromTeam,

--- a/web/src/hooks/useLineupPicker.ts
+++ b/web/src/hooks/useLineupPicker.ts
@@ -5,11 +5,9 @@ import { useMemo, useState } from 'react';
 interface UseLineupPickerOptions<T extends { id: number }> {
   items: T[];
   lineup: (T | null)[];
-  lineupSize: number;
   itemType: string;
   addToTeam: (itemId: number, position: number) => Promise<void>;
   removeFromTeam: (position: number) => Promise<void>;
-  maxDuplicates?: number;
 }
 
 /**
@@ -19,40 +17,21 @@ interface UseLineupPickerOptions<T extends { id: number }> {
 export function useLineupPicker<T extends { id: number }>({
   items,
   lineup,
-  lineupSize,
   itemType,
   addToTeam,
   removeFromTeam,
-  maxDuplicates = 1,
 }: UseLineupPickerOptions<T>) {
   const router = useRouter();
   const [selectedPosition, setSelectedPosition] = useState<number | null>(null);
   const [isPending, setIsPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  /**
-   * Pad lineup with nulls to match lineupSize for empty slots
-   */
-  const displayLineup = useMemo(() => {
-    const currentLineup = lineup ?? [];
-
-    return currentLineup.length === lineupSize
-      ? currentLineup
-      : [...currentLineup, ...Array(lineupSize - currentLineup.length).fill(null)];
-  }, [lineup, lineupSize]);
-
-  /**
-   * Filter out items that have reached their maximum allowed duplicates from the available pool
-   */
   const pool = useMemo(() => {
-    const counts = new Map<number, number>();
-    displayLineup
-      .filter((item): item is T => item !== null)
-      .forEach((item) => {
-        counts.set(item.id, (counts.get(item.id) ?? 0) + 1);
-      });
-    return items.filter((item) => (counts.get(item.id) ?? 0) < maxDuplicates);
-  }, [items, displayLineup, maxDuplicates]);
+    const usedIds = new Set(
+      lineup.filter((item): item is T => item !== null).map((item) => item.id),
+    );
+    return items.filter((item) => !usedIds.has(item.id));
+  }, [items, lineup]);
 
   /**
    * Adds an item to the lineup at the specified position.
@@ -115,7 +94,6 @@ export function useLineupPicker<T extends { id: number }>({
   };
 
   return {
-    displayLineup,
     pool,
     selectedPosition,
     isPending,

--- a/web/src/hooks/useLineupPicker.ts
+++ b/web/src/hooks/useLineupPicker.ts
@@ -5,7 +5,7 @@ import { useMemo, useState } from 'react';
 interface UseLineupPickerOptions<T extends { id: number }> {
   items: T[];
   lineup: (T | null)[];
-  itemType: string;
+  itemType: 'driver' | 'constructor';
   addToTeam: (itemId: number, position: number) => Promise<void>;
   removeFromTeam: (position: number) => Promise<void>;
 }


### PR DESCRIPTION
## Summary

- The ConstructorPicker was allowing users to pick the same constructor into both slots, surfacing a 409 from the backend's uniqueness check (added in #125) instead of preventing the action. Root cause: a leftover `maxDuplicates: 2` option from the pre-5D+2C format.
- Remove `maxDuplicates` and `lineupSize` from `useLineupPicker` entirely so re-introducing the bug becomes a TypeScript error, not a runtime failure. Collapse the pool filter to a Set-based uniqueness check and drop the now-redundant `displayLineup` padding (both callers already pass fixed-length lineups).
- Delete the change-detector test that pinned `maxDuplicates: 2` rather than replacing it at the same layer — the uniqueness rule is now covered behaviorally in `useLineupPicker.test.ts`, and the removed option makes the old bug unrepresentable. Sweep the now-dead `mockDisplayLineup` machinery out of both picker test files.

## Why tests missed the original bug

1. The test asserted the option value (`expect.objectContaining({ maxDuplicates: 2 })`), not the rule. When the format flipped, both source and assertion were updated together and nobody re-read the semantics.
2. Nothing exercised `ConstructorPicker` against the real hook — the component's test file mocks `useLineupPicker` and the hook's own tests are format-agnostic, so the bad argument was never evaluated in context.
3. The original plan's manual verification step treated a 409 from the API as proof the feature worked; it should have required the UI to make the invalid action unreachable.

## Test plan

- [x] `npm run web:test` — 614 tests pass (hook uniqueness covered behaviorally; picker tests driven via `teamConstructors` / `teamDrivers` props)
- [x] `npm run web:lint` / `npm run web:format:check` — clean
- [x] `npm run web:build` — typecheck + build succeed
- [ ] Manual: sign in, open the team builder, pick McLaren into slot 0, open picker for slot 1 → McLaren absent from the list. Repeat in reverse (slot 1 first). Fill both slots, remove slot 0, reopen → removed constructor reappears in the pool.
- [ ] Regression: pick 5 distinct drivers to confirm the `lineupSize` / `displayLineup` removal didn't regress driver rendering.