### PR TITLE
Endpoint authorization audit (#159)

### DIFF
--- a/api/F1CompanionApi.IntegrationTests/Scenarios/TeamTests.cs
+++ b/api/F1CompanionApi.IntegrationTests/Scenarios/TeamTests.cs
@@ -31,16 +31,4 @@ public class TeamTests : IntegrationTestBase
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
-
-    [Fact]
-    public async Task GetAllTeams_NoLongerSupported_Returns405()
-    {
-        var (client, _) = await Factory.CreateAuthenticatedAsync();
-
-        var response = await client.GetAsync("/api/teams");
-
-        // POST /teams still exists at this path, so the routing layer rejects
-        // the unsupported GET verb with 405 rather than 404.
-        Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
-    }
 }

--- a/api/F1CompanionApi.IntegrationTests/Scenarios/TeamTests.cs
+++ b/api/F1CompanionApi.IntegrationTests/Scenarios/TeamTests.cs
@@ -1,0 +1,46 @@
+using System.Net;
+using F1CompanionApi.IntegrationTests.Support;
+
+namespace F1CompanionApi.IntegrationTests.Scenarios;
+
+public class TeamTests : IntegrationTestBase
+{
+    public TeamTests(PostgresFixture postgres)
+        : base(postgres) { }
+
+    [Fact]
+    public async Task GetTeamById_Unauthenticated_Returns401()
+    {
+        var anonClient = Factory.CreateClient();
+
+        var response = await anonClient.GetAsync("/api/teams/1");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetTeamById_Authenticated_ReturnsTeam()
+    {
+        var (client, profile) = await Factory.CreateAuthenticatedAsync();
+
+        var team = await WithDbAsync(async db =>
+            await db.CreateTeamAsync(profile.Id, name: "My Team")
+        );
+
+        var response = await client.GetAsync($"/api/teams/{team.Id}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAllTeams_NoLongerSupported_Returns405()
+    {
+        var (client, _) = await Factory.CreateAuthenticatedAsync();
+
+        var response = await client.GetAsync("/api/teams");
+
+        // POST /teams still exists at this path, so the routing layer rejects
+        // the unsupported GET verb with 405 rather than 404.
+        Assert.Equal(HttpStatusCode.MethodNotAllowed, response.StatusCode);
+    }
+}

--- a/api/F1CompanionApi.UnitTests/Api/Endpoints/LeagueEndpointsTests.cs
+++ b/api/F1CompanionApi.UnitTests/Api/Endpoints/LeagueEndpointsTests.cs
@@ -179,51 +179,6 @@ public class LeagueEndpointsTests
     }
 
     [Fact]
-    public async Task GetLeagueByIdAsync_LeagueExists_ReturnsOkWithLeague()
-    {
-        // Arrange
-        var league = new LeagueDetailsResponse
-        {
-            Id = 1,
-            Name = "Test League",
-            Description = "Test Description",
-            OwnerName = "John Doe",
-            MaxTeams = 15,
-            IsPrivate = true,
-        };
-
-        _mockLeagueService.Setup(x => x.GetLeagueByIdAsync(1)).ReturnsAsync(league);
-
-        // Act
-        var result = await InvokeGetLeagueByIdAsync(1);
-
-        // Assert
-        Assert.IsType<Ok<LeagueDetailsResponse>>(result);
-        var okResult = (Ok<LeagueDetailsResponse>)result;
-        Assert.NotNull(okResult.Value);
-        Assert.Equal(1, okResult.Value.Id);
-        Assert.Equal("Test League", okResult.Value.Name);
-        Assert.Equal("John Doe", okResult.Value.OwnerName);
-    }
-
-    [Fact]
-    public async Task GetLeagueByIdAsync_LeagueDoesNotExist_ReturnsNotFound()
-    {
-        // Arrange
-        _mockLeagueService
-            .Setup(x => x.GetLeagueByIdAsync(999))
-            .ReturnsAsync((LeagueDetailsResponse?)null);
-
-        // Act
-        var result = await InvokeGetLeagueByIdAsync(999);
-
-        // Assert
-        Assert.IsType<ProblemHttpResult>(result);
-        var problemResult = (ProblemHttpResult)result;
-        Assert.Equal(StatusCodes.Status404NotFound, problemResult.StatusCode);
-    }
-
-    [Fact]
     public async Task GetPublicLeaguesAsync_WithoutSearchTerm_ReturnsOkWithAvailableLeagues()
     {
         // Arrange
@@ -974,23 +929,6 @@ public class LeagueEndpointsTests
                 method!.Invoke(
                     null,
                     new object[] { _mockLeagueService.Object, _mockLogger.Object }
-                )!;
-
-        return await task;
-    }
-
-    private async Task<IResult> InvokeGetLeagueByIdAsync(int id)
-    {
-        var method = typeof(LeagueEndpoints).GetMethod(
-            "GetLeagueByIdAsync",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static
-        );
-
-        var task =
-            (Task<IResult>)
-                method!.Invoke(
-                    null,
-                    new object[] { _mockLeagueService.Object, id, _mockLogger.Object }
                 )!;
 
         return await task;

--- a/api/F1CompanionApi.UnitTests/Api/Endpoints/LeagueEndpointsTests.cs
+++ b/api/F1CompanionApi.UnitTests/Api/Endpoints/LeagueEndpointsTests.cs
@@ -103,82 +103,6 @@ public class LeagueEndpointsTests
     }
 
     [Fact]
-    public async Task GetLeaguesAsync_LeaguesExist_ReturnsOkWithLeagues()
-    {
-        // Arrange
-        var leagues = new List<LeagueResponse>
-        {
-            new LeagueResponse
-            {
-                Id = 1,
-                Name = "League 1",
-                Description = "Description 1",
-                OwnerName = "John Doe",
-                MaxTeams = 15,
-                IsPrivate = true,
-            },
-            new LeagueResponse
-            {
-                Id = 2,
-                Name = "League 2",
-                OwnerName = "John Doe",
-                MaxTeams = 20,
-                IsPrivate = false,
-            },
-        };
-
-        _mockLeagueService.Setup(x => x.GetLeaguesAsync()).ReturnsAsync(leagues);
-
-        // Act
-        var result = await InvokeGetLeaguesAsync();
-
-        // Assert
-        Assert.IsType<Ok<IEnumerable<LeagueResponse>>>(result);
-        var okResult = (Ok<IEnumerable<LeagueResponse>>)result;
-        Assert.NotNull(okResult.Value);
-        var leagueList = okResult.Value.ToList();
-        Assert.Equal(2, leagueList.Count);
-        Assert.Equal("League 1", leagueList[0].Name);
-        Assert.Equal("League 2", leagueList[1].Name);
-    }
-
-    [Fact]
-    public async Task GetLeaguesAsync_NoLeagues_ReturnsOkWithEmptyCollection()
-    {
-        // Arrange
-        _mockLeagueService
-            .Setup(x => x.GetLeaguesAsync())
-            .ReturnsAsync(new List<LeagueResponse>());
-
-        // Act
-        var result = await InvokeGetLeaguesAsync();
-
-        // Assert
-        Assert.IsType<Ok<IEnumerable<LeagueResponse>>>(result);
-        var okResult = (Ok<IEnumerable<LeagueResponse>>)result;
-        Assert.NotNull(okResult.Value);
-        Assert.Empty(okResult.Value);
-    }
-
-    [Fact]
-    public async Task GetLeaguesAsync_ServiceReturnsEmptyCollection_ReturnsOkWithEmptyCollection()
-    {
-        // Arrange
-        _mockLeagueService
-            .Setup(x => x.GetLeaguesAsync())
-            .ReturnsAsync(Array.Empty<LeagueResponse>());
-
-        // Act
-        var result = await InvokeGetLeaguesAsync();
-
-        // Assert
-        Assert.IsType<Ok<IEnumerable<LeagueResponse>>>(result);
-        var okResult = (Ok<IEnumerable<LeagueResponse>>)result;
-        Assert.NotNull(okResult.Value);
-        Assert.Empty(okResult.Value);
-    }
-
-    [Fact]
     public async Task GetPublicLeaguesAsync_WithoutSearchTerm_ReturnsOkWithAvailableLeagues()
     {
         // Arrange
@@ -912,23 +836,6 @@ public class LeagueEndpointsTests
                         request,
                         _mockLogger.Object,
                     }
-                )!;
-
-        return await task;
-    }
-
-    private async Task<IResult> InvokeGetLeaguesAsync()
-    {
-        var method = typeof(LeagueEndpoints).GetMethod(
-            "GetLeaguesAsync",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static
-        );
-
-        var task =
-            (Task<IResult>)
-                method!.Invoke(
-                    null,
-                    new object[] { _mockLeagueService.Object, _mockLogger.Object }
                 )!;
 
         return await task;

--- a/api/F1CompanionApi.UnitTests/Api/Endpoints/TeamEndpointsTests.cs
+++ b/api/F1CompanionApi.UnitTests/Api/Endpoints/TeamEndpointsTests.cs
@@ -34,76 +34,6 @@ public class TeamEndpointsTests
     }
 
     [Fact]
