### PR TITLE
Address Supabase security advisor warnings

### DIFF
--- a/api/supabase/migrations/20260508130000_address_security_advisor_warnings.sql
+++ b/api/supabase/migrations/20260508130000_address_security_advisor_warnings.sql
@@ -5,10 +5,20 @@
 ALTER FUNCTION public.enable_rls_on_new_public_tables()
     SET search_path = pg_catalog, public;
 
--- Drop the broad SELECT policy on the public avatars bucket (lint 0025).
--- Public-bucket URL reads do not require this policy; it only enables
--- clients to list every file in the bucket via the storage API.
+-- Avatars: storage.objects SELECT scoped to the owning user (lint 0025).
+-- Supabase Storage uploads use INSERT ... RETURNING *, which Postgres
+-- enforces against SELECT policies. Public CDN reads via
+-- /storage/v1/object/public/... bypass RLS for public buckets.
 DROP POLICY IF EXISTS "Avatar images are publicly accessible" ON storage.objects;
+
+DROP POLICY IF EXISTS "Users can read their own avatar" ON storage.objects;
+CREATE POLICY "Users can read their own avatar"
+ON storage.objects FOR SELECT
+TO authenticated
+USING (
+    bucket_id = 'avatars'
+    AND auth.uid()::text = (storage.foldername(name))[1]
+);
 
 -- Remove RPC surface for the auth.users trigger function (lints 0028, 0029).
 -- The trigger fires automatically on INSERT INTO auth.users; no role needs

--- a/api/supabase/migrations/20260508130000_address_security_advisor_warnings.sql
+++ b/api/supabase/migrations/20260508130000_address_security_advisor_warnings.sql
@@ -1,0 +1,16 @@
+-- Address Supabase database linter security warnings reported by
+-- mcp__supabase__get_advisors / dashboard advisor.
+
+-- Pin search_path on the RLS event-trigger function (lint 0011).
+ALTER FUNCTION public.enable_rls_on_new_public_tables()
+    SET search_path = pg_catalog, public;
+
+-- Drop the broad SELECT policy on the public avatars bucket (lint 0025).
+-- Public-bucket URL reads do not require this policy; it only enables
+-- clients to list every file in the bucket via the storage API.
+DROP POLICY IF EXISTS "Avatar images are publicly accessible" ON storage.objects;
+
+-- Remove RPC surface for the auth.users trigger function (lints 0028, 0029).
+-- The trigger fires automatically on INSERT INTO auth.users; no role needs
+-- EXECUTE via PostgREST.
+REVOKE EXECUTE ON FUNCTION public.handle_new_user() FROM PUBLIC, anon, authenticated;


### PR DESCRIPTION
## Summary

Resolves four WARN-level findings from the Supabase database linter (the fifth, leaked-password protection, is an Auth dashboard toggle and is out of scope for SQL).

| Lint | Target | Fix |
| --- | --- | --- |
| 0011 `function_search_path_mutable` | `public.enable_rls_on_new_public_tables()` | `SET search_path = pg_catalog, public` |
| 0025 `public_bucket_allows_listing` | `storage.objects` policy on `avatars` bucket | Drop `"Avatar images are publicly accessible"` — public-bucket URL reads work without it; the policy only enabled clients to list every file |
| 0028, 0029 `*_security_definer_function_executable` | `public.handle_new_user()` | `REVOKE EXECUTE FROM PUBLIC, anon, authenticated` — the function fires from the `auth.users` insert trigger; no role needs PostgREST RPC access |

All three changes land in a single migration since they share one motivation (linter cleanup).

## Test plan

- [ ] `cd api/supabase && supabase db reset` (or e2e equivalent) applies cleanly with no errors
- [ ] After `supabase db push` to the cloud project, re-run the security advisor and confirm the four lints are gone
- [ ] Sign-up flow still creates `Accounts` + `UserProfiles` rows (handle_new_user trigger still fires)
- [ ] Avatar upload + display still works in the web app (URL reads from public bucket unaffected)
- [ ] `npm run e2e` still green