### PR TITLE
Fix qualifying DSQ breaking /score (issue #148)

### DIFF
--- a/api/F1CompanionApi.IntegrationTests/Scenarios/RaceWeekendScoringTests.cs
+++ b/api/F1CompanionApi.IntegrationTests/Scenarios/RaceWeekendScoringTests.cs
@@ -1,0 +1,94 @@
+using System.Net;
+using System.Net.Http.Json;
+using F1CompanionApi.Api.Models;
+using F1CompanionApi.Data.Entities;
+using F1CompanionApi.IntegrationTests.Support;
+
+namespace F1CompanionApi.IntegrationTests.Scenarios;
+
+public class RaceWeekendScoringTests : IntegrationTestBase
+{
+    public RaceWeekendScoringTests(PostgresFixture postgres)
+        : base(postgres) { }
+
+    [Fact]
+    public async Task NonClassifiedQualifyingEntry_RoundTripsAndScores()
+    {
+        var (client, _) = await Factory.CreateAuthenticatedAsync();
+        client.DefaultRequestHeaders.Add("X-Api-Key", ApiWebApplicationFactory.TestApiKey);
+
+        Season season = null!;
+        RaceWeekend race = null!;
+        Driver dsqDriver = null!;
+        Driver classifiedDriver = null!;
+
+        await WithDbAsync(async db =>
+        {
+            season = await db.CreateCurrentSeasonAsync();
+            race = await db.CreateRaceWeekendAsync(
+                season.Id,
+                raceDate: DateTime.UtcNow.AddDays(2),
+                round: 1
+            );
+            dsqDriver = await db.CreateDriverAsync("AAA", "First", "One");
+            classifiedDriver = await db.CreateDriverAsync("BBB", "First", "Two");
+            var constructor = await db.CreateConstructorAsync("TestCo");
+
+            db.SeasonDrivers.Add(
+                new SeasonDriver
+                {
+                    SeasonId = season.Id,
+                    DriverId = dsqDriver.Id,
+                    ConstructorId = constructor.Id,
+                    IsActive = true,
+                    CreatedAt = DateTime.UtcNow,
+                }
+            );
+            db.SeasonDrivers.Add(
+                new SeasonDriver
+                {
+                    SeasonId = season.Id,
+                    DriverId = classifiedDriver.Id,
+                    ConstructorId = constructor.Id,
+                    IsActive = true,
+                    CreatedAt = DateTime.UtcNow,
+                }
+            );
+            await db.SaveChangesAsync();
+        });
+
+        var resultsUrl = $"/api/seasons/{season.Id}/race-weekends/{race.Round}/results/qualifying";
+        var scoreUrl = $"/api/seasons/{season.Id}/race-weekends/{race.Round}/score";
+
+        var submitResponse = await client.PutAsJsonAsync(
+            resultsUrl,
+            new[]
+            {
+                new QualifyingResultItem
+                {
+                    DriverId = dsqDriver.Id,
+                    Position = null,
+                    Status = RacingStatus.DSQ,
+                },
+                new QualifyingResultItem
+                {
+                    DriverId = classifiedDriver.Id,
+                    Position = 1,
+                    Status = RacingStatus.Classified,
+                },
+            }
+        );
+        Assert.Equal(HttpStatusCode.OK, submitResponse.StatusCode);
+
+        var scoreResponse = await client.PostAsync(scoreUrl, content: null);
+        Assert.Equal(HttpStatusCode.NoContent, scoreResponse.StatusCode);
+
+        var getResults = await client.GetFromJsonAsync<List<DriverQualifyingResultResponse>>(
+            resultsUrl
+        );
+        Assert.NotNull(getResults);
+        var roundTripped = Assert.Single(getResults, r => r.DriverId == dsqDriver.Id);
+        Assert.Null(roundTripped.Position);
+        Assert.Equal(RacingStatus.DSQ, roundTripped.Status);
+    }
+}

--- a/api/F1CompanionApi.IntegrationTests/Scenarios/RaceWeekendScoringTests.cs
+++ b/api/F1CompanionApi.IntegrationTests/Scenarios/RaceWeekendScoringTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using F1CompanionApi.Api.Models;
 using F1CompanionApi.Data.Entities;
 using F1CompanionApi.IntegrationTests.Support;
+using Microsoft.EntityFrameworkCore;
 
 namespace F1CompanionApi.IntegrationTests.Scenarios;
 
@@ -82,6 +83,14 @@ public class RaceWeekendScoringTests : IntegrationTestBase
 
         var scoreResponse = await client.PostAsync(scoreUrl, content: null);
         Assert.Equal(HttpStatusCode.NoContent, scoreResponse.StatusCode);
+
+        await WithDbAsync(async db =>
+        {
+            var constructorScored = await db.ConstructorRaceWeekendScores.AnyAsync(s =>
+                s.RaceWeekendId == race.Id
+            );
+            Assert.True(constructorScored);
+        });
 
         var getResults = await client.GetFromJsonAsync<List<DriverQualifyingResultResponse>>(
             resultsUrl

--- a/api/F1CompanionApi.UnitTests/Api/Endpoints/RaceWeekendResultEndpointsTests.cs
+++ b/api/F1CompanionApi.UnitTests/Api/Endpoints/RaceWeekendResultEndpointsTests.cs
@@ -38,8 +38,18 @@ public class RaceWeekendResultEndpointsTests
         // Arrange
         var items = new List<QualifyingResultItem>
         {
-            new QualifyingResultItem { DriverId = 1, Position = 1 },
-            new QualifyingResultItem { DriverId = 2, Position = 2 },
+            new QualifyingResultItem
+            {
+                DriverId = 1,
+                Position = 1,
+                Status = RacingStatus.Classified,
+            },
+            new QualifyingResultItem
+            {
+                DriverId = 2,
+                Position = 2,
+                Status = RacingStatus.Classified,
+            },
         };
         var expected = new List<DriverQualifyingResultResponse>
         {
@@ -49,6 +59,7 @@ public class RaceWeekendResultEndpointsTests
                 DriverId = 1,
                 RaceWeekendId = RaceWeekendId,
                 Position = 1,
+                Status = RacingStatus.Classified,
             },
         };
 
@@ -77,7 +88,12 @@ public class RaceWeekendResultEndpointsTests
 
         var items = new List<QualifyingResultItem>
         {
-            new QualifyingResultItem { DriverId = 1, Position = 1 },
+            new QualifyingResultItem
+            {
+                DriverId = 1,
+                Position = 1,
+                Status = RacingStatus.Classified,
+            },
         };
 
         // Act
@@ -105,6 +121,7 @@ public class RaceWeekendResultEndpointsTests
                 DriverId = 1,
                 RaceWeekendId = RaceWeekendId,
                 Position = 1,
+                Status = RacingStatus.Classified,
             },
         };
 

--- a/api/F1CompanionApi.UnitTests/Services/RaceWeekendResultServiceTests.cs
+++ b/api/F1CompanionApi.UnitTests/Services/RaceWeekendResultServiceTests.cs
@@ -61,8 +61,17 @@ public class RaceWeekendResultServiceTests
             WeekendFormat = weekendFormat,
         };
 