-    public async Task GetTeamsAsync_MultipleTeams_ReturnsAllTeams()
-    {
-        // Arrange
-        using var context = CreateInMemoryContext();
-        var owners = new List<UserProfile>
-        {
-            new UserProfile
-            {
-                AccountId = Guid.NewGuid().ToString(),
-                Email = "owner1@test.com",
-                FirstName = "Owner",
-                LastName = "One",
-            },
-            new UserProfile
-            {
-                AccountId = Guid.NewGuid().ToString(),
-                Email = "owner2@test.com",
-                FirstName = "Owner",
-                LastName = "Two",
-            },
-            new UserProfile
-            {
-                AccountId = Guid.NewGuid().ToString(),
-                Email = "owner3@test.com",
-                FirstName = "Owner",
-                LastName = "Three",
-            },
-        };
-
-        context.UserProfiles.AddRange(owners);
-        await context.SaveChangesAsync();
-
-        var teams = new List<Team>
-        {
-            new Team
-            {
-                Name = "Team Alpha",
-                UserId = owners[0].Id,
-                CreatedBy = owners[0].Id,
-            },
-            new Team
-            {
-                Name = "Team Beta",
-                UserId = owners[1].Id,
-                CreatedBy = owners[1].Id,
-            },
-            new Team
-            {
-                Name = "Team Gamma",
-                UserId = owners[2].Id,
-                CreatedBy = owners[2].Id,
-            },
-        };
-
-        context.Teams.AddRange(teams);
-        await context.SaveChangesAsync();
-
-        // Act
-        var result = await InvokeGetTeamsAsync(context);
-
-        // Assert
-        Assert.NotNull(result);
-        var teamList = result.ToList();
-        Assert.Equal(3, teamList.Count);
-        Assert.Contains(teamList, t => t.Name == "Team Alpha");
-        Assert.Contains(teamList, t => t.Name == "Team Beta");
-        Assert.Contains(teamList, t => t.Name == "Team Gamma");
-    }
-
-    [Fact]
     public async Task GetTeamByIdAsync_ExistingTeam_ReturnsTeam()
     {
         // Arrange
@@ -256,20 +186,6 @@ public class TeamEndpointsTests
         Assert.Equal("User not found", badRequestResult.Value);
     }
 
