### PR TITLE
Tighten leaderboard mobile layout

### DIFF
--- a/web/src/components/Leaderboard/Leaderboard.tsx
+++ b/web/src/components/Leaderboard/Leaderboard.tsx
@@ -8,7 +8,7 @@ import type { ReactNode } from 'react';
 const routeApi = getRouteApi('/_authenticated/_team-required/league/$leagueId');
 
 const rowBase =
-  'grid w-full items-center gap-3 grid-cols-[52px_1fr_96px] sm:grid-cols-[52px_1fr_70px_96px_36px] text-left transition-colors';
+  'grid w-full items-baseline gap-3 grid-cols-[32px_1fr_52px] sm:items-center sm:grid-cols-[52px_1fr_70px_96px_36px] text-left transition-colors';
 const rowChrome =
   'rounded-[0.65rem] border bg-card p-3 sm:rounded-none sm:border-x-0 sm:border-t-0 sm:bg-transparent sm:px-4 sm:py-3';
 const rowHover = 'sm:hover:bg-accent';
@@ -18,9 +18,10 @@ const rowMyTeam =
 
 interface LeaderboardProps {
   actions?: ReactNode;
+  inlineAction?: ReactNode;
 }
 
-export function Leaderboard({ actions }: LeaderboardProps = {}) {
+export function Leaderboard({ actions, inlineAction }: LeaderboardProps = {}) {
   const { league, standings } = routeApi.useLoaderData();
   const { profile } = useRouteContext({ from: '/_authenticated' });
 
@@ -28,7 +29,12 @@ export function Leaderboard({ actions }: LeaderboardProps = {}) {
 
   return (
     <>
-      <LeaderboardHeader league={league} standings={standings} actions={actions} />
+      <LeaderboardHeader
+        league={league}
+        standings={standings}
+        actions={actions}
+        inlineAction={inlineAction}
+      />
       {entries.length === 0 ? (
         <div className="bg-card rounded-lg p-8 text-center">
           <p className="text-muted-foreground text-lg">No teams in this league yet.</p>
@@ -36,7 +42,7 @@ export function Leaderboard({ actions }: LeaderboardProps = {}) {
       ) : (
         <div className="sm:border-border sm:bg-card sm:overflow-hidden sm:rounded-[0.65rem] sm:border">
           <div
-            className="text-muted-foreground grid grid-cols-[52px_1fr_96px] items-center gap-3 px-3 pb-2 text-[11px] font-semibold tracking-wider uppercase sm:hidden"
+            className="text-muted-foreground grid grid-cols-[32px_1fr_52px] items-center gap-3 px-3 pb-2 text-[11px] font-semibold tracking-wider uppercase sm:hidden"
             aria-hidden="true"
           >
             <div className="text-center">Pos</div>

--- a/web/src/components/LeaderboardHeader/LeaderboardHeader.tsx
+++ b/web/src/components/LeaderboardHeader/LeaderboardHeader.tsx
@@ -6,29 +6,38 @@ interface LeaderboardHeaderProps {
   league: League;
   standings: LeagueStandings;
   actions?: ReactNode;
+  inlineAction?: ReactNode;
 }
 
-export function LeaderboardHeader({ league, standings, actions }: LeaderboardHeaderProps) {
+export function LeaderboardHeader({
+  league,
+  standings,
+  actions,
+  inlineAction,
+}: LeaderboardHeaderProps) {
   return (
     <div className="pb-5">
       <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
+        <div className="min-w-0 flex-1">
           {standings.lastScoredRound != null && standings.lastScoredRaceWeekendName != null && (
             <p className="mb-1 text-[12px] font-semibold tracking-[0.14em] text-[color-mix(in_oklab,var(--primary)_70%,var(--muted-foreground))] uppercase">
               Round {standings.lastScoredRound} <span aria-hidden="true">·</span>{' '}
               {standings.lastScoredRaceWeekendName}
             </p>
           )}
-          <h1 className="text-foreground text-[24px] font-bold tracking-tight sm:text-[28px]">
-            {league.name}
-          </h1>
+          <div className="flex items-center gap-3">
+            <h1 className="text-foreground min-w-0 flex-1 text-[24px] font-bold tracking-tight sm:text-[28px]">
+              {league.name}
+            </h1>
+            {inlineAction && <div className="shrink-0 sm:hidden">{inlineAction}</div>}
+          </div>
           {league.description && (
             <p className="text-muted-foreground mt-1 max-w-[52ch] text-[13px] leading-relaxed">
               {league.description}
             </p>
           )}
         </div>
-        {actions && <div className="shrink-0">{actions}</div>}
+        {actions && <div className="hidden shrink-0 sm:block">{actions}</div>}
       </div>
     </div>
   );

--- a/web/src/components/League/League.tsx
+++ b/web/src/components/League/League.tsx
@@ -3,21 +3,14 @@ import { useClipboard } from '@/hooks/useClipboard';
 import { getOrCreateLeagueInvite } from '@/services/leagueInviteService';
 import * as Sentry from '@sentry/react';
 import { getRouteApi, useRouteContext } from '@tanstack/react-router';
-import { Check, Copy, UserPlus } from 'lucide-react';
+import { Check, Copy, Share, UserPlus } from 'lucide-react';
 import { useState } from 'react';
 
 import { AppContainer } from '../AppContainer/AppContainer';
 import { InlineError } from '../InlineError/InlineError';
 import { Leaderboard } from '../Leaderboard/Leaderboard';
 import { Button } from '../ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '../ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '../ui/dialog';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
 
@@ -62,46 +55,54 @@ export function League() {
     }
   };
 
-  const inviteButton = displayInviteButton ? (
-    <Dialog open={isDialogOpen} onOpenChange={handleDialogOpen}>
-      <DialogTrigger asChild>
-        <Button className="shrink-0">
-          <UserPlus className="h-4 w-4" />
-          Invite
-        </Button>
-      </DialogTrigger>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Share League Invite</DialogTitle>
-          <DialogDescription>
-            Anyone who has this link will be able to join your league
-          </DialogDescription>
-        </DialogHeader>
-        {isLoading && <div>Loading invite link...</div>}
-        {error && <InlineError message={error} />}
-        {leagueInvite && (
-          <div className="flex items-center gap-2">
-            <Label htmlFor="link" className="sr-only">
-              League Invite Link
-            </Label>
-            <Input id="link" className="flex-1" value={inviteUrl} readOnly></Input>
-            <Button
-              size="icon"
-              variant="outline"
-              onClick={() => copy(inviteUrl)}
-              aria-label={hasCopied ? 'Copied' : 'Copy invite link'}
-            >
-              {hasCopied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
-            </Button>
-          </div>
-        )}
-      </DialogContent>
-    </Dialog>
+  const handleOpenInvite = () => handleDialogOpen(true);
+
+  const inviteFullButton = displayInviteButton ? (
+    <Button className="shrink-0" onClick={handleOpenInvite}>
+      <UserPlus className="h-4 w-4" />
+      Invite
+    </Button>
+  ) : null;
+
+  const inviteIconButton = displayInviteButton ? (
+    <Button size="icon-sm" aria-label="Invite to league" onClick={handleOpenInvite}>
+      <Share className="h-4 w-4" />
+    </Button>
   ) : null;
 
   return (
     <AppContainer maxWidth="md">
-      <Leaderboard actions={inviteButton} />
+      <Leaderboard actions={inviteFullButton} inlineAction={inviteIconButton} />
+      {displayInviteButton && (
+        <Dialog open={isDialogOpen} onOpenChange={handleDialogOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Share League Invite</DialogTitle>
+              <DialogDescription>
+                Anyone who has this link will be able to join your league
+              </DialogDescription>
+            </DialogHeader>
+            {isLoading && <div>Loading invite link...</div>}
+            {error && <InlineError message={error} />}
+            {leagueInvite && (
+              <div className="flex items-center gap-2">
+                <Label htmlFor="link" className="sr-only">
+                  League Invite Link
+                </Label>
+                <Input id="link" className="flex-1" value={inviteUrl} readOnly></Input>
+                <Button
+                  size="icon"
+                  variant="outline"
+                  onClick={() => copy(inviteUrl)}
+                  aria-label={hasCopied ? 'Copied' : 'Copy invite link'}
+                >
+                  {hasCopied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                </Button>
+              </div>
+            )}
+          </DialogContent>
+        </Dialog>
+      )}
     </AppContainer>
   );
 }

--- a/web/src/tests/integration/leaderboard.integration.test.tsx
+++ b/web/src/tests/integration/leaderboard.integration.test.tsx
@@ -229,7 +229,7 @@ describe('Leaderboard page', () => {
       );
 
       const heading = await screen.findByRole('heading', { name: 'Pit Wall' });
-      const eyebrow = heading.previousElementSibling;
+      const eyebrow = heading.parentElement?.previousElementSibling;
       expect(eyebrow?.textContent?.replace(/\s+/g, ' ').trim()).toMatch(/^round 7 · miami gp$/i);
     });
 
@@ -243,7 +243,7 @@ describe('Leaderboard page', () => {
       );
 
       const heading = await screen.findByRole('heading', { name: 'Pit Wall' });
-      expect(heading.previousElementSibling).toBeNull();
+      expect(heading.parentElement?.previousElementSibling).toBeNull();
     });
   });
 });

--- a/web/src/tests/integration/league-invite-dialog.integration.test.tsx
+++ b/web/src/tests/integration/league-invite-dialog.integration.test.tsx
@@ -161,7 +161,7 @@ describe('Share invite dialog', () => {
 
     expect(inviteFetch).not.toHaveBeenCalled();
 
-    await user.click(await screen.findByRole('button', { name: /invite/i }));
+    await user.click(await screen.findByRole('button', { name: 'Invite' }));
 
     expect(await screen.findByDisplayValue(inviteUrl)).toBeInTheDocument();
     expect(inviteFetch).toHaveBeenCalledTimes(1);
@@ -187,7 +187,7 @@ describe('Share invite dialog', () => {
       routerContext: ownerRouterContext(),
     });
 
-    await user.click(await screen.findByRole('button', { name: /invite/i }));
+    await user.click(await screen.findByRole('button', { name: 'Invite' }));
 
     expect(await screen.findByText('Failed to load invite link')).toBeInTheDocument();
     expect(screen.queryByDisplayValue(inviteUrl)).not.toBeInTheDocument();
@@ -218,7 +218,7 @@ describe('Share invite dialog', () => {
       routerContext: ownerRouterContext(),
     });
 
-    await user.click(await screen.findByRole('button', { name: /invite/i }));
+    await user.click(await screen.findByRole('button', { name: 'Invite' }));
     expect(await screen.findByDisplayValue(inviteUrl)).toBeInTheDocument();
 
     await user.keyboard('{Escape}');
@@ -226,7 +226,7 @@ describe('Share invite dialog', () => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole('button', { name: /invite/i }));
+    await user.click(screen.getByRole('button', { name: 'Invite' }));
 
     expect(screen.getByDisplayValue(inviteUrl)).toBeInTheDocument();
     expect(inviteFetch).toHaveBeenCalledTimes(1);
@@ -257,7 +257,7 @@ describe('Share invite dialog', () => {
       routerContext: ownerRouterContext(),
     });
 
-    await user.click(await screen.findByRole('button', { name: /invite/i }));
+    await user.click(await screen.findByRole('button', { name: 'Invite' }));
     await screen.findByDisplayValue(inviteUrl);
 
     await user.click(screen.getByRole('button', { name: 'Copy invite link' }));
@@ -289,7 +289,7 @@ describe('Share invite dialog', () => {
       routerContext: ownerRouterContext(),
     });
 
-    await user.click(await screen.findByRole('button', { name: /invite/i }));
+    await user.click(await screen.findByRole('button', { name: 'Invite' }));
     await screen.findByDisplayValue(inviteUrl);
 
     await user.keyboard('{Escape}');


### PR DESCRIPTION
## Summary

- Mobile column widths shrunk on the leaderboard rows so team names stop truncating: POS `52→32px`, PTS `96→52px` (~64px reclaimed for the team column)
- Mobile rows now use `items-baseline` so rank/team-name/points share a text baseline instead of vertically centering against the multi-line owner+delta block
- Mobile invite control is now an icon-only Share button anchored to the right edge of the title row; desktop keeps the full top-right Invite button. Both share a single controlled Dialog instance

## Test plan

- [ ] On mobile width, team names like "Mercedes Maniacs" / "Hamilton Heroes" render in full (no ellipsis)
- [ ] On mobile, rank number and team-name first line align on the same baseline
- [ ] On mobile, league owners see a 32px Share icon button at the right edge of the title row; non-owners see no button
- [ ] On desktop, the existing "Invite" button still appears top-right
- [ ] Clicking either trigger opens the same invite dialog with the shareable link