-    private static QualifyingResultItem QualItem(int driverId, int position) =>
-        new() { DriverId = driverId, Position = position };
+    private static QualifyingResultItem QualItem(
+        int driverId,
+        int? position,
+        RacingStatus status = RacingStatus.Classified
+    ) =>
+        new()
+        {
+            DriverId = driverId,
+            Position = position,
+            Status = status,
+        };
 
     private static RacingResultItem RaceItem(
         int driverId,
@@ -112,6 +121,7 @@ public class RaceWeekendResultServiceTests
                 DriverId = 1,
                 RaceWeekendId = 10,
                 Position = 5,
+                Status = RacingStatus.Classified,
             }
         );
         await context.SaveChangesAsync();
@@ -163,6 +173,67 @@ public class RaceWeekendResultServiceTests
 
         await Assert.ThrowsAsync<ArgumentException>(() =>
             service.SubmitQualifyingResultsAsync(10, [QualItem(99, 1)])
+        );
+    }
+
+    [Fact]
+    public async Task SubmitQualifyingResultsAsync_PersistsDsqEntry_WithNullPosition()
+    {
+        using var context = CreateInMemoryContext();
+        context.Drivers.Add(CreateDriver(1, "VER"));
+        context.Circuits.Add(CreateCircuit(10));
+        context.RaceWeekends.Add(CreateRace(10));
+        await context.SaveChangesAsync();
+
+        var service = new RaceWeekendResultService(context, _mockLogger.Object);
+
+        await service.SubmitQualifyingResultsAsync(
+            10,
+            [QualItem(1, position: null, status: RacingStatus.DSQ)]
+        );
+
+        var saved = await context.DriverQualifyingResults.SingleAsync();
+        Assert.Null(saved.Position);
+        Assert.Equal(RacingStatus.DSQ, saved.Status);
+    }
+
+    [Fact]
+    public async Task SubmitQualifyingResultsAsync_ThrowsArgumentException_WhenClassifiedHasNullPosition()
+    {
+        using var context = CreateInMemoryContext();
+        context.Drivers.Add(CreateDriver(1, "VER"));
+        context.Circuits.Add(CreateCircuit(10));
+        context.RaceWeekends.Add(CreateRace(10));
+        await context.SaveChangesAsync();
+
+        var service = new RaceWeekendResultService(context, _mockLogger.Object);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.SubmitQualifyingResultsAsync(
+                10,
+                [QualItem(1, position: null, status: RacingStatus.Classified)]
+            )
+        );
+    }
+
+    [Theory]
+    [InlineData(RacingStatus.DNF)]
+    [InlineData(RacingStatus.DSQ)]
+    [InlineData(RacingStatus.DNS)]
+    public async Task SubmitQualifyingResultsAsync_ThrowsArgumentException_WhenNonClassifiedHasPosition(
+        RacingStatus status
+    )
+    {
+        using var context = CreateInMemoryContext();
+        context.Drivers.Add(CreateDriver(1, "VER"));
+        context.Circuits.Add(CreateCircuit(10));
+        context.RaceWeekends.Add(CreateRace(10));
+        await context.SaveChangesAsync();
+
+        var service = new RaceWeekendResultService(context, _mockLogger.Object);
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            service.SubmitQualifyingResultsAsync(10, [QualItem(1, position: 5, status: status)])
         );
     }
 
@@ -430,12 +501,14 @@ public class RaceWeekendResultServiceTests
                 DriverId = 2,
                 RaceWeekendId = 10,
                 Position = 2,
+                Status = RacingStatus.Classified,
             },
             new DriverQualifyingResult
             {
                 DriverId = 1,
                 RaceWeekendId = 10,
                 Position = 1,
+                Status = RacingStatus.Classified,
             }
         );
         await context.SaveChangesAsync();
@@ -459,12 +532,14 @@ public class RaceWeekendResultServiceTests
                 DriverId = 1,
                 RaceWeekendId = 10,
                 Position = 1,
+                Status = RacingStatus.Classified,
             },
             new DriverQualifyingResult
             {
                 DriverId = 1,
                 RaceWeekendId = 11,
                 Position = 3,
+                Status = RacingStatus.Classified,
             }
         );
         await context.SaveChangesAsync();

--- a/api/F1CompanionApi.UnitTests/Services/ScoringServiceTests.cs
+++ b/api/F1CompanionApi.UnitTests/Services/ScoringServiceTests.cs
@@ -82,12 +82,17 @@ public class ScoringServiceTests
             IsActive = isActive,
         };
 
-    private static DriverQualifyingResult QualResult(int driverId, int position) =>
+    private static DriverQualifyingResult QualResult(
+        int driverId,
+        int? position,
+        RacingStatus status = RacingStatus.Classified
+    ) =>
         new()
         {
             DriverId = driverId,
             RaceWeekendId = 1,
             Position = position,
+            Status = status,
         };
 
     private static DriverRacingResult RaceResult(
@@ -131,6 +136,18 @@ public class ScoringServiceTests
     {
         var service = CreateService();
         Assert.Equal(0, service.CalculateDriverQualifyingPoints(QualResult(1, 11)));
+    }
+
+    [Fact]
+    public void CalculateDriverQualifyingPoints_NullPosition_Returns0()
+    {
+        var service = CreateService();
+        Assert.Equal(
+            0,
+            service.CalculateDriverQualifyingPoints(
+                QualResult(1, position: null, status: RacingStatus.DSQ)
+            )
+        );
     }
 
     #endregion

--- a/api/F1CompanionApi/Api/Mappers/DriverQualifyingResultResponseMapper.cs
+++ b/api/F1CompanionApi/Api/Mappers/DriverQualifyingResultResponseMapper.cs
@@ -20,6 +20,7 @@ public static class DriverQualifyingResultResponseMapper
             DriverId = result.DriverId,
             RaceWeekendId = result.RaceWeekendId,
             Position = result.Position,
+            Status = result.Status,
         };
     }
 }

--- a/api/F1CompanionApi/Api/Models/DriverQualifyingResultResponse.cs
+++ b/api/F1CompanionApi/Api/Models/DriverQualifyingResultResponse.cs
@@ -1,3 +1,5 @@
+using F1CompanionApi.Data.Entities;
+
 namespace F1CompanionApi.Api.Models;
 
 public class DriverQualifyingResultResponse
@@ -5,5 +7,6 @@ public class DriverQualifyingResultResponse
     public required int Id { get; set; }
     public required int DriverId { get; set; }
     public required int RaceWeekendId { get; set; }
-    public required int Position { get; set; }
+    public int? Position { get; set; }
+    public required RacingStatus Status { get; set; }
 }

--- a/api/F1CompanionApi/Api/Models/QualifyingResultItem.cs
+++ b/api/F1CompanionApi/Api/Models/QualifyingResultItem.cs
@@ -1,7 +1,10 @@
+using F1CompanionApi.Data.Entities;
+
 namespace F1CompanionApi.Api.Models;
 
 public class QualifyingResultItem
 {
     public required int DriverId { get; set; }
-    public required int Position { get; set; }
+    public int? Position { get; set; }
+    public required RacingStatus Status { get; set; }
 }

