### PR TITLE
Support ingesting partial F1 weekends

### DIFF
--- a/api/scripts/ingest_results.py
+++ b/api/scripts/ingest_results.py
@@ -12,7 +12,6 @@ Usage:
 import argparse
 import os
 import sys
-from datetime import datetime, timezone
 from enum import IntEnum
 from itertools import combinations
 
@@ -94,20 +93,19 @@ def find_race_weekend(race_weekends: list[dict], round_number: int) -> dict:
 
 
 def load_session(year: int, round_number: int, session_name: str):
-    """Load a FastF1 session. Returns the session object, or None on failure."""
+    """Load a FastF1 session. Returns the session object, or None if unavailable."""
     try:
         session = fastf1.get_session(year, round_number, session_name)
         session.load(telemetry=False, weather=False, messages=False)
-        if session.results is None or session.results.empty:
-            raise IngestError(
-                f"No data available for {session_name} R{round_number} — session may not have occurred yet"
-            )
-        return session
-    except IngestError:
-        raise
     except Exception as exc:
         print(f"  Warning: could not load {session_name} R{round_number}: {exc}")
         return None
+
+    if session.results is None or session.results.empty:
+        print(f"  Warning: {session_name} R{round_number} has no results yet")
+        return None
+
+    return session
 
 
 def _build_pit_laps(laps) -> set[tuple[str, int]]:
@@ -374,6 +372,7 @@ def ingest(round_number: int, env: str) -> None:
     # Set up FastF1 cache
     os.makedirs(CACHE_DIR, exist_ok=True)
     fastf1.Cache.enable_cache(CACHE_DIR)
+    fastf1.set_log_level("ERROR")
 
     api_session = create_api_session(config["F1_API_KEY"])
     api_url = config["F1_API_URL"]
@@ -394,38 +393,37 @@ def ingest(round_number: int, env: str) -> None:
     race_weekends = fetch_race_weekends(api_session, api_url, season_id)
     race_weekend = find_race_weekend(race_weekends, round_number)
     has_sprint = race_weekend.get("weekendFormat", 0) == WEEKEND_FORMAT_SPRINT
-    race_date = datetime.fromisoformat(race_weekend["raceDate"]).replace(tzinfo=timezone.utc)
     print(f"  Race weekend: {race_weekend['name']} (round={round_number}, hasSprint={has_sprint})")
-
-    if datetime.now(timezone.utc) < race_date:
-        raise IngestError(f"Race has not occurred yet (scheduled {race_date.date()})")
-
-    # Qualifying
-    print(f"Loading qualifying session (R{round_number})...")
-    quali = load_session(year, round_number, "Qualifying")
-    if quali is not None:
-        payload, warnings = build_qualifying_payload(quali, driver_map)
-        report_warnings(warnings, "qualifying")
-        if payload:
-            submit_results(api_session, api_url, season_id, round_number, "qualifying", payload)
-            post_score(api_session, api_url, season_id, round_number)
-    else:
-        print("  Skipping qualifying — session not available")
 
     # Sprint
     if has_sprint:
         print(f"Loading sprint session (R{round_number})...")
         sprint = load_session(year, round_number, "Sprint")
-        if sprint is not None:
-            sprint_overtakes = count_overtakes(sprint.laps)
-            sprint_fl = get_fastest_lap_driver(sprint.laps)
-            payload, warnings = build_race_payload(sprint, driver_map, sprint_overtakes, sprint_fl)
-            report_warnings(warnings, "sprint")
-            if payload:
-                submit_results(api_session, api_url, season_id, round_number, "sprint", payload)
-                post_score(api_session, api_url, season_id, round_number)
-        else:
-            print("  Skipping sprint — session not available")
+        if sprint is None:
+            print(f"  Sprint not available yet — nothing to ingest for round {round_number}")
+            return
+        sprint_overtakes = count_overtakes(sprint.laps)
+        sprint_fl = get_fastest_lap_driver(sprint.laps)
+        payload, warnings = build_race_payload(sprint, driver_map, sprint_overtakes, sprint_fl)
+        report_warnings(warnings, "sprint")
+        if payload:
+            submit_results(api_session, api_url, season_id, round_number, "sprint", payload)
+            post_score(api_session, api_url, season_id, round_number)
+
+    # Qualifying
+    print(f"Loading qualifying session (R{round_number})...")
+    quali = load_session(year, round_number, "Qualifying")
+    if quali is None:
+        if not has_sprint:
+            print(f"  Qualifying not available yet — nothing to ingest for round {round_number}")
+            return
+        print("  Skipping qualifying — session not available")
+    else:
+        payload, warnings = build_qualifying_payload(quali, driver_map)
+        report_warnings(warnings, "qualifying")
+        if payload:
+            submit_results(api_session, api_url, season_id, round_number, "qualifying", payload)
+            post_score(api_session, api_url, season_id, round_number)
 
     # Grand Prix
     print(f"Loading race session (R{round_number})...")