-    [Fact]
-    public async Task GetTeams_EmptyDatabase_ReturnsEmptyList()
-    {
-        // Arrange
-        using var context = CreateInMemoryContext();
-
-        // Act
-        var result = await InvokeGetTeamsAsync(context);
-
-        // Assert
-        Assert.NotNull(result);
-        Assert.Empty(result);
-    }
-
     [Theory]
     [InlineData(0)]
     [InlineData(-1)]
@@ -366,20 +282,6 @@ public class TeamEndpointsTests
     }
 
     // Helper methods to invoke private endpoint methods via reflection
-    private async Task<IEnumerable<TeamResponse>> InvokeGetTeamsAsync(ApplicationDbContext db)
-    {
-        var method = typeof(TeamEndpoints).GetMethod(
-            "GetTeamsAsync",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static
-        );
-
-        var task = (Task<IResult>)method!.Invoke(null, new object[] { db, _mockLogger.Object })!;
-
-        var result = await task;
-        var okResult = (Ok<IEnumerable<TeamResponse>>)result;
-        return okResult.Value!;
-    }
-
     private async Task<IResult> InvokeGetTeamByIdAsync(int id, ApplicationDbContext db)
     {
         var method = typeof(TeamEndpoints).GetMethod(

--- a/api/F1CompanionApi.UnitTests/Services/LeagueServiceTests.cs
+++ b/api/F1CompanionApi.UnitTests/Services/LeagueServiceTests.cs
@@ -191,63 +191,6 @@ public class LeagueServiceTests
     }
 
     [Fact]
-    public async Task GetLeaguesAsync_NoLeagues_ReturnsEmptyCollection()
-    {
-        // Arrange
-        using var context = CreateInMemoryContext();
-        var service = new LeagueService(context, _mockLogger.Object);
-
-        // Act
-        var result = await service.GetLeaguesAsync();
-
-        // Assert
-        Assert.NotNull(result);
-        Assert.Empty(result);
-    }
-
-    [Fact]
-    public async Task GetLeaguesAsync_MultipleLeagues_ReturnsAllLeagues()
-    {
-        // Arrange
-        using var context = CreateInMemoryContext();
-        var service = new LeagueService(context, _mockLogger.Object);
-
-        var owner = new UserProfile
-        {
-            AccountId = "test-account",
-            Email = "owner@test.com",
-            FirstName = "Test",
-            LastName = "Owner",
-        };
-        context.UserProfiles.Add(owner);
-
-        var league1 = new League
-        {
-            Name = "League 1",
-            OwnerId = owner.Id,
-            CreatedBy = owner.Id,
-            CreatedAt = DateTime.UtcNow,
-        };
-        var league2 = new League
-        {
-            Name = "League 2",
-            OwnerId = owner.Id,
-            CreatedBy = owner.Id,
-            CreatedAt = DateTime.UtcNow,
-        };
-
-        context.Leagues.AddRange(league1, league2);
-        await context.SaveChangesAsync();
-
-        // Act
-        var result = await service.GetLeaguesAsync();
-
-        // Assert
-        Assert.NotNull(result);
-        Assert.Equal(2, result.Count());
-    }
-
-    [Fact]
     public async Task GetLeagueByIdAsync_ExistingLeague_ReturnsLeague()
     {
         // Arrange

--- a/api/F1CompanionApi.UnitTests/Services/LeagueServiceTests.cs
+++ b/api/F1CompanionApi.UnitTests/Services/LeagueServiceTests.cs
@@ -1395,4 +1395,123 @@ public class LeagueServiceTests
     }
 
     #endregion
+
+    #region GuardLeagueAccessAsync Tests
+
+    [Theory]
+    [InlineData(false, false)] // public league, non-member
+    [InlineData(false, true)] // public league, member
+    [InlineData(true, true)] // private league, member
+    public async Task GuardLeagueAccessAsync_AccessAllowed_DoesNotThrow(
+        bool isPrivate,
+        bool isMember
+    )
+    {
+        using var context = CreateInMemoryContext();
+        var service = new LeagueService(context, _mockLogger.Object);
+        var (leagueId, userId) = await SeedLeagueWithMembershipAsync(
+            context,
+            isPrivate,
+            seedMembership: isMember
+        );
+
+        await service.GuardLeagueAccessAsync(leagueId, userId);
+    }
+
+    [Fact]
+    public async Task GuardLeagueAccessAsync_PrivateLeague_NonMember_ThrowsNotLeagueMember()
+    {
+        using var context = CreateInMemoryContext();
+        var service = new LeagueService(context, _mockLogger.Object);
+        var (leagueId, userId) = await SeedLeagueWithMembershipAsync(
+            context,
+            isPrivate: true,
+            seedMembership: false
+        );
+
+        var exception = await Assert.ThrowsAsync<NotLeagueMemberException>(() =>
+            service.GuardLeagueAccessAsync(leagueId, userId)
+        );
+        Assert.Equal(leagueId, exception.LeagueId);
+        Assert.Equal(userId, exception.UserId);
+    }
+
+    [Fact]
+    public async Task GuardLeagueAccessAsync_NonExistentLeague_ThrowsLeagueNotFound()
+    {
+        using var context = CreateInMemoryContext();
+        var service = new LeagueService(context, _mockLogger.Object);
+
+        var exception = await Assert.ThrowsAsync<LeagueNotFoundException>(() =>
+            service.GuardLeagueAccessAsync(leagueId: 999, userId: 1)
+        );
+        Assert.Equal(999, exception.LeagueId);
+    }
+
+    private static async Task<(int LeagueId, int UserId)> SeedLeagueWithMembershipAsync(
+        ApplicationDbContext context,
+        bool isPrivate,
+        bool seedMembership
+    )
+    {
+        var owner = new UserProfile
+        {
+            AccountId = "owner-account",
+            Email = "owner@test.com",
+            FirstName = "Owner",
+            LastName = "User",
+        };
+        context.UserProfiles.Add(owner);
+
+        var requester = seedMembership
+            ? owner
+            : new UserProfile
+            {
+                AccountId = "requester-account",
+                Email = "requester@test.com",
+                FirstName = "Requester",
+                LastName = "User",
+            };
+        if (!seedMembership)
+        {
+            context.UserProfiles.Add(requester);
+        }
+
+        var league = new League
+        {
+            Name = "Test League",
+            IsPrivate = isPrivate,
+            OwnerId = owner.Id,
+            CreatedBy = owner.Id,
+            CreatedAt = DateTime.UtcNow,
+        };
+        context.Leagues.Add(league);
+        await context.SaveChangesAsync();
+
+        var ownerTeam = new Team
+        {
+            Name = "Owner Team",
+            UserId = owner.Id,
+            CreatedBy = owner.Id,
+            CreatedAt = DateTime.UtcNow,
+        };
+        context.Teams.Add(ownerTeam);
+        await context.SaveChangesAsync();
+
+        context.LeagueTeams.Add(
+            new LeagueTeam
+            {
+                LeagueId = league.Id,
+                TeamId = ownerTeam.Id,
+                JoinedAt = DateTime.UtcNow,
+                CreatedBy = owner.Id,
+                CreatedAt = DateTime.UtcNow,
+            }
+        );
+        await context.SaveChangesAsync();
+
+        return (league.Id, requester.Id);
+    }
+
+    #endregion
 }