--- a/api/F1CompanionApi/Data/Entities/DriverQualifyingResult.cs
+++ b/api/F1CompanionApi/Data/Entities/DriverQualifyingResult.cs
@@ -7,7 +7,8 @@ public class DriverQualifyingResult : BaseEntity
 {
     public required int DriverId { get; set; }
     public required int RaceWeekendId { get; set; }
-    public required int Position { get; set; }
+    public int? Position { get; set; }
+    public required RacingStatus Status { get; set; }
 
     public Driver Driver { get; set; } = null!;
     public RaceWeekend RaceWeekend { get; set; } = null!;

--- a/api/F1CompanionApi/Data/Migrations/20260429231856_AllowNullPositionAndAddStatusToDriverQualifyingResult.Designer.cs
+++ b/api/F1CompanionApi/Data/Migrations/20260429231856_AllowNullPositionAndAddStatusToDriverQualifyingResult.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using F1CompanionApi.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace F1CompanionApi.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260429231856_AllowNullPositionAndAddStatusToDriverQualifyingResult")]
+    partial class AllowNullPositionAndAddStatusToDriverQualifyingResult
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/F1CompanionApi/Data/Migrations/20260429231856_AllowNullPositionAndAddStatusToDriverQualifyingResult.cs
+++ b/api/F1CompanionApi/Data/Migrations/20260429231856_AllowNullPositionAndAddStatusToDriverQualifyingResult.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace F1CompanionApi.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AllowNullPositionAndAddStatusToDriverQualifyingResult : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "Position",
+                table: "DriverQualifyingResults",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Status",
+                table: "DriverQualifyingResults",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "DriverQualifyingResults");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Position",
+                table: "DriverQualifyingResults",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+        }
+    }
+}

--- a/api/F1CompanionApi/Domain/Services/RaceWeekendResultService.cs
+++ b/api/F1CompanionApi/Domain/Services/RaceWeekendResultService.cs
@@ -79,6 +79,7 @@ public class RaceWeekendResultService : IRaceWeekendResultService
                 DriverId = i.DriverId,
                 RaceWeekendId = raceWeekendId,
                 Position = i.Position,
+                Status = i.Status,
                 CreatedAt = DateTime.UtcNow,
             })
             .ToList();
@@ -196,7 +197,9 @@ public class RaceWeekendResultService : IRaceWeekendResultService
     }
 
     /// <summary>
-    /// Validates that no duplicate driverIds appear in the batch.
+    /// Validates that no duplicate driverIds appear in the batch and that Position
+    /// is consistent with Status: a Classified driver must have a Position; a non-Classified
+    /// driver must not.
     /// </summary>
     /// <param name="qualifyingItems">The qualifying result items to validate.</param>
     private static void ValidateQualifyingItems(List<QualifyingResultItem> qualifyingItems)
@@ -209,6 +212,23 @@ public class RaceWeekendResultService : IRaceWeekendResultService
             throw new ArgumentException(
                 $"Duplicate driverIds in batch: {string.Join(", ", duplicates.Select(g => g.Key))}"
             );
+
+        foreach (var item in qualifyingItems)
+        {
+            var positionRequired = item.Status == RacingStatus.Classified && item.Position is null;
+            var positionForbidden =
+                item.Status != RacingStatus.Classified && item.Position is not null;
+
+            if (positionRequired)
+                throw new ArgumentException(
+                    $"Driver {item.DriverId}: Position is required when Status is Classified"
+                );
+
+            if (positionForbidden)
+                throw new ArgumentException(
+                    $"Driver {item.DriverId}: Position must be null when Status is {item.Status}"
+                );
+        }
     }
 
     /// <summary>

--- a/api/scripts/README.md
+++ b/api/scripts/README.md
@@ -60,3 +60,11 @@ The script will:
 5. Load qualifying results from FastF1 and submit them
 6. If sprint weekend: load sprint results, overtakes, and fastest lap and submit them
 7. Load race results, overtakes, and fastest lap and submit them
+
+## Tests
+
+```bash
+cd api/scripts
+source .venv/bin/activate
+python3 -m pytest test_ingest_results.py
+```

--- a/api/scripts/ingest_results.py
+++ b/api/scripts/ingest_results.py
@@ -201,7 +201,8 @@ def map_session_status(row) -> RacingStatus:
     classification). Falls back to Position-NaN for qualifying, where FastF1
     leaves ClassifiedPosition empty.
     """
-    cp = str(row.get("ClassifiedPosition") or "").strip()
+    cp_raw = row.get("ClassifiedPosition")
+    cp = "" if pd.isna(cp_raw) else str(cp_raw).strip()
     if cp == "":
         return (
             RacingStatus.CLASSIFIED
@@ -214,6 +215,12 @@ def map_session_status(row) -> RacingStatus:
         return RacingStatus.DSQ
     if cp in ("W", "F"):
         return RacingStatus.DNS
+    if cp in ("R", "N"):
+        return RacingStatus.DNF
+    print(
+        f"Warning: unknown FIA ClassifiedPosition '{cp}', bucketing as DNF",
+        file=sys.stderr,
+    )
     return RacingStatus.DNF
 
 

--- a/api/scripts/ingest_results.py
+++ b/api/scripts/ingest_results.py
@@ -23,9 +23,6 @@ from dotenv import dotenv_values
 
 CACHE_DIR = ".ff1_cache"
 
-# FastF1 status strings that mean the driver finished the race
-_CLASSIFIED_STATUSES = {"Finished"}
-
 WEEKEND_FORMAT_SPRINT = 1
 
 
@@ -197,21 +194,26 @@ def count_overtakes(laps) -> dict[str, int]:
     return overtakes
 
 
-def map_status(status_str) -> RacingStatus:
-    """Map a FastF1 status string to a RacingStatus enum value."""
-    if pd.isna(status_str) or status_str is None:
-        return RacingStatus.DNS
+def map_session_status(row) -> RacingStatus:
+    """Map a FastF1 SessionResults row to a RacingStatus.
 