--- a/api/scripts/test_ingest_results.py
+++ b/api/scripts/test_ingest_results.py
@@ -85,12 +85,13 @@ class TestMapSessionStatus:
 
 
 class TestLoadSession:
-    def test_raises_ingest_error_when_results_empty(self):
+    def test_returns_none_when_results_empty(self, capsys):
         mock_session = MagicMock()
         mock_session.results = pd.DataFrame()
         with patch("ingest_results.fastf1.get_session", return_value=mock_session):
-            with pytest.raises(IngestError, match="may not have occurred yet"):
-                load_session(2026, 7, "Race")
+            result = load_session(2026, 7, "Race")
+        assert result is None
+        assert "no results yet" in capsys.readouterr().out
 
     def test_returns_none_when_session_type_does_not_exist(self):
         with patch("ingest_results.fastf1.get_session", side_effect=Exception("Session type 'Sprint' does not exist")):
@@ -560,3 +561,66 @@ class TestIngestOrchestration:
         assert write_calls.index(advance) > gp_put_idx
         # Exactly one advance call.
         assert sum(1 for c in write_calls if c == advance) == 1
+
+    def test_bails_on_sprint_weekend_when_sprint_unavailable(self, monkeypatch, capsys):
+        api_session = _make_ingest_mocks(
+            monkeypatch, has_sprint=True, total_rounds=10, round_number=6
+        )
+        monkeypatch.setattr(
+            "ingest_results.load_session", lambda year, rn, name: None
+        )
+
+        ingest(round_number=6, env="local")
+
+        write_calls = [c for c in _captured_calls(api_session) if c[0] in ("PUT", "POST")]
+        assert write_calls == []
+        captured = capsys.readouterr().out
+        assert "Sprint not available yet" in captured
+        assert "nothing to ingest for round 6" in captured
+        assert "Loading qualifying session" not in captured
+        assert "Loading race session" not in captured
+
+    def test_bails_on_standard_weekend_when_qualifying_unavailable(
+        self, monkeypatch, capsys
+    ):
+        api_session = _make_ingest_mocks(
+            monkeypatch, has_sprint=False, total_rounds=10, round_number=6
+        )
+        monkeypatch.setattr(
+            "ingest_results.load_session", lambda year, rn, name: None
+        )
+
+        ingest(round_number=6, env="local")
+
+        write_calls = [c for c in _captured_calls(api_session) if c[0] in ("PUT", "POST")]
+        assert write_calls == []
+        captured = capsys.readouterr().out
+        assert "Qualifying not available yet" in captured
+        assert "nothing to ingest for round 6" in captured
+        assert "Loading race session" not in captured
+
+    def test_continues_on_sprint_weekend_when_only_qualifying_missing(
+        self, monkeypatch, capsys
+    ):
+        api_session = _make_ingest_mocks(
+            monkeypatch, has_sprint=True, total_rounds=10, round_number=6
+        )
+        fake_session = MagicMock()
+        fake_session.results = pd.DataFrame([{"Abbreviation": "VER"}])
+        fake_session.laps = None
+        monkeypatch.setattr(
+            "ingest_results.load_session",
+            lambda year, rn, name: None if name == "Qualifying" else fake_session,
+        )
+
+        ingest(round_number=6, env="local")
+
+        write_calls = [c for c in _captured_calls(api_session) if c[0] in ("PUT", "POST")]
+        sprint_put = ("PUT", "http://api/api/seasons/1/race-weekends/6/results/sprint")
+        gp_put = ("PUT", "http://api/api/seasons/1/race-weekends/6/results/grand-prix")
+        quali_put = ("PUT", "http://api/api/seasons/1/race-weekends/6/results/qualifying")
+        assert sprint_put in write_calls
+        assert gp_put in write_calls
+        assert quali_put not in write_calls
+        captured = capsys.readouterr().out
+        assert "Skipping qualifying — session not available" in captured


### PR DESCRIPTION
## Summary
- Removes the upfront race-date guard so qualifying and sprint can be ingested before race day. PUT endpoints already replace results and scoring recomputes from current state, so re-running after the GP remains idempotent and lineups still advance only when the race itself ingests successfully.
- Reorders session processing to Sprint → Qualifying → Race (the chronological order on sprint weekends) and bails with a single clear message when the first scoreable session of the weekend has no data yet, instead of cascading through every block with per-session warnings.
- Normalizes `load_session` to return `None` on empty results and quiets FastF1's stderr logger to `ERROR` so the script's own status output is readable.

## Test plan
- [ ] `python3 ingest_results.py --round <future_round>` prints the bail message and exits 0 with no FastF1 chatter.
- [ ] Running mid-weekend on a sprint round after only Sprint has finished ingests sprint, skips qualifying with a one-line notice, skips race, exits cleanly.
- [ ] Running after race day on the same round re-submits all three sessions, recomputes scores, and advances lineups exactly once.
- [ ] `pytest api/scripts/test_ingest_results.py` is green (47 tests).