--- a/api/F1CompanionApi/Api/Endpoints/LeagueEndpoints.cs
+++ b/api/F1CompanionApi/Api/Endpoints/LeagueEndpoints.cs
@@ -119,43 +119,32 @@ public static class LeagueEndpoints
 
     private static async Task<IResult> GetLeagueByIdAsync(
         ILeagueService leagueService,
+        IUserProfileService userProfileService,
         int id,
         [FromServices] ILogger logger
     )
     {
         logger.LogDebug("Fetching league {LeagueId}", id);
+        var user = await userProfileService.GetRequiredCurrentUserProfileAsync();
+        await leagueService.GuardLeagueAccessAsync(id, user.Id);
+
         var league = await leagueService.GetLeagueByIdAsync(id);
-
-        if (league is null)
-        {
-            logger.LogWarning("League {LeagueId} not found", id);
-            return Results.Problem(
-                detail: "League not found",
-                statusCode: StatusCodes.Status404NotFound
-            );
-        }
-
         return Results.Ok(league);
     }
 
     private static async Task<IResult> GetLeagueStandingsAsync(
+        ILeagueService leagueService,
         ILeagueStandingsService leagueStandingsService,
+        IUserProfileService userProfileService,
         int id,
         [FromServices] ILogger logger
     )
     {
         logger.LogDebug("Fetching standings for league {LeagueId}", id);
+        var user = await userProfileService.GetRequiredCurrentUserProfileAsync();
+        await leagueService.GuardLeagueAccessAsync(id, user.Id);
+
         var standings = await leagueStandingsService.GetLeagueStandingsAsync(id);
-
-        if (standings is null)
-        {
-            logger.LogWarning("League {LeagueId} not found", id);
-            return Results.Problem(
-                detail: "League not found",
-                statusCode: StatusCodes.Status404NotFound
-            );
-        }
-
         return Results.Ok(standings);
     }
 

--- a/api/F1CompanionApi/Api/Endpoints/LeagueEndpoints.cs
+++ b/api/F1CompanionApi/Api/Endpoints/LeagueEndpoints.cs
@@ -19,12 +19,6 @@ public static class LeagueEndpoints
             .WithDescription("Create a new league");
 
         leaguesGroup
-            .MapGet("/", GetLeaguesAsync)
-            .RequireAuthorization()
-            .WithName("GetLeagues")
-            .WithDescription("Get all leagues");
-
-        leaguesGroup
             .MapGet("/available", GetAvailableLeaguesAsync)
             .RequireAuthorization()
             .WithName("GetAvailableLeagues")
@@ -89,17 +83,6 @@ public static class LeagueEndpoints
         );
 
         return Results.Created($"/leagues/{leagueResponse.Id}", leagueResponse);
-    }
-
-    private static async Task<IResult> GetLeaguesAsync(
-        ILeagueService leagueService,
-        [FromServices] ILogger logger
-    )
-    {
-        logger.LogDebug("Fetching all leagues");
-        var leagues = await leagueService.GetLeaguesAsync();
-
-        return Results.Ok(leagues);
     }
 
     private static async Task<IResult> GetAvailableLeaguesAsync(

--- a/api/F1CompanionApi/Api/Endpoints/TeamEndpoints.cs
+++ b/api/F1CompanionApi/Api/Endpoints/TeamEndpoints.cs
@@ -18,9 +18,8 @@ public static class TeamEndpoints
             .WithName("CreateTeam")
             .WithDescription("Create a new team for the current user");
 
-        app.MapGet("/teams", GetTeamsAsync).WithName("GetTeams").WithDescription("Gets all teams");
-
         app.MapGet("/teams/{id}", GetTeamByIdAsync)
+            .RequireAuthorization()
             .WithName("GetTeamById")
             .WithDescription("Get Team By Id");
 
@@ -49,17 +48,6 @@ public static class TeamEndpoints
             logger.LogWarning(ex, "Failed to create team for user {UserId}", user.Id);
             return Results.BadRequest(ex.Message);
         }