-    status = str(status_str).strip()
-
-    if status == "Disqualified":
-        return RacingStatus.DSQ
-
-    if status in _CLASSIFIED_STATUSES or "Lap" in status:
-        # "Finished" or lapped (e.g. "+1 Lap", "+2 Laps")
+    Reads ClassifiedPosition for grand-prix and sprint sessions (FIA's official
+    classification). Falls back to Position-NaN for qualifying, where FastF1
+    leaves ClassifiedPosition empty.
+    """
+    cp = str(row.get("ClassifiedPosition") or "").strip()
+    if cp == "":
+        return (
+            RacingStatus.CLASSIFIED
+            if not pd.isna(row.get("Position"))
+            else RacingStatus.DSQ
+        )
+    if cp.isdigit():
         return RacingStatus.CLASSIFIED
-
-    # Everything else: "Retired", mechanical failures, accidents, etc.
+    if cp in ("D", "E"):
+        return RacingStatus.DSQ
+    if cp in ("W", "F"):
+        return RacingStatus.DNS
     return RacingStatus.DNF
 
 
@@ -231,14 +233,16 @@ def build_qualifying_payload(
             warnings.append(f"Driver '{abbr}' not found in API, skipping")
             continue
 
+        status = map_session_status(row)
         position = row.get("Position")
-        if pd.isna(position):
-            warnings.append(f"Driver '{abbr}' has no qualifying position, skipping")
-            continue
+        position_value = (
+            int(position) if status == RacingStatus.CLASSIFIED else None
+        )
 
         items.append({
             "driverId": driver_id,
-            "position": int(position),
+            "position": position_value,
+            "status": int(status),
         })
     return items, warnings
 
@@ -260,7 +264,7 @@ def build_race_payload(
             warnings.append(f"Driver '{abbr}' not found in API, skipping")
             continue
 
-        status = map_status(row.get("Status", ""))
+        status = map_session_status(row)
 
         grid = row.get("GridPosition")
         grid = 0 if pd.isna(grid) else int(grid)

--- a/api/scripts/test_ingest_results.py
+++ b/api/scripts/test_ingest_results.py
@@ -48,6 +48,23 @@ class TestMapSessionStatus:
     def test_unknown_letter_returns_dnf(self):
         assert map_session_status({"ClassifiedPosition": "X"}) == RacingStatus.DNF
 
+    def test_unknown_letter_warns_to_stderr(self, capsys):
+        map_session_status({"ClassifiedPosition": "X"})
+        captured = capsys.readouterr()
+        assert "unknown FIA ClassifiedPosition 'X'" in captured.err
+
+    def test_nan_classified_position_falls_through_to_position(self):
+        assert (
+            map_session_status({"ClassifiedPosition": float("nan"), "Position": 5})
+            == RacingStatus.CLASSIFIED
+        )
+        assert (
+            map_session_status(
+                {"ClassifiedPosition": float("nan"), "Position": float("nan")}
+            )
+            == RacingStatus.DSQ
+        )
+
     def test_qualifying_with_position_returns_classified(self):
         assert (
             map_session_status({"ClassifiedPosition": "", "Position": 5})

--- a/api/scripts/test_ingest_results.py
+++ b/api/scripts/test_ingest_results.py
@@ -15,43 +15,53 @@ from ingest_results import (
     get_fastest_lap_driver,
     ingest,
     load_session,
-    map_status,
+    map_session_status,
 )
 
 
-# --- map_status ---
+# --- map_session_status ---
 
 
-class TestMapStatus:
-    def test_finished_returns_classified(self):
-        assert map_status("Finished") == RacingStatus.CLASSIFIED
+class TestMapSessionStatus:
+    def test_integer_classified_position_is_classified(self):
+        assert map_session_status({"ClassifiedPosition": "1"}) == RacingStatus.CLASSIFIED
+        assert map_session_status({"ClassifiedPosition": "17"}) == RacingStatus.CLASSIFIED
 
-    def test_lapped_one_lap_returns_classified(self):
-        assert map_status("+1 Lap") == RacingStatus.CLASSIFIED
+    def test_d_returns_dsq(self):
+        assert map_session_status({"ClassifiedPosition": "D"}) == RacingStatus.DSQ
 
-    def test_lapped_two_laps_returns_classified(self):
-        assert map_status("+2 Laps") == RacingStatus.CLASSIFIED
+    def test_e_returns_dsq(self):
+        assert map_session_status({"ClassifiedPosition": "E"}) == RacingStatus.DSQ
 
-    def test_retired_returns_dnf(self):
-        assert map_status("Retired") == RacingStatus.DNF
+    def test_w_returns_dns(self):
+        assert map_session_status({"ClassifiedPosition": "W"}) == RacingStatus.DNS
 
-    def test_engine_failure_returns_dnf(self):
-        assert map_status("Engine") == RacingStatus.DNF
+    def test_f_returns_dns(self):
+        assert map_session_status({"ClassifiedPosition": "F"}) == RacingStatus.DNS
 
-    def test_accident_returns_dnf(self):
-        assert map_status("Accident") == RacingStatus.DNF
+    def test_r_returns_dnf(self):
+        assert map_session_status({"ClassifiedPosition": "R"}) == RacingStatus.DNF
 
-    def test_disqualified_returns_dsq(self):
-        assert map_status("Disqualified") == RacingStatus.DSQ
+    def test_n_returns_dnf(self):
+        assert map_session_status({"ClassifiedPosition": "N"}) == RacingStatus.DNF
 
-    def test_none_returns_dns(self):
-        assert map_status(None) == RacingStatus.DNS
+    def test_unknown_letter_returns_dnf(self):
+        assert map_session_status({"ClassifiedPosition": "X"}) == RacingStatus.DNF
 
-    def test_nan_returns_dns(self):
-        assert map_status(float("nan")) == RacingStatus.DNS
+    def test_qualifying_with_position_returns_classified(self):
+        assert (
+            map_session_status({"ClassifiedPosition": "", "Position": 5})
+            == RacingStatus.CLASSIFIED
+        )
+
+    def test_qualifying_with_nan_position_returns_dsq(self):
+        assert (
+            map_session_status({"ClassifiedPosition": "", "Position": float("nan")})
+            == RacingStatus.DSQ
+        )
 
     def test_whitespace_is_stripped(self):
-        assert map_status("  Finished  ") == RacingStatus.CLASSIFIED
+        assert map_session_status({"ClassifiedPosition": "  D  "}) == RacingStatus.DSQ
 
 
 # --- load_session ---
@@ -225,21 +235,29 @@ def _make_session(results_data: list[dict]) -> SimpleNamespace:
 class TestBuildQualifyingPayload:
     def test_builds_payload(self):
         session = _make_session([
-            {"Abbreviation": "VER", "Position": 1},
-            {"Abbreviation": "NOR", "Position": 2},
+            {"Abbreviation": "VER", "Position": 1, "ClassifiedPosition": ""},
+            {"Abbreviation": "NOR", "Position": 2, "ClassifiedPosition": ""},
         ])
         driver_map = {"VER": 10, "NOR": 20}
         payload, warnings = build_qualifying_payload(session, driver_map)
 
         assert len(payload) == 2
-        assert payload[0] == {"driverId": 10, "position": 1}
-        assert payload[1] == {"driverId": 20, "position": 2}
+        assert payload[0] == {
+            "driverId": 10,
+            "position": 1,
+            "status": int(RacingStatus.CLASSIFIED),
+        }
+        assert payload[1] == {
+            "driverId": 20,
+            "position": 2,
+            "status": int(RacingStatus.CLASSIFIED),
+        }
         assert warnings == []
 
     def test_skips_unknown_driver_with_warning(self):
         session = _make_session([
-            {"Abbreviation": "VER", "Position": 1},
-            {"Abbreviation": "XXX", "Position": 2},
+            {"Abbreviation": "VER", "Position": 1, "ClassifiedPosition": ""},
+            {"Abbreviation": "XXX", "Position": 2, "ClassifiedPosition": ""},
         ])
         driver_map = {"VER": 10}
         payload, warnings = build_qualifying_payload(session, driver_map)
@@ -248,16 +266,20 @@ class TestBuildQualifyingPayload:
         assert len(warnings) == 1
         assert "XXX" in warnings[0]
 
-    def test_skips_missing_position_with_warning(self):
+    def test_nan_position_emits_dsq_with_null_position(self):
         session = _make_session([
-            {"Abbreviation": "VER", "Position": float("nan")},
+            {"Abbreviation": "VER", "Position": float("nan"), "ClassifiedPosition": ""},
         ])
         driver_map = {"VER": 10}
         payload, warnings = build_qualifying_payload(session, driver_map)
 
-        assert len(payload) == 0
-        assert len(warnings) == 1
-        assert "VER" in warnings[0]
+        assert len(payload) == 1
+        assert payload[0] == {
+            "driverId": 10,
+            "position": None,
+            "status": int(RacingStatus.DSQ),
+        }
+        assert warnings == []
 
 
 # --- build_race_payload ---
@@ -266,7 +288,7 @@ class TestBuildQualifyingPayload:
 class TestBuildRacePayload:
     def test_classified_driver(self):
         session = _make_session([
-            {"Abbreviation": "VER", "Status": "Finished", "GridPosition": 1,
+            {"Abbreviation": "VER", "ClassifiedPosition": "1", "GridPosition": 1,
              "Position": 1},
         ])
         driver_map = {"VER": 10}
@@ -286,7 +308,7 @@ class TestBuildRacePayload:
 
     def test_fastest_lap_false_when_not_matching(self):
         session = _make_session([
-            {"Abbreviation": "VER", "Status": "Finished", "GridPosition": 1,
+            {"Abbreviation": "VER", "ClassifiedPosition": "1", "GridPosition": 1,
              "Position": 1},
         ])
         driver_map = {"VER": 10}
@@ -296,7 +318,7 @@ class TestBuildRacePayload:
 
     def test_fastest_lap_false_when_none(self):
         session = _make_session([
-            {"Abbreviation": "VER", "Status": "Finished", "GridPosition": 1,
+            {"Abbreviation": "VER", "ClassifiedPosition": "1", "GridPosition": 1,
              "Position": 1},
         ])
         driver_map = {"VER": 10}
@@ -306,7 +328,7 @@ class TestBuildRacePayload:
 
     def test_dnf_driver_has_null_finish_position(self):
         session = _make_session([
-            {"Abbreviation": "NOR", "Status": "Retired", "GridPosition": 3,
+            {"Abbreviation": "NOR", "ClassifiedPosition": "R", "GridPosition": 3,
              "Position": float("nan")},
         ])
         driver_map = {"NOR": 20}
@@ -317,7 +339,7 @@ class TestBuildRacePayload:
 
     def test_dsq_driver_has_null_finish_position(self):
         session = _make_session([
-            {"Abbreviation": "VER", "Status": "Disqualified", "GridPosition": 1,
+            {"Abbreviation": "VER", "ClassifiedPosition": "D", "GridPosition": 1,
              "Position": 1},
         ])
         driver_map = {"VER": 10}
@@ -326,20 +348,34 @@ class TestBuildRacePayload:
         assert payload[0]["finishPosition"] is None
         assert payload[0]["status"] == int(RacingStatus.DSQ)
 
-    def test_lapped_driver_is_classified(self):
+    def test_dns_driver_has_null_finish_position(self):
         session = _make_session([
-            {"Abbreviation": "VER", "Status": "+1 Lap", "GridPosition": 15,
-             "Position": 12},
+            {"Abbreviation": "PIA", "ClassifiedPosition": "W", "GridPosition": 0,
+             "Position": float("nan")},
         ])
-        driver_map = {"VER": 10}
+        driver_map = {"PIA": 30}
         payload, warnings = build_race_payload(session, driver_map, {})
 
-        assert payload[0]["finishPosition"] == 12
-        assert payload[0]["status"] == int(RacingStatus.CLASSIFIED)
+        assert payload[0]["finishPosition"] is None
+        assert payload[0]["status"] == int(RacingStatus.DNS)
+
+    def test_classified_position_r_with_finish_position_is_dnf(self):
+        # Regression: under the old `Status`-based mapper, a "Lapped" entry with
+        # Position=17 was stored as CLASSIFIED. The FIA `R` classification means
+        # the driver was not classified — must round-trip as DNF with null finish.
+        session = _make_session([
+            {"Abbreviation": "STR", "ClassifiedPosition": "R", "GridPosition": 14,
+             "Position": 17},
+        ])
+        driver_map = {"STR": 40}
+        payload, warnings = build_race_payload(session, driver_map, {})
+
+        assert payload[0]["finishPosition"] is None
+        assert payload[0]["status"] == int(RacingStatus.DNF)
 
     def test_skips_unknown_driver_with_warning(self):
         session = _make_session([
-            {"Abbreviation": "XXX", "Status": "Finished", "GridPosition": 1,
+            {"Abbreviation": "XXX", "ClassifiedPosition": "1", "GridPosition": 1,
              "Position": 1},
         ])
         payload, warnings = build_race_payload(session, {}, {})
@@ -350,7 +386,7 @@ class TestBuildRacePayload:
 
     def test_missing_overtakes_defaults_to_zero(self):
         session = _make_session([
-            {"Abbreviation": "VER", "Status": "Finished", "GridPosition": 1,
+            {"Abbreviation": "VER", "ClassifiedPosition": "1", "GridPosition": 1,
              "Position": 1},
         ])
         driver_map = {"VER": 10}
@@ -360,7 +396,7 @@ class TestBuildRacePayload:
 
     def test_missing_grid_position_defaults_to_zero(self):
         session = _make_session([
-            {"Abbreviation": "VER", "Status": "Finished", "GridPosition": float("nan"),
+            {"Abbreviation": "VER", "ClassifiedPosition": "1", "GridPosition": float("nan"),
              "Position": 1},
         ])
         driver_map = {"VER": 10}
@@ -441,7 +477,7 @@ def _make_ingest_mocks(monkeypatch, *, has_sprint: bool, total_rounds: int, roun
     monkeypatch.setattr("ingest_results.load_session", _load)
     monkeypatch.setattr(
         "ingest_results.build_qualifying_payload",
-        lambda sess, dm: ([{"driverId": 10, "position": 1}], []),
+        lambda sess, dm: ([{"driverId": 10, "position": 1, "status": 0}], []),
     )
     monkeypatch.setattr(
         "ingest_results.build_race_payload",

--- a/docs/plans/148-qualifying-dsq.md
+++ b/docs/plans/148-qualifying-dsq.md
@@ -1,0 +1,346 @@
+# Plan — gh issue #148 (qualifying DSQ breaks `/score`)
+
+## Context
+
+`POST /api/seasons/{id}/race-weekends/{round}/score` throws `InvalidOperationException`
+from `ScoringService.ScoreConstructors` (`api/F1CompanionApi/Domain/Services/ScoringService.cs:318-323`)
+after qualifying ingestion if any driver was DSQ'd / withdrew / failed to qualify. Real-world
+example: 2026 Australian GP (round 1) — VER, STR, SAI all DSQ'd from quali.
+
+Three layers compound to produce the bug:
+
+1. `DriverQualifyingResult` (`api/F1CompanionApi/Data/Entities/DriverQualifyingResult.cs:1-14`)
+   has only `DriverId` + `required int Position` — no way to record a non-classified entry.
+2. `build_qualifying_payload` in `api/scripts/ingest_results.py:218-243` skips any row with
+   NaN `Position`. DSQ'd quali drivers have NaN `Position` upstream, so they are silently dropped.
+3. `ScoreDrivers` (`ScoringService.cs:257-267`) builds the driver set from the union of
+   qualifying + grand-prix/sprint rows. After qualifying-only ingestion, a DSQ'd driver appears in neither,
+   so `ScoreConstructors` (`:300-336`) sees only one of the constructor's two drivers and throws.
+
+Goal: make non-classified qualifying entries first-class so they're persisted, returned by
+`ScoreDrivers`, and produce a 0-point qualifying score. The `ScoreConstructors` invariant stays —
+it now only fires for the original case it was written for (driver missing from **both** quali and
+weekend, i.e. genuine roster/data drift).
+
+## Reuse audit
+
+The user asked to confirm what existing mapping logic can be reused before inventing new code.
+
+### C# side — pattern is fully reusable
+
+Grand prix / sprint already implement exactly the shape qualifying needs. Both share
+`DriverRacingResult` (`Data/Entities/DriverRacingResult.cs:1-19`) which has:
+
+- `int? FinishPosition` (nullable)
+- `required RacingStatus Status` (`Data/Entities/RacingStatus.cs` — `Classified=0, DNF=1, DSQ=2, DNS=3`)
+
+Mirroring patterns to copy verbatim:
+
+- API model: `RacingResultItem` (`Api/Models/RacingResultItem.cs:1-13`) — nullable position + required Status.
+- API response: `DriverRacingResultResponse` (`Api/Models/DriverRacingResultResponse.cs:1-16`).
+- Validation cross-field rule: `ValidateRaceItems` (`Domain/Services/RaceWeekendResultService.cs:218-249`),
+  specifically lines 234-247 enforcing `Status==Classified ⇔ FinishPosition!=null`.
+- Scoring null-handling: `GetPositionPoints` (`ScoringService.cs:119-125`) **already** returns 0
+  for null position. `CalculateDriverQualifyingPoints` (`:36-39`) calls into it. No scoring code
+  needs to change once the field becomes nullable — null flows through to 0 with no math edit.
+- Scoring penalty: grand prix / sprint apply `dnfPenalty` when `Status != Classified`
+  (`CalculateDriverSessionPoints:97-102`). **Qualifying does not apply a penalty.**
+  `docs/research/fantasy-rules/decisions/scoring.md:27` is explicit:
+  > Qualifying retirements carry no penalty.
+  So no change to `CalculateDriverQualifyingPoints` — null Position → 0 points, end of story.
+
+### Python side — unify on `ClassifiedPosition`, retire `map_status`
+
+`map_status` (`api/scripts/ingest_results.py:200-215`) currently reads FastF1's free-text
+`Status` column ("Finished", "Disqualified", "Retired", "Lapped", "+ 1 Lap", "Crash",
+"Gearbox", "Did not start", …) and collapses to `RacingStatus`. Two problems with that source:
+
+1. It **doesn't exist for qualifying.** Verified by a fresh, non-cached load of 2026 R1
+   qualifying (network fetch, all seven artifacts pulled fresh): `Status` is empty string for
+   all 22 drivers. (`ClassifiedPosition` is also empty for plain qualifying — verified the
+   same way; FastF1's docs over-promise on that field for current-season qualifying. The
+   single signal qualifying gives us is `Position is NaN`.)
+2. Its mapping for grand prix / sprint **has latent bugs.** Verified against 2026 AUS grand
+   prix data:
+   - **Stroll**: `Status="Lapped"` paired with `ClassifiedPosition="R"`. `map_status` matches
+     `"Lap" in status` → CLASSIFIED, leaves him with `finishPosition=17`. Per `scoring.md:103`
+     ("a driver listed as DNF or Not Classified receives 0 finish points and the −10
+     penalty"), an FIA `R` classification is DNF — current code is wrong.
+   - **Piastri / Hülkenberg**: `Status="Did not start"` paired with `ClassifiedPosition="W"`.
+     `map_status` falls through to DNF (catch-all); the FIA `W` classification is DNS. Same
+     point total under `scoring.md:103` ("DNF / DSQ / DNS are treated identically"), so no
+     fantasy-points change — but the stored Status is wrong.
+
+`ClassifiedPosition` is a small, structured field (integer string or one of `R`/`D`/`E`/`W`/
+`F`/`N`) that already encodes the four `RacingStatus` buckets we care about, and it's reliable
+for grand prix / sprint. So: **replace `map_status` with one helper that reads
+`ClassifiedPosition` for grand prix / sprint and falls back to `Position is NaN` for
+qualifying** (where the column is empty). Single source of truth, kills the free-text
+dependency, and fixes the Stroll-class bug as a side effect.
+
+Verified empirical state of FastF1 columns:
+
+| Column | Grand Prix / Sprint | **Qualifying (actual behavior)** |
+|---|---|---|
+| `Position` | populated even for non-classified (it's a finishing rank) | populated; **NaN** for non-classified |
+| `ClassifiedPosition` | populated: integer or `R`/`D`/`E`/`W`/`F`/`N` | **always empty string** for all drivers (incl. DSQ'd) |
+| `Status` | populated, free-text ("Lapped"/"Did not start"/"Crash"/…) | **always empty string** |
+| `Q1`/`Q2`/`Q3` | n/a | populated for runners; **NaT for DSQ'd drivers** (FastF1 wipes their times) |
+
+For qualifying, `Position is NaN` is the only available bit. We can't disambiguate DSQ vs DNS
+vs DNF from the data, so the auto-ingest emits one canonical non-classified bucket (DSQ —
+matches the case the issue documents and the most common modern cause). The API/entity still
+accepts all four `RacingStatus` values so a future manual correction or alternate source can
+record the precise reason.
+
+## Plan — ordered commits
+
+Each commit is independently buildable, lintable, testable, formatted. Tests ship with their
+implementation. Order: branch + plan → data model → API → ingest, so each layer's tests can use
+the previous.
+
+---
+
+### Commit 1 — branch off `main` and check the plan into `docs/plans/`
+
+**Steps**
+
+1. From `main`, create a new branch — e.g. `git checkout -b fix/issue-148-qualifying-dsq`.
+2. Copy this plan file from `~/.claude/plans/plan-gh-issue-148-graceful-leaf.md` to
+   `docs/plans/issue-148-qualifying-dsq.md` (project convention per `CLAUDE.md`:
+   *"Write the plan to `docs/plans/` when producing a full plan."*).
+3. Commit just the new plan file. No code changes in this commit.
+
+This commit gives the rest of the work a stable, reviewable starting point and puts the plan
+under version control alongside the changes it describes.
+
+---
+
+### Commit 2 — backend: Status as a first-class field on qualifying results
+
+**Files**
+
+- `api/F1CompanionApi/Data/Entities/DriverQualifyingResult.cs` — change `required int Position`
+  to `int? Position`; add `required RacingStatus Status`.
+- `api/F1CompanionApi/Api/Models/QualifyingResultItem.cs` — same shape change.
+- `api/F1CompanionApi/Api/Models/DriverQualifyingResultResponse.cs` — same shape change
+  (nullable Position, required Status).
+- `api/F1CompanionApi/Api/Mappers/DriverQualifyingResultResponseMapper.cs` — pass Status through;
+  Position is already pass-through.
+- `api/F1CompanionApi/Domain/Services/RaceWeekendResultService.cs`:
+  - `SubmitQualifyingResultsAsync` (`:51-90`) — set `Status = i.Status` on the entity.
+  - `ValidateQualifyingItems` (`:202-212`) — add the same cross-field rule used in
+    `ValidateRaceItems:234-247`, adapted for `Position` instead of `FinishPosition`:
+    `Status==Classified ⇒ Position!=null`; `Status!=Classified ⇒ Position==null`.
+- New EF migration:
+  ```
+  dotnet ef migrations add AllowNullPositionAndAddStatusToDriverQualifyingResult --project F1CompanionApi
+  ```
+  Expected generated operations:
+  - `AlterColumn` on `DriverQualifyingResults.Position` → `nullable: true`.
+  - `AddColumn` `DriverQualifyingResults.Status` int, `nullable: false`, `defaultValue: 0`.
+  Existing rows backfill to `Classified` (value 0), which is correct because every existing row
+  has a non-null Position.
+
+**Tests (in this commit)**
+
+- Update existing `RaceWeekendResultServiceTests.cs` and `ScoringServiceTests.cs` constructions of
+  `DriverQualifyingResult` / `QualifyingResultItem` to include `Status = RacingStatus.Classified`.
+  Compile-time enforced by the `required` modifier.
+- `RaceWeekendResultServiceTests`:
+  - `SubmitQualifyingResultsAsync_PersistsDsqEntry_WithNullPosition` — payload contains one
+    `{driverId, position: null, status: DSQ}`; verify entity stored with those values.
+  - `SubmitQualifyingResultsAsync_ThrowsArgumentException_WhenClassifiedHasNullPosition`.
+  - `SubmitQualifyingResultsAsync_ThrowsArgumentException_WhenNonClassifiedHasPosition`.
+- `ScoringServiceTests`:
+  - `CalculateDriverQualifyingPoints_ReturnsZero_WhenPositionIsNull` (covers the null path
+    already provided by `GetPositionPoints`).
+
+**No changes** to `ScoringService.cs` — null Position → 0 via `GetPositionPoints`; the
+`ScoreConstructors` invariant is preserved.
+
+---
+
+### Commit 3 — integration test: DSQ qualifying scoring round-trip
+
+Goal: exercise the full HTTP pipeline against a real Postgres to prove the issue-148 500 is gone.
+
+**Files**
+
+- `api/F1CompanionApi.IntegrationTests/Scenarios/QualifyingDsqScoringTests.cs` (new). Inherits
+  `IntegrationTestBase`. Uses `factory.CreateAuthenticatedAsync()`.
+
+**Seed (minimal — just the constructor pair the bug fires on, no full grid):**
+
+Inside `WithDbAsync` block, using the existing `TestDataBuilder` extensions
+(`api/F1CompanionApi.IntegrationTests/Support/TestDataBuilder.cs`):
+
+- `db.CreateCurrentSeasonAsync()` → season
+- `db.CreateRaceWeekendAsync(season.Id, raceDate, round: 1)` → race weekend
+- `db.CreateDriverAsync("AAA", "First", "One")` and `db.CreateDriverAsync("BBB", "First",
+  "Two")` → the two drivers of one constructor
+- `db.CreateConstructorAsync("TestCo")` → constructor
+- Two `SeasonDriver` rows linking the drivers to the constructor with `IsActive=true`. No
+  shared helper exists for this; add inline as `db.SeasonDrivers.Add(new SeasonDriver { ... })`
+  twice (3–4 lines). Optionally extract a `CreateSeasonDriverAsync` extension on
+  `TestDataBuilder` if it cleans up the test, but YAGNI is fine here.
+
+**Scenario**
+
+1. `PUT /api/seasons/{id}/race-weekends/1/results/qualifying` with two entries: one DSQ
+   driver `{driverId: AAA.Id, position: null, status: 2 /* DSQ */}`, one classified driver
+   `{driverId: BBB.Id, position: 1, status: 0 /* Classified */}`.
+2. `POST /api/seasons/{id}/race-weekends/1/score`. Assert 200 (the previous failure surface).
+3. `GET /api/seasons/{id}/race-weekends/1/results/qualifying` — DSQ entry round-trips with
+   `position: null, status: 2`.
+4. Via `WithDbAsync`, read `DriverRaceWeekendScore` for AAA — assert
+   `QualifyingPositionPoints == 0`.
+5. Via `WithDbAsync`, read `ConstructorRaceWeekendScore` for the constructor — assert it
+   exists (this row is what `ScoreConstructors:318` previously threw on).
+
+---
+
+### Commit 4 — Python ingest: unified `ClassifiedPosition` mapping, replaces `map_status`
+
+**Files**
+
+- `api/scripts/ingest_results.py`:
+  - **Delete** `map_status` (`:200-215`) and the `_CLASSIFIED_STATUSES` constant (`:27`).
+  - **Add** `map_session_status(row) -> RacingStatus`:
+    ```python
+    def map_session_status(row) -> RacingStatus:
+        """Map a FastF1 SessionResults row to a RacingStatus.
+
+        Reads ClassifiedPosition for grand-prix and sprint sessions (FIA's official
+        classification). Falls back to Position-NaN for qualifying, where FastF1
+        leaves ClassifiedPosition empty.
+        """
+        cp = str(row.get("ClassifiedPosition") or "").strip()
+        if cp == "":
+            # Qualifying: only signal is Position
+            return (RacingStatus.CLASSIFIED
+                    if not pd.isna(row.get("Position"))
+                    else RacingStatus.DSQ)
+        if cp.isdigit():
+            return RacingStatus.CLASSIFIED
+        if cp in ("D", "E"):
+            return RacingStatus.DSQ
+        if cp in ("W", "F"):
+            return RacingStatus.DNS
+        # 'R', 'N', or any unknown letter
+        return RacingStatus.DNF
+    ```
+  - **Update** `build_race_payload` (`:246-284`) — replace `map_status(row.get("Status",""))`
+    with `map_session_status(row)`. No other change needed; downstream
+    `if pd.isna(finish) or status != RacingStatus.CLASSIFIED: finish_position = None`
+    logic continues to work and now correctly drops Stroll's `Position=17` for an `R`
+    classification.
+  - **Update** `build_qualifying_payload` (`:218-243`):
+    - Stop skipping rows with NaN `Position`. The "driver missing from API" guard stays.
+    - Compute `status = map_session_status(row)`.
+    - `position = int(row["Position"])` if `status == CLASSIFIED` else `None`.
+    - Payload item: `{driverId, position: int|None, status: int(status)}`.
+
+- `api/scripts/test_ingest_results.py`:
+  - **Delete** `TestMapStatus`.
+  - **Add** `TestMapSessionStatus` with cases for each branch:
+    - integer-string CP (`'1'`, `'17'`) → CLASSIFIED
+    - `'D'`, `'E'` → DSQ
+    - `'W'`, `'F'` → DNS
+    - `'R'`, `'N'` → DNF
+    - unknown letter (e.g. `'X'`) → DNF (catch-all)
+    - empty CP + non-NaN Position → CLASSIFIED (qualifying classified path)
+    - empty CP + NaN Position → DSQ (qualifying non-classified path)
+  - **Update** `TestBuildRacePayload` rows: switch the synthetic data from `Status="…"`
+    to `ClassifiedPosition="…"`. Add a regression case for the Stroll bug:
+    `ClassifiedPosition="R"` + `Position=17` → payload row has `finishPosition=None`,
+    `status=DNF`.
+  - **Update** `TestBuildQualifyingPayload` for the new payload shape (`status` field
+    always present; `position` is `int` or `None`); add a NaN-Position → DSQ case.
+
+Order note: this commit lands the unified mapper alongside the qualifying behavior change. It
+does not depend on commits 2–3 to compile/run; pytest exercises the script in isolation. The
+runtime behavior of `build_race_payload` does change for grand-prix sessions where
+`ClassifiedPosition` differs from what `Status` would have implied — see verification step for
+the post-deploy re-ingest of 2026 R1 grand prix.
+
+---
+
+## Confirmed decisions
+
+1. **Auto-ingest emits a single canonical non-classified status (DSQ).** FastF1 doesn't expose
+   enough qualifying data to distinguish DSQ / DNS / DNF (see Python-side reuse audit above).
+   The API still accepts all four `RacingStatus` values, so a future caller (manual correction
+   tool, alternate data source) can record the precise reason when it's known.
+
+2. **No penalty for any non-Classified qualifying status.** Per `scoring.md:27` qualifying
+   retirements carry no penalty; there is no `QualifyingDnfPenalty` in `ScoringConstants`. The
+   null-Position → 0 path in `GetPositionPoints` already implements this correctly.
+
+3. **No backfill of local Supabase seed data.** Existing rows all have a Position, so the
+   migration's `defaultValue: 0` (Classified) is correct as-is.
+
+4. **Grand prix / sprint mapping unified onto `ClassifiedPosition` as part of this PR.**
+   Explicitly in scope. Replaces `map_status` with one source-of-truth mapper. Drives two
+   real corrections in stored data:
+   - **Stroll 2026 AUS GP**: was stored CLASSIFIED with `finishPosition=17`; under the new
+     mapping he becomes DNF with `finishPosition=null` (per `scoring.md:103`'s rule that an
+     FIA `R` classification is DNF). One real fantasy-points change in 2026 R1 — Stroll
+     loses the position-points for P17 and gains the −10 penalty.
+   - **Piastri / Hülkenberg 2026 AUS GP**: were stored DNF; under the new mapping they
+     become DNS. **No fantasy-points change** (DNF / DSQ / DNS scored identically per
+     `scoring.md:103`); just a more accurate stored Status.
+   Operational consequence: 2026 R1 grand prix data needs to be re-ingested after the script
+   change ships — see verification.
+
+## What this plan does NOT fix
+
+A driver missing from **both** qualifying and grand-prix/sprint results (full-weekend no-show with stale
+`SeasonDrivers`) still throws at `ScoreConstructors:318`. That is the original case the throw
+was written for and is intentionally preserved.
+
+## Critical files
+
+| File | Change |
+|---|---|
+| `api/F1CompanionApi/Data/Entities/DriverQualifyingResult.cs` | nullable Position; add Status |
+| `api/F1CompanionApi/Api/Models/QualifyingResultItem.cs` | nullable Position; add Status |
+| `api/F1CompanionApi/Api/Models/DriverQualifyingResultResponse.cs` | nullable Position; add Status |
+| `api/F1CompanionApi/Api/Mappers/DriverQualifyingResultResponseMapper.cs` | pass Status through |
+| `api/F1CompanionApi/Domain/Services/RaceWeekendResultService.cs` | extend `ValidateQualifyingItems`; set Status in `SubmitQualifyingResultsAsync` |
+| `api/F1CompanionApi/Data/Migrations/<ts>_AddStatusToDriverQualifyingResult.cs` | new (generated) |
+| `api/F1CompanionApi.UnitTests/Services/RaceWeekendResultServiceTests.cs` | update + add cases |
+| `api/F1CompanionApi.UnitTests/Services/ScoringServiceTests.cs` | update + add null-Position case |
+| `api/F1CompanionApi.IntegrationTests/Scenarios/QualifyingDsqScoringTests.cs` | new |
+| `api/scripts/ingest_results.py` | replace `map_status` with `map_session_status` (reads `ClassifiedPosition`); update both `build_qualifying_payload` and `build_race_payload` to call it |
+| `api/scripts/test_ingest_results.py` | replace `TestMapStatus` with `TestMapSessionStatus`; switch `TestBuildRacePayload` synthetic rows from `Status` to `ClassifiedPosition`; update `TestBuildQualifyingPayload` for new shape |
+
+`api/F1CompanionApi/Domain/Services/ScoringService.cs` — **no edits.** Existing null-Position
+handling in `GetPositionPoints` is sufficient.
+
+## Verification
+
+- `npm run api:test` (unit + integration) passes.
+- `npm run api:format:check` clean.
+- Python: `cd api/scripts && python3 -m pytest test_ingest_results.py` passes.
+- Manual repro from the issue, against local stack with 2026 AUS GP data:
+  ```
+  cd api/scripts
+  source .venv/bin/activate
+  python3 ingest_results.py --round 1
+  ```
+  Expected:
+  1. **Qualifying** submission accepted; `/score` returns 200; no `InvalidOperationException`
+     in `dotnet watch` output. VER, STR, SAI persisted with `position=null`, `status=DSQ`.
+  2. **Grand prix** submission accepted; `/score` returns 200. Stroll persisted with
+     `status=DNF` and `finishPosition=null` (correction from the previous CLASSIFIED storage
+     under the old mapper). Piastri and Hülkenberg persisted with `status=DNS` (correction
+     from previous DNF storage; same fantasy points either way).
+- `GET /api/seasons/{id}/race-weekends/1/results/qualifying` returns the three DSQ entries
+  with `position: null, status: 2`.
+- `GET /api/seasons/{id}/race-weekends/1/results/grand-prix` returns Stroll with
+  `finishPosition: null, status: 1 /* DNF */`, and Piastri/Hülkenberg with
+  `status: 3 /* DNS */`.
+- Driver scores for round 1: VER, STR, SAI show 0 qualifying points; Stroll's grand-prix
+  total reflects the −10 DNF penalty rather than position points for P17. Constructor scores
+  compute for all 11 constructors.


### PR DESCRIPTION
## Summary

- Make `DriverQualifyingResult.Position` nullable and add a required `RacingStatus` so DSQ / DNS / DNF qualifying entries are first-class instead of being silently dropped during ingest. Validation enforces `Status == Classified ⇔ Position != null`.
- Replace the FastF1 free-text `Status` mapper in `ingest_results.py` with one that reads the FIA's official `ClassifiedPosition`, used for both qualifying and grand-prix/sprint payloads. Also fixes a latent bug where drivers FIA-classified `R` (e.g. Stroll AUS 2026) were stored as Classified with a finish position.
- Adds an integration test that exercises the full HTTP pipeline for the original failure: submit qualifying with a DSQ entry, score the weekend, assert no 500 and that the constructor row is produced.

Closes #148.

## Test plan

- [x] `npm run api:test` — unit 466/466, integration 15/15
- [x] `npm run api:format:check` — clean
- [x] `python3 -m pytest api/scripts/test_ingest_results.py` — 42/42
- [x] `npm run e2e` — 11/11
- [x] Manual repro: re-ingest 2026 R1 against local stack; confirm VER/STR/SAI persist with `position=null, status=DSQ` and `/score` returns 200; confirm Stroll persists as DNF with null finish, Piastri/Hülkenberg as DNS