-    }
-
-    private static async Task<IResult> GetTeamsAsync(
-        ApplicationDbContext db,
-        [FromServices] ILogger logger
-    )
-    {
-        logger.LogDebug("Fetching all teams");
-        var teams = await db.Teams.Include(t => t.Owner).ToListAsync() ?? [];
-        logger.LogDebug("Retrieved {TeamCount} teams", teams.Count);
-        return Results.Ok(teams.Select(t => t.ToResponseModel()));
     }
 
     private static async Task<IResult> GetTeamByIdAsync(

--- a/api/F1CompanionApi/Domain/Exceptions/GlobalExceptionHandler.cs
+++ b/api/F1CompanionApi/Domain/Exceptions/GlobalExceptionHandler.cs
@@ -62,6 +62,12 @@ public class GlobalExceptionHandler : IExceptionHandler
                 ex.Message
             ),
 
+            NotLeagueMemberException _ => (
+                StatusCodes.Status403Forbidden,
+                "Not a League Member",
+                "You are not a member of this league."
+            ),
+
             UnauthorizedAccessException ex => (
                 StatusCodes.Status403Forbidden,
                 "Forbidden",

--- a/api/F1CompanionApi/Domain/Exceptions/NotLeagueMemberException.cs
+++ b/api/F1CompanionApi/Domain/Exceptions/NotLeagueMemberException.cs
@@ -1,0 +1,21 @@
+namespace F1CompanionApi.Domain.Exceptions;
+
+/// <summary>
+/// Exception thrown when a user attempts to read a private league's details or
+/// standings without being a member of that league. This is considered exceptional
+/// because the UI surfaces private leagues only to their members, so any request
+/// reaching the API for a private league the caller does not belong to indicates
+/// a client-side bug or URL manipulation.
+/// </summary>
+public class NotLeagueMemberException : Exception
+{
+    public int LeagueId { get; init; }
+    public int UserId { get; init; }
+
+    public NotLeagueMemberException(int leagueId, int userId)
+        : base($"User {userId} is not a member of league {leagueId}")
+    {
+        LeagueId = leagueId;
+        UserId = userId;
+    }
+}

--- a/api/F1CompanionApi/Domain/Services/LeagueService.cs
+++ b/api/F1CompanionApi/Domain/Services/LeagueService.cs
@@ -10,7 +10,6 @@ namespace F1CompanionApi.Domain.Services;
 public interface ILeagueService
 {
     Task<LeagueResponse> CreateLeagueAsync(CreateLeagueRequest createLeagueRequest, int ownerId);
-    Task<IEnumerable<LeagueResponse>> GetLeaguesAsync();
     Task<IEnumerable<LeagueResponse>> GetAvailableLeaguesAsync(
         int userId,
         string? searchTerm = null
@@ -99,17 +98,6 @@ public class LeagueService : ILeagueService
         await _dbContext.SaveChangesAsync();
 
         return newLeague.ToResponseModel();
-    }
-
-    public async Task<IEnumerable<LeagueResponse>> GetLeaguesAsync()
-    {
-        _logger.LogDebug("Fetching all leagues");
-
-        var leagues = await _dbContext.Leagues.Include(x => x.Owner).ToListAsync();
-
-        _logger.LogDebug("Retrieved {LeagueCount} leagues", leagues.Count);
-
-        return leagues.Select(league => league.ToResponseModel());
     }
 
     public async Task<IEnumerable<LeagueResponse>> GetAvailableLeaguesAsync(

--- a/api/F1CompanionApi/Domain/Services/LeagueService.cs
+++ b/api/F1CompanionApi/Domain/Services/LeagueService.cs
@@ -19,6 +19,7 @@ public interface ILeagueService
     Task<IEnumerable<LeagueResponse>> GetLeaguesByOwnerIdAsync(int ownerId);
     Task<IEnumerable<LeagueResponse>> GetLeaguesForUserAsync(int userId);
     Task<LeagueResponse> JoinLeagueAsync(int leagueId, int userId);
+    Task GuardLeagueAccessAsync(int leagueId, int userId);
 }
 
 public class LeagueService : ILeagueService
@@ -302,5 +303,27 @@ public class LeagueService : ILeagueService
         );
 
         return league.ToResponseModel();
+    }
+
+    public async Task GuardLeagueAccessAsync(int leagueId, int userId)
+    {
+        var access = await _dbContext
+            .Leagues.Where(l => l.Id == leagueId)
+            .Select(l => new
+            {
+                l.IsPrivate,
+                IsMember = l.LeagueTeams.Any(lt => lt.Team.UserId == userId),
+            })
+            .FirstOrDefaultAsync();
+
+        if (access is null)
+        {
+            throw new LeagueNotFoundException(leagueId);
+        }
+
+        if (access.IsPrivate && !access.IsMember)
+        {
+            throw new NotLeagueMemberException(leagueId, userId);
+        }
     }
 }

--- a/api/F1CompanionApi/Domain/Services/LeagueStandingsService.cs
+++ b/api/F1CompanionApi/Domain/Services/LeagueStandingsService.cs
@@ -125,8 +125,7 @@ public class LeagueStandingsService : ILeagueStandingsService
     }
 
     /// <summary>
-    /// The current leaderboard for a league: each team's position, points earned this
-    /// season, and how that position has shifted since the previous race.
+    /// The current leaderboard for a league.
     /// </summary>
     /// <param name="leagueId">The league whose leaderboard is wanted.</param>
     public async Task<LeagueStandingsResponse?> GetLeagueStandingsAsync(int leagueId)

--- a/docs/plans/159-endpoint-authorization-audit.md
+++ b/docs/plans/159-endpoint-authorization-audit.md
@@ -1,0 +1,139 @@
+# Endpoint Authorization Audit (gh #159)
+
+## Context
+
+A sweep of every API endpoint to confirm that each verifies the caller's right to access or modify the resource. Today, four endpoints leak data across users:
+
+- `GET /api/teams` — no authentication at all; returns every team in the database.
+- `GET /api/teams/{id}` — no authentication at all; returns any team's roster.
+- `GET /api/leagues/{id}` — authenticated, but no membership check; any signed-in user can read **private** leagues.
+- `GET /api/leagues/{id}/standings` — same shape: no membership check on private leagues.
+- `GET /api/leagues` — authenticated, but returns all leagues including private ones (in scope as part of the sweep).
+
+A broader scan of the other endpoint files (`MeEndpoints`, `LineupEndpoints`, `RaceWeekendResultEndpoints`, `RaceWeekendScoringEndpoints`, `SeasonEndpoints`, `RaceWeekendEndpoints`, `DriverEndpoints`, `ConstructorEndpoints`, `LeagueEndpoints` non-listed routes) found no further gaps: every other route is either correctly authenticated and resource-scoped (`/me/*` derives the user from the JWT; `POST /leagues/{id}/invite` already enforces ownership inside `LeagueInviteService`) or is intentionally public reference data.
+
+Decisions made up-front (one approach each, no alternatives below):
+
+1. `GET /teams` → **delete** the endpoint (no production caller; `getTeams()` in `web/src/services/teamService.ts` is unused).
+2. `GET /teams/{id}` → require authentication only; any authenticated user may view a team. Matches the existing `/team/$teamId` UX where the link arrives from a league standings page the user is already viewing.
+3. `GET /leagues/{id}` and `GET /leagues/{id}/standings` → public leagues remain visible to any authenticated user; private leagues require league membership (403 otherwise).
+4. `GET /leagues` → **delete**. `/me/leagues` and `/leagues/available` already serve the two legitimate views.
+
+## Critical files
+
+Backend
+- `api/F1CompanionApi/Api/Endpoints/LeagueEndpoints.cs` — endpoint definitions and handlers for `/leagues/*`.
+- `api/F1CompanionApi/Api/Endpoints/TeamEndpoints.cs` — endpoint definitions and handlers for `/teams/*`.
+- `api/F1CompanionApi/Domain/Services/LeagueService.cs` — add `IsUserLeagueMemberAsync` helper alongside the existing `GetLeaguesForUserAsync` (which already does the same `LeagueTeams.Any(lt => lt.Team.UserId == userId)` filter at line 192).
+
+Frontend
+- `web/src/services/teamService.ts` — remove unused `getTeams()` (line 33–35).
+- `web/src/services/teamService.test.ts` — remove `describe('getTeams', ...)` block.
+
+Tests
+- `api/F1CompanionApi.IntegrationTests/Scenarios/AuthorizationTests.cs` — extend with the new resource-scoped cases (the existing single test only covers anonymous-401 on `/me/profile`).
+- Reuse helpers: `Factory.CreateAuthenticatedAsync()` / `WithDbAsync()` / `db.CreateTeamAsync()` (see `LeagueInviteTests.cs` for the established pattern for setting up two users + a league).
+
+## Implementation — three commits, each self-contained
+
+### Commit 1: Enforce league membership on `GET /leagues/{id}` and `GET /leagues/{id}/standings`
+
+Why first: highest blast radius (private-league leak) and introduces the shared membership helper used elsewhere if needed.
+
+Backend
+- Add to `ILeagueService` and `LeagueService`:
+  ```csharp
+  Task<bool> IsUserLeagueMemberAsync(int leagueId, int userId);
+  ```
+  Implementation: `_dbContext.LeagueTeams.AnyAsync(lt => lt.LeagueId == leagueId && lt.Team.UserId == userId)`.
+- Modify `GetLeagueByIdAsync` handler (`LeagueEndpoints.cs:120`):
+  - Inject `IUserProfileService`.
+  - After the existing 404 check, if `league.IsPrivate && !await leagueService.IsUserLeagueMemberAsync(id, user.Id)` → `Results.Problem(detail: "You are not a member of this league", statusCode: StatusCodes.Status403Forbidden)`. Log a warning at the same call site, mirroring the existing log style.
+- Modify `GetLeagueStandingsAsync` handler (`LeagueEndpoints.cs:141`):
+  - Same change. Note: standings response does not currently include `IsPrivate`, so resolve it via `ILeagueService` or extend the standings response to carry it. Recommended path: load the `League` once via `ILeagueService` (or a small `IsPrivateAsync` lookup) before the standings call, since `GetLeagueStandingsAsync` already does a separate league fetch internally — the duplication is minor.
+
+Tests (`AuthorizationTests.cs`)
+- `PublicLeague_NonMemberCanViewDetailsAndStandings_ReturnsOk`
+- `PrivateLeague_MemberCanViewDetailsAndStandings_ReturnsOk`
+- `PrivateLeague_NonMemberCannotViewDetails_Returns403`
+- `PrivateLeague_NonMemberCannotViewStandings_Returns403`
+- `League_DoesNotExist_Returns404` (preserve existing behavior — 404 must win over 403 to avoid leaking existence)
+
+Quality gates: `npm run api:test:integration && npm run api:format:check`.
+
+### Commit 2: Require auth on `GET /teams/{id}`; delete `GET /teams`
+
+Backend (`TeamEndpoints.cs`)
+- Delete the `GetTeamsAsync` handler and its `app.MapGet("/teams", GetTeamsAsync)...` registration (lines 21, 54–63).
+- Add `.RequireAuthorization()` to the `GetTeamById` registration (line 23).
+
+Frontend
+- `web/src/services/teamService.ts`: delete `getTeams()` (lines 33–35).
+- `web/src/services/teamService.test.ts`: delete the `describe('getTeams', ...)` block.
+
+Tests — additions
+- Backend integration (`AuthorizationTests.cs`):
+  - `GetTeamById_Unauthenticated_Returns401`
+  - `GetTeamById_Authenticated_ReturnsOk`
+  - `GetTeams_Endpoint_Removed_Returns404`
+
+Tests — removals (these reference the deleted handler and would fail to compile)
+- `api/F1CompanionApi.UnitTests/Api/Endpoints/TeamEndpointsTests.cs`:
+  - Delete test `GetTeamsAsync_MultipleTeams_ReturnsAllTeams` (around line 37).
+  - Delete test `GetTeams_EmptyDatabase_ReturnsEmptyList` (around line 260).
+  - Delete the `InvokeGetTeamsAsync` private helper (around lines 369–380) and any unused imports it brought in.
+- `web/src/services/teamService.test.ts`:
+  - Delete the entire `describe('getTeams', ...)` block (around lines 117–149) — three `it` cases.
+
+Quality gates: `npm run api:test:integration && npm run web:test && npm run web:lint && npm run web:format:check && npm run api:format:check`.
+
+### Commit 3: Delete `GET /leagues`
+
+Backend
+- `LeagueEndpoints.cs`: delete `GetLeaguesAsync` and its registration (lines 21–25, 94–103).
+- `LeagueService.cs`: confirm no other caller of `GetLeaguesAsync()`; if none, remove it from `ILeagueService` and `LeagueService` (lines 13, 103–112).
+
+Frontend
+- Grep `web/src/` for `'/leagues'` (exact) and `getLeagues(` to confirm no caller. If any caller exists, redirect to `/me/leagues` or `/leagues/available` per intent and adjust callers + tests.
+
+Tests — additions (`AuthorizationTests.cs`)
+- `GetAllLeagues_Endpoint_Removed_Returns404`
+
+Tests — removals (these reference the deleted endpoint and service method)
+- `api/F1CompanionApi.UnitTests/Api/Endpoints/LeagueEndpointsTests.cs`:
+  - Delete `GetLeaguesAsync_LeaguesExist_ReturnsOkWithLeagues` (around line 106).
+  - Delete `GetLeaguesAsync_NoLeagues_ReturnsOkWithEmptyCollection` (around line 146).
+  - Delete `GetLeaguesAsync_ServiceReturnsEmptyCollection_ReturnsOkWithEmptyCollection` (around line 164).
+  - Delete the `InvokeGetLeaguesAsync` private helper (around lines 965–980).
+- `api/F1CompanionApi.UnitTests/Services/LeagueServiceTests.cs` (only if `ILeagueService.GetLeaguesAsync` is removed):
+  - Delete `GetLeaguesAsync_NoLeagues_ReturnsEmptyCollection` (around line 194).
+  - Delete `GetLeaguesAsync_MultipleLeagues_ReturnsAllLeagues` (around line 209).
+- `web/src/services/`: no `getLeagues()` exists — confirmed. The frontend uses `getMyLeagues` / `getAvailableLeagues` instead, so no frontend deletions needed.
+
+Quality gates: same as Commit 2.
+
+## Verification
+
+End-to-end manual checks (after all three commits land):
+
+```bash
+# Private-league membership enforcement (uses two users in a private league)
+npm run api:watch                                     # in one shell
+# In another shell, with two valid Supabase JWTs:
+curl -H "Authorization: Bearer $JWT_MEMBER"     http://localhost:5077/api/leagues/$ID    # 200
+curl -H "Authorization: Bearer $JWT_NONMEMBER"  http://localhost:5077/api/leagues/$ID    # 403
+curl -H "Authorization: Bearer $JWT_NONMEMBER"  http://localhost:5077/api/leagues/$ID/standings  # 403
+
+# Removed surfaces return 404
+curl -H "Authorization: Bearer $JWT" http://localhost:5077/api/teams       # 404
+curl -H "Authorization: Bearer $JWT" http://localhost:5077/api/leagues     # 404
+
+# Auth required on teams/{id}
+curl http://localhost:5077/api/teams/1                                    # 401
+curl -H "Authorization: Bearer $JWT" http://localhost:5077/api/teams/1    # 200 or 404
+```
+
+Automated:
+- `npm run api:test` — unit + integration including the new authorization scenarios.
+- `npm run web:test` — confirms removed `getTeams` did not break adjacent tests.
+- `npm run e2e` — the existing browser suite exercises the league-details and team-detail flows; smoke check for regressions.

--- a/web/src/services/leagueService.test.ts
+++ b/web/src/services/leagueService.test.ts
@@ -10,7 +10,6 @@ import {
   createLeague,
   getAvailableLeagues,
   getLeagueById,
-  getLeagues,
   getMyLeagues,
   joinLeague,
 } from './leagueService';
@@ -96,37 +95,6 @@ describe('leagueService', () => {
         mockLeagueRequest,
         'create league',
       );
-    });
-  });
-
-  describe('getLeagues', () => {
-    it('calls apiClient.get with correct endpoint', async () => {
-      const mockLeagues: League[] = createMockLeagueList(2);
-
-      mockApiClient.get.mockResolvedValue(mockLeagues);
-
-      const result = await getLeagues();
-
-      expect(mockApiClient.get).toHaveBeenCalledWith('/leagues', 'get leagues');
-      expect(result).toEqual(mockLeagues);
-    });
-
-    it('returns empty array when no leagues exist', async () => {
-      mockApiClient.get.mockResolvedValue([]);
-
-      const result = await getLeagues();
-
-      expect(result).toEqual([]);
-      expect(mockApiClient.get).toHaveBeenCalledWith('/leagues', 'get leagues');
-    });
-
-    it('propagates API errors during league retrieval', async () => {
-      const mockError = new Error('Server error');
-
-      mockApiClient.get.mockRejectedValue(mockError);
-
-      await expect(getLeagues()).rejects.toThrow('Server error');
-      expect(mockApiClient.get).toHaveBeenCalledWith('/leagues', 'get leagues');
     });
   });
 

--- a/web/src/services/leagueService.ts
+++ b/web/src/services/leagueService.ts
@@ -21,10 +21,6 @@ export async function createLeague(data: CreateLeagueRequest): Promise<League> {
   return league;
 }
 
-export async function getLeagues(): Promise<League[]> {
-  return apiClient.get<League[]>('/leagues', 'get leagues');
-}
-
 export async function getMyLeagues(): Promise<League[]> {
   return apiClient.get<League[]>('/me/leagues', 'get your leagues');
 }

--- a/web/src/services/teamService.test.ts
+++ b/web/src/services/teamService.test.ts
@@ -13,7 +13,6 @@ import {
   createTeam,
   getMyTeam,
   getTeamById,
-  getTeams,
   removeConstructorFromTeam,
   removeDriverFromTeam,
   setCaptain,
@@ -111,41 +110,6 @@ describe('teamService', () => {
         message: 'Server error',
         status: 500,
       });
-    });
-  });
-
-  describe('getTeams', () => {
-    it('calls apiClient.get with correct endpoint', async () => {
-      const mockTeams: Team[] = [
-        createMockTeam({ id: 1, name: 'Team Alpha', ownerName: 'Alice' }),
-        createMockTeam({ id: 2, name: 'Team Beta', ownerName: 'Bob' }),
-        createMockTeam({ id: 3, name: 'Team Gamma', ownerName: 'Charlie' }),
-      ];
-
-      vi.mocked(apiClient.get).mockResolvedValue(mockTeams);
-
-      const result = await getTeams();
-
-      expect(apiClient.get).toHaveBeenCalledWith('/teams', 'get teams');
-      expect(result).toEqual(mockTeams);
-    });
-
-    it('returns empty array when no teams exist', async () => {
-      vi.mocked(apiClient.get).mockResolvedValue([]);
-
-      const result = await getTeams();
-
-      expect(result).toEqual([]);
-      expect(apiClient.get).toHaveBeenCalledWith('/teams', 'get teams');
-    });
-
-    it('propagates API errors during team retrieval', async () => {
-      const mockError = new Error('Failed to fetch teams');
-
-      vi.mocked(apiClient.get).mockRejectedValue(mockError);
-
-      await expect(getTeams()).rejects.toThrow('Failed to fetch teams');
-      expect(apiClient.get).toHaveBeenCalledWith('/teams', 'get teams');
     });
   });
 

--- a/web/src/services/teamService.ts
+++ b/web/src/services/teamService.ts
@@ -30,10 +30,6 @@ export async function getMyTeam(): Promise<Team | null> {
   }
 }
 
-export async function getTeams(): Promise<Team[]> {
-  return await apiClient.get('/teams', 'get teams');
-}
-
 export async function getTeamById(id: number): Promise<Team | null> {
   try {
     return await apiClient.get<Team>(`/teams/${id}`, 'get team');


### PR DESCRIPTION
## Summary

Sweep of API endpoints to close cross-user data leaks identified in #159. Three commits, each independently reviewable:

- **`07404a6`** — `GET /api/leagues/{id}` and `GET /api/leagues/{id}/standings` now enforce league membership for private leagues. Both endpoints route through a single `LeagueService.GuardLeagueAccessAsync`, which throws `NotLeagueMemberException` (→ 403) for non-members and `LeagueNotFoundException` (→ 404) for missing leagues. Public leagues remain readable by any authenticated user.
- **`1e65ec0`** — `GET /api/teams` removed entirely (no production caller; the unused `getTeams()` helper is dropped from the web service module too). `GET /api/teams/{id}` now requires authentication; any authenticated user can view any team, matching the existing `/team/$teamId` UX.
- **`82a89b6`** — `GET /api/leagues` removed entirely. `GET /me/leagues` and `GET /leagues/available` already serve the two legitimate views; the catch-all only existed as a leak of private league names.

A broader audit of the other endpoint files (`MeEndpoints`, `LineupEndpoints`, `RaceWeekendResultEndpoints`, `RaceWeekendScoringEndpoints`, `SeasonEndpoints`, `RaceWeekendEndpoints`, `DriverEndpoints`, `ConstructorEndpoints`) found no further gaps.

Plan written to `docs/plans/159-endpoint-authorization-audit.md`.

## Test plan

- [ ] CI green: backend unit + integration, frontend.
- [ ] Manually verify with two authenticated users in a private league:
  - [ ] Member can `GET /api/leagues/{id}` and `/standings` (200).
  - [ ] Non-member gets 403 on both.
  - [ ] Either user gets 404 on a non-existent league.
- [ ] Verify `GET /api/leagues` and `GET /api/teams` return 405 (POST still claims those paths).
- [ ] Verify `GET /api/teams/{id}` requires auth (401 unauthenticated, 200 authenticated).
- [ ] Smoke the `/team/$teamId` route in the browser to confirm the auth requirement didn't break the existing UX.

Closes #159.