### PR TITLE
Add /me/team/summary and /me/standings endpoints for Home page

### DIFF
--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -142,6 +142,8 @@ RLS is auto-enabled on new public tables via the `auto_enable_rls_public` Supaba
 1. Create interface `I{Feature}Service` and implementation in `Domain/Services/`
 2. Register as scoped in `ServiceExtensions.cs:AddServices`: `services.AddScoped<IFeatureService, FeatureService>()`
 
+**Service method naming for user-scoped reads.** When a method takes `int userId` and returns something belonging to that user, use the `GetXForUserAsync(int userId)` shape (e.g., `GetStandingsForUserAsync`, `GetLeaguesForUserAsync`) rather than `GetUserXAsync`. The `User`-prefixed form is grammatically ambiguous — `GetUserStandingsAsync` reads either as "get [user-standings]" (some concept) or "get [the user's] standings." The `ForUser` form removes that ambiguity. The codebase has both forms historically (`TeamService.GetUserTeamAsync` uses the prefix); don't retroactively rename existing methods unless asked, but prefer `ForUser` for new ones.
+
 ### Adding a New Exception
 
 - **Custom exceptions are for write-side business-rule violations only** — `DuplicateTeamException`, `TeamOwnershipException`, `RosterLockedException`, `BudgetExceededException` etc. Reads use the null-return + handler-side 404 pattern from "Adding a New Endpoint" above. Several existing `*NotFoundException` types map to **400**, not 404 (e.g., `TeamNotFoundException` → 400 with a league-creation-flavored message) — check `GlobalExceptionHandler.cs` before assuming an exception name implies a status code.

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -116,7 +116,17 @@ instance.
 2. Define private static async methods returning `IResult`, chain `.RequireAuthorization()`, `.WithName()`, `.WithDescription()`
 3. Register in `Endpoints.MapEndpoints()` by chaining `.Map{Feature}Endpoints()`
 4. Add request/response DTOs in `Api/Models/`
-5. Add mapper extension method in `Api/Mappers/`
+5. Add mapper extension method in `Api/Mappers/` (see "Mapper file organization" below)
+
+**Read-endpoint 404 pattern.** When a read targets a single resource that may not exist, the service returns a nullable response (`Task<XxxResponse?>`) and the handler maps `null → 404`: `LogWarning(...)` then `Results.Problem(detail: "...", statusCode: StatusCodes.Status404NotFound)`. Reference: `SeasonEndpoints.GetCurrentSeasonAsync`, `DriverEndpoints`, `ConstructorEndpoints`. Don't throw a `*NotFoundException` from a read — those are write-side guards (see "Adding a New Exception" below).
+
+**Required-resource guards in services.** When a service needs a resource that must exist for the work to be meaningful (e.g., the current season for a season-scoped read), guard at the service boundary with `?? throw new InvalidOperationException("...")`. Surfaces as a 500, distinct from "the resource the caller asked for doesn't exist" (404). Reference: `LeagueStandingsService.cs:147`, `LineupService.cs:39`, `ScoringService.cs:218`.
+
+### Mapper file organization
+
+- **One file per source entity.** Named after the primary DTO it produces, lives in `Api/Mappers/`. Multiple methods in the same file when the same source maps to base + richer variants — `Team → TeamResponse` and `Team → TeamDetailsResponse` both live in `TeamResponseMapper.cs`.
+- **Container/child splits across files.** When a DTO contains a nested child DTO, the child gets its own mapper file. `TeamDetailsResponse` contains `TeamDriverResponse` and `TeamConstructorResponse`, so there are three mapper files (`TeamResponseMapper`, `TeamDriverResponseMapper`, `TeamConstructorResponseMapper`); the parent mapper calls the children via their extension methods.
+- **Mappers stay decision-free.** Selection logic (`OrderByDescending(...).FirstOrDefault()`) belongs in the service; pass the already-selected value into the mapper. Aggregation (`Sum`, ordering for output) inside the mapper is fine. Reference: `TeamSummaryResponseMapper.ToResponseModel` accepts a pre-selected `latest`.
 
 ### Adding a New Entity
 
@@ -134,5 +144,6 @@ RLS is auto-enabled on new public tables via the `auto_enable_rls_public` Supaba
 
 ### Adding a New Exception
 
+- **Custom exceptions are for write-side business-rule violations only** — `DuplicateTeamException`, `TeamOwnershipException`, `RosterLockedException`, `BudgetExceededException` etc. Reads use the null-return + handler-side 404 pattern from "Adding a New Endpoint" above. Several existing `*NotFoundException` types map to **400**, not 404 (e.g., `TeamNotFoundException` → 400 with a league-creation-flavored message) — check `GlobalExceptionHandler.cs` before assuming an exception name implies a status code.
 - Use standard HTTP status codes only — avoid WebDAV-specific codes (e.g. use 409 Conflict, not 423 Locked)
 - The class `<summary>` should explain both what triggers the exception and why it's considered exceptional (what it implies about the caller). See `SlotOccupiedException` as the reference example.

--- a/api/F1CompanionApi.IntegrationTests/Scenarios/MeStandingsTests.cs
+++ b/api/F1CompanionApi.IntegrationTests/Scenarios/MeStandingsTests.cs
@@ -1,0 +1,266 @@
+using System.Net;
+using System.Net.Http.Json;
+using F1CompanionApi.Api.Models;
+using F1CompanionApi.Data;
+using F1CompanionApi.Data.Entities;
+using F1CompanionApi.IntegrationTests.Support;
+
+namespace F1CompanionApi.IntegrationTests.Scenarios;
+
+public class MeStandingsTests : IntegrationTestBase
+{
+    public MeStandingsTests(PostgresFixture postgres)
+        : base(postgres) { }
+
+    [Fact]
+    public async Task GetMyStandings_Unauthenticated_Returns401()
+    {
+        var anonClient = Factory.CreateClient();
+
+        var response = await anonClient.GetAsync("/api/me/standings");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetMyStandings_NoTeam_ReturnsEmptyArray()
+    {
+        var (client, _) = await Factory.CreateAuthenticatedAsync();
+
+        var standings = await client.GetFromJsonAsync<List<MyLeagueStandingResponse>>(
+            "/api/me/standings"
+        );
+
+        Assert.NotNull(standings);
+        Assert.Empty(standings!);
+    }
+
+    [Fact]
+    public async Task GetMyStandings_LeagueWithScoredRounds_ReturnsLatestRoundPositionAndPoints()
+    {
+        var (client, callerProfile) = await Factory.CreateAuthenticatedAsync();
+
+        var leagueId = await SeedAsync(async db =>
+        {
+            var season = await db.CreateCurrentSeasonAsync();
+            var callerTeam = await db.CreateTeamAsync(callerProfile.Id, "Caller Team");
+
+            var league = await CreateLeagueAsync(db, callerProfile.Id, "Scored League");
+            var other1 = await CreateExtraTeamAsync(db, "a1");
+            var other2 = await CreateExtraTeamAsync(db, "a2");
+            await JoinTeamsAsync(
+                db,
+                league.Id,
+                callerProfile.Id,
+                callerTeam.Id,
+                other1.Id,
+                other2.Id
+            );
+
+            var w1 = await db.CreateRaceWeekendAsync(
+                season.Id,
+                raceDate: DateTime.UtcNow.AddDays(-21),
+                round: 1,
+                name: "Round One GP"
+            );
+            var w2 = await db.CreateRaceWeekendAsync(
+                season.Id,
+                raceDate: DateTime.UtcNow.AddDays(-14),
+                round: 2,
+                name: "Round Two GP"
+            );
+
+            // Insert out of round order so latest-round-pick isn't accidentally
+            // satisfied by insertion order.
+            db.TeamLeagueStandings.AddRange(
+                Standing(league.Id, callerTeam.Id, w2.Id, position: 1, totalPoints: 130),
+                Standing(league.Id, callerTeam.Id, w1.Id, position: 2, totalPoints: 30)
+            );
+            await db.SaveChangesAsync();
+
+            return league.Id;
+        });
+
+        var standings = await client.GetFromJsonAsync<List<MyLeagueStandingResponse>>(
+            "/api/me/standings"
+        );
+
+        var row = Assert.Single(standings!);
+        Assert.Equal(leagueId, row.LeagueId);
+        Assert.Equal("Scored League", row.LeagueName);
+        Assert.Equal(3, row.TotalTeams);
+        Assert.Equal(1, row.Position);
+        Assert.Equal(130, row.TotalPoints);
+    }
+
+    [Fact]
+    public async Task GetMyStandings_LeagueWithoutScoredRound_ListsLeagueWithNullFields()
+    {
+        var (client, callerProfile) = await Factory.CreateAuthenticatedAsync();
+
+        var leagueId = await SeedAsync(async db =>
+        {
+            await db.CreateCurrentSeasonAsync();
+            var callerTeam = await db.CreateTeamAsync(callerProfile.Id, "Caller Team");
+
+            var league = await CreateLeagueAsync(db, callerProfile.Id, "Unscored League");
+            var other = await CreateExtraTeamAsync(db, "b1");
+            await JoinTeamsAsync(db, league.Id, callerProfile.Id, callerTeam.Id, other.Id);
+
+            return league.Id;
+        });
+
+        var standings = await client.GetFromJsonAsync<List<MyLeagueStandingResponse>>(
+            "/api/me/standings"
+        );
+
+        var row = Assert.Single(standings!);
+        Assert.Equal(leagueId, row.LeagueId);
+        Assert.Equal("Unscored League", row.LeagueName);
+        Assert.Equal(2, row.TotalTeams);
+        Assert.Null(row.Position);
+        Assert.Null(row.TotalPoints);
+    }
+
+    [Fact]
+    public async Task GetMyStandings_PriorSeasonStandingOnly_ListsLeagueWithNullFields()
+    {
+        var (client, callerProfile) = await Factory.CreateAuthenticatedAsync();
+
+        var leagueId = await SeedAsync(async db =>
+        {
+            var currentSeason = await db.CreateCurrentSeasonAsync();
+            var priorSeason = new Season
+            {
+                Year = currentSeason.Year - 1,
+                StartDate = DateTime.UtcNow.AddDays(-400),
+                EndDate = DateTime.UtcNow.AddDays(-100),
+            };
+            db.Seasons.Add(priorSeason);
+            await db.SaveChangesAsync();
+
+            var callerTeam = await db.CreateTeamAsync(callerProfile.Id, "Caller Team");
+
+            var league = await CreateLeagueAsync(db, callerProfile.Id, "Prior Season League");
+            var other = await CreateExtraTeamAsync(db, "c1");
+            await JoinTeamsAsync(db, league.Id, callerProfile.Id, callerTeam.Id, other.Id);
+
+            var priorRace = await db.CreateRaceWeekendAsync(
+                priorSeason.Id,
+                raceDate: DateTime.UtcNow.AddDays(-200),
+                round: 1,
+                name: "Prior Season Finale"
+            );
+
+            db.TeamLeagueStandings.Add(
+                Standing(league.Id, callerTeam.Id, priorRace.Id, position: 1, totalPoints: 999)
+            );
+            await db.SaveChangesAsync();
+
+            return league.Id;
+        });
+
+        var standings = await client.GetFromJsonAsync<List<MyLeagueStandingResponse>>(
+            "/api/me/standings"
+        );
+
+        var row = Assert.Single(standings!);
+        Assert.Equal(leagueId, row.LeagueId);
+        Assert.Equal("Prior Season League", row.LeagueName);
+        Assert.Equal(2, row.TotalTeams);
+        Assert.Null(row.Position);
+        Assert.Null(row.TotalPoints);
+    }
+
+    private async Task<T> SeedAsync<T>(Func<ApplicationDbContext, Task<T>> seed)
+    {
+        T result = default!;
+        await WithDbAsync(async db =>
+        {
+            result = await seed(db);
+        });
+        return result;
+    }
+
+    private static async Task<League> CreateLeagueAsync(
+        ApplicationDbContext db,
+        int ownerId,
+        string name
+    )
+    {
+        var league = new League
+        {
+            Name = name,
+            OwnerId = ownerId,
+            CreatedBy = ownerId,
+            CreatedAt = DateTime.UtcNow,
+        };
+        db.Leagues.Add(league);
+        await db.SaveChangesAsync();
+        return league;
+    }
+
+    private static async Task<Team> CreateExtraTeamAsync(ApplicationDbContext db, string slug)
+    {
+        var account = new Account
+        {
+            Id = Guid.NewGuid().ToString(),
+            CreatedAt = DateTime.UtcNow,
+            IsActive = true,
+        };
+        db.Accounts.Add(account);
+        var profile = new UserProfile
+        {
+            AccountId = account.Id,
+            Email = $"{slug}-{Guid.NewGuid():N}@test.local",
+            FirstName = slug,
+            LastName = "User",
+            CreatedAt = DateTime.UtcNow,
+        };
+        db.UserProfiles.Add(profile);
+        await db.SaveChangesAsync();
+
+        return await db.CreateTeamAsync(profile.Id, $"Team {slug}");
+    }
+
+    private static async Task JoinTeamsAsync(
+        ApplicationDbContext db,
+        int leagueId,
+        int actingUserId,
+        params int[] teamIds
+    )
+    {
+        foreach (var teamId in teamIds)
+        {
+            db.LeagueTeams.Add(
+                new LeagueTeam
+                {
+                    LeagueId = leagueId,
+                    TeamId = teamId,
+                    JoinedAt = DateTime.UtcNow,
+                    CreatedBy = actingUserId,
+                    CreatedAt = DateTime.UtcNow,
+                }
+            );
+        }
+        await db.SaveChangesAsync();
+    }
+
+    private static TeamLeagueStanding Standing(
+        int leagueId,
+        int teamId,
+        int raceWeekendId,
+        int position,
+        int totalPoints
+    ) =>
+        new()
+        {
+            LeagueId = leagueId,
+            TeamId = teamId,
+            RaceWeekendId = raceWeekendId,
+            Position = position,
+            TotalPoints = totalPoints,
+            CalculatedAt = DateTime.UtcNow,
+            CreatedAt = DateTime.UtcNow,
+        };
+}

--- a/api/F1CompanionApi.IntegrationTests/Scenarios/MeTeamSummaryTests.cs
+++ b/api/F1CompanionApi.IntegrationTests/Scenarios/MeTeamSummaryTests.cs
@@ -1,0 +1,109 @@
+using System.Net;
+using System.Net.Http.Json;
+using F1CompanionApi.Api.Models;
+using F1CompanionApi.Data.Entities;
+using F1CompanionApi.IntegrationTests.Support;
+
+namespace F1CompanionApi.IntegrationTests.Scenarios;
+
+public class MeTeamSummaryTests : IntegrationTestBase
+{
+    public MeTeamSummaryTests(PostgresFixture postgres)
+        : base(postgres) { }
+
+    [Fact]
+    public async Task GetMyTeamSummary_Unauthenticated_Returns401()
+    {
+        var anonClient = Factory.CreateClient();
+
+        var response = await anonClient.GetAsync("/api/me/team/summary");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetMyTeamSummary_NoTeam_Returns404()
+    {
+        var (client, _) = await Factory.CreateAuthenticatedAsync();
+
+        var response = await client.GetAsync("/api/me/team/summary");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetMyTeamSummary_HappyPath_SumsCurrentSeasonAndPicksLatestRace()
+    {
+        var (client, profile) = await Factory.CreateAuthenticatedAsync();
+
+        await WithDbAsync(async db =>
+        {
+            var currentSeason = await db.CreateCurrentSeasonAsync();
+            var priorSeason = new Season
+            {
+                Year = currentSeason.Year - 1,
+                StartDate = DateTime.UtcNow.AddDays(-400),
+                EndDate = DateTime.UtcNow.AddDays(-100),
+            };
+            db.Seasons.Add(priorSeason);
+            await db.SaveChangesAsync();
+
+            var team = await db.CreateTeamAsync(profile.Id);
+
+            // Three current-season scored rounds, out of insertion order, so the test
+            // verifies "latest by Round" rather than insertion or RaceDate order.
+            var w2 = await db.CreateRaceWeekendAsync(
+                currentSeason.Id,
+                raceDate: DateTime.UtcNow.AddDays(-14),
+                round: 2,
+                name: "Round Two GP"
+            );
+            var w1 = await db.CreateRaceWeekendAsync(
+                currentSeason.Id,
+                raceDate: DateTime.UtcNow.AddDays(-21),
+                round: 1,
+                name: "Round One GP"
+            );
+            var w3 = await db.CreateRaceWeekendAsync(
+                currentSeason.Id,
+                raceDate: DateTime.UtcNow.AddDays(-7),
+                round: 3,
+                name: "Round Three GP"
+            );
+            var priorSeasonRace = await db.CreateRaceWeekendAsync(
+                priorSeason.Id,
+                raceDate: DateTime.UtcNow.AddDays(-200),
+                round: 1,
+                name: "Prior Season Finale"
+            );
+
+            db.TeamRaceWeekendScores.AddRange(
+                Score(team.Id, w1.Id, 25),
+                Score(team.Id, w2.Id, 40),
+                Score(team.Id, w3.Id, 18),
+                // Prior-season score must NOT contribute to sum or latest-race pick.
+                Score(team.Id, priorSeasonRace.Id, 999)
+            );
+            await db.SaveChangesAsync();
+        });
+
+        var summary = await client.GetFromJsonAsync<TeamSummaryResponse>("/api/me/team/summary");
+
+        Assert.NotNull(summary);
+        Assert.Equal(25 + 40 + 18, summary!.SeasonTotalPoints);
+        Assert.NotNull(summary.LastRace);
+        Assert.Equal(3, summary.LastRace!.Round);
+        Assert.Equal("Round Three GP", summary.LastRace.Name);
+        Assert.Equal(18, summary.LastRace.TotalScore);
+    }
+
+    private static TeamRaceWeekendScore Score(int teamId, int raceWeekendId, int total) =>
+        new()
+        {
+            TeamId = teamId,
+            RaceWeekendId = raceWeekendId,
+            TotalPoints = total,
+            CalculatedAt = DateTime.UtcNow,
+            CreatedAt = DateTime.UtcNow,
+        };
+}

--- a/api/F1CompanionApi.UnitTests/Api/Mappers/TeamSummaryLastRaceResponseMapperTests.cs
+++ b/api/F1CompanionApi.UnitTests/Api/Mappers/TeamSummaryLastRaceResponseMapperTests.cs
@@ -1,0 +1,33 @@
+using F1CompanionApi.Api.Mappers;
+using F1CompanionApi.Data.Entities;
+
+namespace F1CompanionApi.UnitTests.Api.Mappers;
+
+public class TeamSummaryLastRaceResponseMapperTests
+{
+    [Fact]
+    public void ToResponseModel_MapsAllFields()
+    {
+        var score = new TeamRaceWeekendScore
+        {
+            TeamId = 1,
+            RaceWeekendId = 7,
+            TotalPoints = 42,
+            CalculatedAt = DateTime.UtcNow,
+            RaceWeekend = new RaceWeekend
+            {
+                SeasonId = 100,
+                Round = 5,
+                Name = "Monaco GP",
+                CircuitId = 200,
+                RaceDate = DateTime.UtcNow,
+            },
+        };
+
+        var response = score.ToResponseModel();
+
+        Assert.Equal(5, response.Round);
+        Assert.Equal("Monaco GP", response.Name);
+        Assert.Equal(42, response.TotalScore);
+    }
+}

--- a/api/F1CompanionApi.UnitTests/Api/Mappers/TeamSummaryResponseMapperTests.cs
+++ b/api/F1CompanionApi.UnitTests/Api/Mappers/TeamSummaryResponseMapperTests.cs
@@ -1,0 +1,53 @@
+using F1CompanionApi.Api.Mappers;
+using F1CompanionApi.Data.Entities;
+
+namespace F1CompanionApi.UnitTests.Api.Mappers;
+
+public class TeamSummaryResponseMapperTests
+{
+    [Fact]
+    public void ToResponseModel_NullLatest_ReturnsNullFields()
+    {
+        var response = Array.Empty<TeamRaceWeekendScore>().ToResponseModel(latest: null);
+
+        Assert.Null(response.SeasonTotalPoints);
+        Assert.Null(response.LastRace);
+    }
+
+    [Fact]
+    public void ToResponseModel_WithLatest_SumsAndMapsLastRace()
+    {
+        var scores = new[]
+        {
+            Score(round: 1, points: 25, name: "Round One"),
+            Score(round: 2, points: 40, name: "Round Two"),
+            Score(round: 3, points: 18, name: "Round Three"),
+        };
+        var latest = scores[2];
+
+        var response = scores.ToResponseModel(latest);
+
+        Assert.Equal(25 + 40 + 18, response.SeasonTotalPoints);
+        Assert.NotNull(response.LastRace);
+        Assert.Equal(3, response.LastRace!.Round);
+        Assert.Equal("Round Three", response.LastRace.Name);
+        Assert.Equal(18, response.LastRace.TotalScore);
+    }
+
+    private static TeamRaceWeekendScore Score(int round, int points, string name) =>
+        new()
+        {
+            TeamId = 1,
+            RaceWeekendId = round,
+            TotalPoints = points,
+            CalculatedAt = DateTime.UtcNow,
+            RaceWeekend = new RaceWeekend
+            {
+                SeasonId = 100,
+                Round = round,
+                Name = name,
+                CircuitId = 200,
+                RaceDate = DateTime.UtcNow,
+            },
+        };
+}

--- a/api/F1CompanionApi.UnitTests/Services/TeamServiceTests.cs
+++ b/api/F1CompanionApi.UnitTests/Services/TeamServiceTests.cs
@@ -39,7 +39,14 @@ public class TeamServiceTests
                     .FirstOrDefaultAsync()
             );
 
-        return new TeamService(context, raceWeekendService.Object, _mockLogger.Object);
+        var seasonService = new Mock<ISeasonService>();
+
+        return new TeamService(
+            context,
+            raceWeekendService.Object,
+            seasonService.Object,
+            _mockLogger.Object
+        );
     }
 
     [Fact]

--- a/api/F1CompanionApi/Api/Endpoints/MeEndpoints.cs
+++ b/api/F1CompanionApi/Api/Endpoints/MeEndpoints.cs
@@ -33,6 +33,13 @@ public static class MeEndpoints
             .WithName("Get My Leagues")
             .WithDescription("Gets leagues owned by the authenticated user");
 
+        meGroup
+            .MapGet("/standings", GetMyStandingsAsync)
+            .WithName("Get My Standings")
+            .WithDescription(
+                "Gets the authenticated user's latest position and total points in each league their team belongs to"
+            );
+
         var teamGroup = meGroup.MapGroup("/team");
 
         teamGroup
@@ -236,6 +243,20 @@ public static class MeEndpoints
             logger.LogError(ex, "Failed to fetch leagues for current user");
             throw;
         }
+    }
+
+    private static async Task<IResult> GetMyStandingsAsync(
+        ILeagueStandingsService leagueStandingsService,
+        IUserProfileService userProfileService,
+        ILogger logger
+    )
+    {
+        var user = await userProfileService.GetRequiredCurrentUserProfileAsync();
+
+        logger.LogDebug("Fetching standings for user {UserId}", user.Id);
+
+        var standings = await leagueStandingsService.GetStandingsForUserAsync(user.Id);
+        return Results.Ok(standings);
     }
 
     private static async Task<IResult> GetMyTeamAsync(

--- a/api/F1CompanionApi/Api/Endpoints/MeEndpoints.cs
+++ b/api/F1CompanionApi/Api/Endpoints/MeEndpoints.cs
@@ -41,6 +41,11 @@ public static class MeEndpoints
             .WithDescription("Get current user's team or null if none exists");
 
         teamGroup
+            .MapGet("/summary", GetMyTeamSummaryAsync)
+            .WithName("Get My Team Summary")
+            .WithDescription("Gets a summary of the current user's team this season");
+
+        teamGroup
             .MapPost("/drivers", AddDriverToTeamAsync)
             .WithName("Add Driver to Team")
             .WithDescription("Add a driver to the current user's team at a specific slot position");
@@ -252,6 +257,29 @@ public static class MeEndpoints
         }
 
         return Results.Ok(team);
+    }
+
+    private static async Task<IResult> GetMyTeamSummaryAsync(
+        ITeamService teamService,
+        IUserProfileService userProfileService,
+        ILogger logger
+    )
+    {
+        var user = await userProfileService.GetRequiredCurrentUserProfileAsync();
+
+        logger.LogDebug("Fetching team summary for user {UserId}", user.Id);
+
+        var summary = await teamService.GetTeamSummaryAsync(user.Id);
+        if (summary is null)
+        {
+            logger.LogWarning("User {UserId} has no team", user.Id);
+            return Results.Problem(
+                detail: "User has no team",
+                statusCode: StatusCodes.Status404NotFound
+            );
+        }
+
+        return Results.Ok(summary);
     }
 
     private static async Task<IResult> AddDriverToTeamAsync(

--- a/api/F1CompanionApi/Api/Endpoints/MeEndpoints.cs
+++ b/api/F1CompanionApi/Api/Endpoints/MeEndpoints.cs
@@ -290,7 +290,7 @@ public static class MeEndpoints
 
         logger.LogDebug("Fetching team summary for user {UserId}", user.Id);
 
-        var summary = await teamService.GetTeamSummaryAsync(user.Id);
+        var summary = await teamService.GetTeamSummaryForUserAsync(user.Id);
         if (summary is null)
         {
             logger.LogWarning("User {UserId} has no team", user.Id);

--- a/api/F1CompanionApi/Api/Mappers/MyLeagueStandingResponseMapper.cs
+++ b/api/F1CompanionApi/Api/Mappers/MyLeagueStandingResponseMapper.cs
@@ -1,0 +1,23 @@
+using F1CompanionApi.Api.Models;
+using F1CompanionApi.Data.Entities;
+
+namespace F1CompanionApi.Api.Mappers;
+
+public static class MyLeagueStandingResponseMapper
+{
+    public static MyLeagueStandingResponse ToResponseModel(
+        this LeagueTeam membership,
+        int totalTeams,
+        TeamLeagueStanding? latestStanding
+    )
+    {
+        return new MyLeagueStandingResponse
+        {
+            LeagueId = membership.LeagueId,
+            LeagueName = membership.League.Name,
+            TotalTeams = totalTeams,
+            Position = latestStanding?.Position,
+            TotalPoints = latestStanding?.TotalPoints,
+        };
+    }
+}

--- a/api/F1CompanionApi/Api/Mappers/TeamSummaryLastRaceResponseMapper.cs
+++ b/api/F1CompanionApi/Api/Mappers/TeamSummaryLastRaceResponseMapper.cs
@@ -1,0 +1,17 @@
+using F1CompanionApi.Api.Models;
+using F1CompanionApi.Data.Entities;
+
+namespace F1CompanionApi.Api.Mappers;
+
+public static class TeamSummaryLastRaceResponseMapper
+{
+    public static TeamSummaryLastRaceResponse ToResponseModel(this TeamRaceWeekendScore score)
+    {
+        return new TeamSummaryLastRaceResponse
+        {
+            Round = score.RaceWeekend.Round,
+            Name = score.RaceWeekend.Name,
+            TotalScore = score.TotalPoints,
+        };
+    }
+}

--- a/api/F1CompanionApi/Api/Mappers/TeamSummaryResponseMapper.cs
+++ b/api/F1CompanionApi/Api/Mappers/TeamSummaryResponseMapper.cs
@@ -1,0 +1,19 @@
+using F1CompanionApi.Api.Models;
+using F1CompanionApi.Data.Entities;
+
+namespace F1CompanionApi.Api.Mappers;
+
+public static class TeamSummaryResponseMapper
+{
+    public static TeamSummaryResponse ToResponseModel(
+        this IReadOnlyList<TeamRaceWeekendScore> scoredRaces,
+        TeamRaceWeekendScore? latest
+    )
+    {
+        return new TeamSummaryResponse
+        {
+            SeasonTotalPoints = latest is null ? null : scoredRaces.Sum(s => s.TotalPoints),
+            LastRace = latest?.ToResponseModel(),
+        };
+    }
+}

--- a/api/F1CompanionApi/Api/Models/MyLeagueStandingResponse.cs
+++ b/api/F1CompanionApi/Api/Models/MyLeagueStandingResponse.cs
@@ -1,0 +1,10 @@
+namespace F1CompanionApi.Api.Models;
+
+public class MyLeagueStandingResponse
+{
+    public required int LeagueId { get; set; }
+    public required string LeagueName { get; set; }
+    public required int TotalTeams { get; set; }
+    public int? Position { get; set; }
+    public int? TotalPoints { get; set; }
+}

--- a/api/F1CompanionApi/Api/Models/TeamSummaryLastRaceResponse.cs
+++ b/api/F1CompanionApi/Api/Models/TeamSummaryLastRaceResponse.cs
@@ -1,0 +1,8 @@
+namespace F1CompanionApi.Api.Models;
+
+public class TeamSummaryLastRaceResponse
+{
+    public required int Round { get; set; }
+    public required string Name { get; set; }
+    public required int TotalScore { get; set; }
+}

--- a/api/F1CompanionApi/Api/Models/TeamSummaryResponse.cs
+++ b/api/F1CompanionApi/Api/Models/TeamSummaryResponse.cs
@@ -1,0 +1,7 @@
+namespace F1CompanionApi.Api.Models;
+
+public class TeamSummaryResponse
+{
+    public int? SeasonTotalPoints { get; set; }
+    public TeamSummaryLastRaceResponse? LastRace { get; set; }
+}

--- a/api/F1CompanionApi/Domain/Services/LeagueStandingsService.cs
+++ b/api/F1CompanionApi/Domain/Services/LeagueStandingsService.cs
@@ -1,3 +1,4 @@
+using F1CompanionApi.Api.Mappers;
 using F1CompanionApi.Api.Models;
 using F1CompanionApi.Data;
 using F1CompanionApi.Data.Entities;
@@ -9,6 +10,7 @@ public interface ILeagueStandingsService
 {
     Task UpdateLeagueStandingsForRaceWeekendAsync(int raceWeekendId);
     Task<LeagueStandingsResponse?> GetLeagueStandingsAsync(int leagueId);
+    Task<IReadOnlyList<MyLeagueStandingResponse>> GetStandingsForUserAsync(int userId);
 }
 
 public class LeagueStandingsService : ILeagueStandingsService
@@ -173,6 +175,64 @@ public class LeagueStandingsService : ILeagueStandingsService
             LastScoredRaceWeekendName = latestScoredWeekend?.Name,
             Standings = LeagueStandingsBuilder.Build(league, currentStandings, priorStandings),
         };
+    }
+
+    /// <summary>
+    /// One row per league the caller's team belongs to, each carrying the caller's
+    /// latest-round position and total in that league. Position and totals are null
+    /// when the league has no scored round in the current season.
+    /// </summary>
+    /// <param name="userId">The authenticated user whose memberships are being summarized.</param>
+    public async Task<IReadOnlyList<MyLeagueStandingResponse>> GetStandingsForUserAsync(int userId)
+    {
+        _logger.LogDebug("Fetching standings for user {UserId}", userId);
+
+        var memberships = await _dbContext
+            .LeagueTeams.AsNoTracking()
+            .Include(lt => lt.League)
+            .Where(lt => lt.Team.UserId == userId)
+            .ToListAsync();
+
+        if (memberships.Count == 0)
+        {
+            return [];
+        }
+
+        var teamId = memberships[0].TeamId;
+        var leagueIds = memberships.Select(m => m.LeagueId).ToList();
+
+        var totalTeamsByLeague = await _dbContext
+            .LeagueTeams.Where(lt => leagueIds.Contains(lt.LeagueId))
+            .GroupBy(lt => lt.LeagueId)
+            .Select(g => new { LeagueId = g.Key, Count = g.Count() })
+            .ToDictionaryAsync(x => x.LeagueId, x => x.Count);
+
+        var currentSeason =
+            await _seasonService.GetCurrentSeasonAsync()
+            ?? throw new InvalidOperationException("No active season found.");
+
+        var latestByLeague = (
+            await _dbContext
+                .TeamLeagueStandings.AsNoTracking()
+                .Include(ls => ls.RaceWeekend)
+                .Where(ls =>
+                    ls.TeamId == teamId
+                    && leagueIds.Contains(ls.LeagueId)
+                    && ls.RaceWeekend.SeasonId == currentSeason.Id
+                )
+                .ToListAsync()
+        )
+            .GroupBy(ls => ls.LeagueId)
+            .ToDictionary(g => g.Key, g => g.OrderByDescending(s => s.RaceWeekend.Round).First());
+
+        return memberships
+            .Select(m =>
+                m.ToResponseModel(
+                    totalTeamsByLeague.GetValueOrDefault(m.LeagueId, 0),
+                    latestByLeague.GetValueOrDefault(m.LeagueId)
+                )
+            )
+            .ToList();
     }
 
     /// <summary>

--- a/api/F1CompanionApi/Domain/Services/TeamService.cs
+++ b/api/F1CompanionApi/Domain/Services/TeamService.cs
@@ -12,7 +12,7 @@ public interface ITeamService
 {
     Task<TeamResponse> CreateTeamAsync(CreateTeamRequest request, int userId);
     Task<TeamDetailsResponse?> GetUserTeamAsync(int userId);
-    Task<TeamSummaryResponse?> GetTeamSummaryAsync(int userId);
+    Task<TeamSummaryResponse?> GetTeamSummaryForUserAsync(int userId);
     Task AddDriverToTeamAsync(int teamId, int driverId, int slotPosition, int userId);
     Task RemoveDriverFromTeamAsync(int teamId, int slotPosition, int userId);
     Task AddConstructorToTeamAsync(int teamId, int constructorId, int slotPosition, int userId);
@@ -124,7 +124,7 @@ public class TeamService : ITeamService
         return team.ToDetailsResponseModel(captainDriverId);
     }
 
-    public async Task<TeamSummaryResponse?> GetTeamSummaryAsync(int userId)
+    public async Task<TeamSummaryResponse?> GetTeamSummaryForUserAsync(int userId)
     {
         _logger.LogDebug("Fetching team summary for user {UserId}", userId);
 

--- a/api/F1CompanionApi/Domain/Services/TeamService.cs
+++ b/api/F1CompanionApi/Domain/Services/TeamService.cs
@@ -12,6 +12,7 @@ public interface ITeamService
 {
     Task<TeamResponse> CreateTeamAsync(CreateTeamRequest request, int userId);
     Task<TeamDetailsResponse?> GetUserTeamAsync(int userId);
+    Task<TeamSummaryResponse?> GetTeamSummaryAsync(int userId);
     Task AddDriverToTeamAsync(int teamId, int driverId, int slotPosition, int userId);
     Task RemoveDriverFromTeamAsync(int teamId, int slotPosition, int userId);
     Task AddConstructorToTeamAsync(int teamId, int constructorId, int slotPosition, int userId);
@@ -23,20 +24,24 @@ public class TeamService : ITeamService
 {
     private readonly ApplicationDbContext _dbContext;
     private readonly IRaceWeekendService _raceWeekendService;
+    private readonly ISeasonService _seasonService;
     private readonly ILogger<TeamService> _logger;
 
     public TeamService(
         ApplicationDbContext dbContext,
         IRaceWeekendService raceWeekendService,
+        ISeasonService seasonService,
         ILogger<TeamService> logger
     )
     {
         ArgumentNullException.ThrowIfNull(dbContext);
         ArgumentNullException.ThrowIfNull(raceWeekendService);
+        ArgumentNullException.ThrowIfNull(seasonService);
         ArgumentNullException.ThrowIfNull(logger);
 
         _dbContext = dbContext;
         _raceWeekendService = raceWeekendService;
+        _seasonService = seasonService;
         _logger = logger;
     }
 
@@ -117,6 +122,30 @@ public class TeamService : ITeamService
                 .FirstOrDefaultAsync();
 
         return team.ToDetailsResponseModel(captainDriverId);
+    }
+
+    public async Task<TeamSummaryResponse?> GetTeamSummaryAsync(int userId)
+    {
+        _logger.LogDebug("Fetching team summary for user {UserId}", userId);
+
+        var team = await _dbContext.Teams.FirstOrDefaultAsync(t => t.UserId == userId);
+        if (team is null)
+        {
+            return null;
+        }
+
+        var currentSeason =
+            await _seasonService.GetCurrentSeasonAsync()
+            ?? throw new InvalidOperationException("No active season found.");
+
+        var scoredRaces = await _dbContext
+            .TeamRaceWeekendScores.AsNoTracking()
+            .Include(s => s.RaceWeekend)
+            .Where(s => s.TeamId == team.Id && s.RaceWeekend.SeasonId == currentSeason.Id)
+            .ToListAsync();
+
+        var latest = scoredRaces.OrderByDescending(s => s.RaceWeekend.Round).FirstOrDefault();
+        return scoredRaces.ToResponseModel(latest);
     }
 
     public async Task AddDriverToTeamAsync(int teamId, int driverId, int slotPosition, int userId)

--- a/docs/plans/205-me-team-summary-and-standings.md
+++ b/docs/plans/205-me-team-summary-and-standings.md
@@ -84,35 +84,36 @@ Service is a thin EF query + trivial in-memory pick; no extractable pure logic. 
 
 ---
 
-## Commit 2 — `GET /me/standings`
+## Commit 2 — `GET /me/standings` *(implemented)*
 
 ### Files
 
 - `api/F1CompanionApi/Api/Models/MyLeagueStandingResponse.cs` (new) — `{ required int LeagueId, required string LeagueName, required int TotalTeams, int? Position, int? TotalPoints }`.
 - `api/F1CompanionApi/Api/Mappers/MyLeagueStandingResponseMapper.cs` (new) — `(this LeagueTeam membership, int totalTeams, TeamLeagueStanding? latestStanding) → MyLeagueStandingResponse`. Pure shape transformation; service pre-computes `totalTeams` and `latestStanding`.
-- `api/F1CompanionApi/Domain/Services/LeagueStandingsService.cs` + `ILeagueStandingsService.cs` — add `Task<IReadOnlyList<MyLeagueStandingResponse>> GetUserStandingsAsync(int userId)`.
+- `api/F1CompanionApi/Domain/Services/LeagueStandingsService.cs` + `ILeagueStandingsService.cs` — add `Task<IReadOnlyList<MyLeagueStandingResponse>> GetStandingsForUserAsync(int userId)`.
 - `api/F1CompanionApi/Api/Endpoints/MeEndpoints.cs` — register `meGroup.MapGet("/standings", ...)` + handler.
 - `api/F1CompanionApi.IntegrationTests/Scenarios/MeStandingsTests.cs` (new) — integration tests.
 
 ### Service shape
 
-Resolve team, league memberships, total-teams-per-league, and latest standing per (team, league) within the current season. Materialise standings then group in memory — bounded by `leagues-per-user × races-per-season` (max ~15 × ~24 ≈ 360 rows).
+Resolve league memberships, total-teams-per-league, and latest standing per (team, league) within the current season. Materialise standings then group in memory — bounded by `leagues-per-user × races-per-season` (max ~15 × ~24 ≈ 360 rows). Membership query joins through `lt.Team.UserId == userId`, so the no-team case collapses naturally into an empty memberships result — no separate Teams lookup or no-team guard.
 
 ```csharp
-public async Task<IReadOnlyList<MyLeagueStandingResponse>> GetUserStandingsAsync(int userId)
+public async Task<IReadOnlyList<MyLeagueStandingResponse>> GetStandingsForUserAsync(int userId)
 {
     _logger.LogDebug("Fetching standings for user {UserId}", userId);
-
-    var team = await _dbContext.Teams.FirstOrDefaultAsync(t => t.UserId == userId);
-    if (team is null) return Array.Empty<MyLeagueStandingResponse>();
 
     var memberships = await _dbContext
         .LeagueTeams.AsNoTracking()
         .Include(lt => lt.League)
-        .Where(lt => lt.TeamId == team.Id)
+        .Where(lt => lt.Team.UserId == userId)
         .ToListAsync();
-    if (memberships.Count == 0) return Array.Empty<MyLeagueStandingResponse>();
+    if (memberships.Count == 0)
+    {
+        return [];
+    }
 
+    var teamId = memberships[0].TeamId;
     var leagueIds = memberships.Select(m => m.LeagueId).ToList();
 
     var totalTeamsByLeague = await _dbContext
@@ -128,7 +129,7 @@ public async Task<IReadOnlyList<MyLeagueStandingResponse>> GetUserStandingsAsync
     var latestByLeague = (
         await _dbContext.TeamLeagueStandings.AsNoTracking()
             .Include(ls => ls.RaceWeekend)
-            .Where(ls => ls.TeamId == team.Id
+            .Where(ls => ls.TeamId == teamId
                       && leagueIds.Contains(ls.LeagueId)
                       && ls.RaceWeekend.SeasonId == currentSeason.Id)
             .ToListAsync()
@@ -150,7 +151,7 @@ public async Task<IReadOnlyList<MyLeagueStandingResponse>> GetUserStandingsAsync
 Collection endpoint — always returns a list, no null-mapping needed:
 
 ```csharp
-return Results.Ok(await leagueStandingsService.GetUserStandingsAsync(user.Id));
+return Results.Ok(await leagueStandingsService.GetStandingsForUserAsync(user.Id));
 ```
 
 ### Tests
@@ -158,8 +159,10 @@ return Results.Ok(await leagueStandingsService.GetUserStandingsAsync(user.Id));
 Same reasoning as Commit 1 — thin EF + in-memory grouping. All tests at the HTTP seam. Distinct failure modes only:
 
 - **Auth boundary** — unauthenticated → 401.
-- **Empty state** — authed caller with no team → `[]`. (Empty memberships collapse to the same path; one test covers both since the early-returns share a shape.)
-- **Happy path / multi-league fan-out** — caller's team in three leagues with mixed state: League A has multiple current-season scored rounds (asserts `position`/`totalPoints` reflect the latest round); League B is a member but has no scored race in the current season (asserts null fields while still listing the league); League C has a scored standing only in a *prior* season (asserts current-season WHERE clause excludes it, row remains listed with nulls). Each league has additional non-caller teams so `totalTeams` is exercised end-to-end.
+- **Empty state** — authed caller with no team → `[]`. (After the membership-via-`Team.UserId` refactor, no-team and no-memberships share a single code path; one test covers both.)
+- **League with scored rounds** — multiple current-season scored rounds inserted out of round order; asserts `Position`/`TotalPoints` come from the latest round (not insertion order) and `TotalTeams` reflects all league members.
+- **League with no scored round** — caller is a member but the league has no standings; asserts the league still lists with null `Position`/`TotalPoints`.
+- **Prior-season standing only** — caller has a standing in a prior season but none in the current season; asserts the current-season filter excludes it while the league row still lists with null fields.
 
 ---
 

--- a/docs/plans/205-me-team-summary-and-standings.md
+++ b/docs/plans/205-me-team-summary-and-standings.md
@@ -1,0 +1,186 @@
+# Plan: `/me/team/summary` and `/me/standings` endpoints (issue #205)
+
+## Context
+
+The Home page needs two aggregate reads to drive the score cards and the my-leagues table. Today no endpoint surfaces season-total points, the latest scored race for the caller's team, or per-league position across all of the caller's memberships. The composition is shaped specifically for the Home page: a single team-summary blob plus one row per league membership.
+
+Both endpoints are authed and scoped to the authed caller's team in the current season. They follow the established `/me/*` patterns: group-level `.RequireAuthorization()`, service-backed handlers, mapper extensions per source entity, response DTOs in `Api/Models/`.
+
+**Decisions:**
+
+- **No team** → `404 Not Found` for `/me/team/summary`; `[]` for `/me/standings`. The summary represents a single resource (the team's season summary) that doesn't exist without a team; standings is a collection that's legitimately empty when the caller has no memberships.
+- **No current season** (offseason) → `?? throw new InvalidOperationException("No active season found.")`. Matches `LeagueStandingsService.cs:147` precedent. Broader offseason UX is a separate product decision (see research synthesis: F1 Fantasy locks for ~3.5 months; FPL keeps last-season data as a read-only "trophy room").
+- **Service placement** → extend `TeamService` and `LeagueStandingsService`. Each will need `ISeasonService` injected if it doesn't have it already.
+
+---
+
+## Commit 1 — `GET /me/team/summary` *(implemented)*
+
+### Files
+
+- `api/F1CompanionApi/Api/Models/TeamSummaryResponse.cs` — `{ int? SeasonTotalPoints, TeamSummaryLastRaceResponse? LastRace }`.
+- `api/F1CompanionApi/Api/Models/TeamSummaryLastRaceResponse.cs` — `{ required int Round, required string Name, required int TotalScore }`.
+- `api/F1CompanionApi/Api/Mappers/TeamSummaryResponseMapper.cs` — `(this IReadOnlyList<TeamRaceWeekendScore>, TeamRaceWeekendScore? latest) → TeamSummaryResponse`.
+- `api/F1CompanionApi/Api/Mappers/TeamSummaryLastRaceResponseMapper.cs` — `(this TeamRaceWeekendScore) → TeamSummaryLastRaceResponse`.
+- `api/F1CompanionApi/Domain/Services/TeamService.cs` + `ITeamService.cs` — add `Task<TeamSummaryResponse?> GetTeamSummaryAsync(int userId)`; inject `ISeasonService`.
+- `api/F1CompanionApi/Api/Endpoints/MeEndpoints.cs` — register `teamGroup.MapGet("/summary", ...)` + handler.
+- `api/F1CompanionApi.IntegrationTests/Scenarios/MeTeamSummaryTests.cs` — integration tests.
+- `api/F1CompanionApi.UnitTests/Services/TeamServiceTests.cs` — update constructor wiring to include new `ISeasonService` mock.
+
+### Mapper split (container/child precedent)
+
+`TeamSummaryResponse` is a container DTO; `TeamSummaryLastRaceResponse` is its nested child. Codebase convention for container/child is one mapper file per source entity, mirroring `TeamResponseMapper` (Team), `TeamDriverResponseMapper` (TeamDriver), `TeamConstructorResponseMapper` (TeamConstructor). The aggregate mapper accepts a pre-selected `latest` so selection logic stays in the service; the mapper is decision-free.
+
+### Service shape
+
+```csharp
+public async Task<TeamSummaryResponse?> GetTeamSummaryAsync(int userId)
+{
+    _logger.LogDebug("Fetching team summary for user {UserId}", userId);
+
+    var team = await _dbContext.Teams.FirstOrDefaultAsync(t => t.UserId == userId);
+    if (team is null) return null;  // handler → 404
+
+    var currentSeason =
+        await _seasonService.GetCurrentSeasonAsync()
+        ?? throw new InvalidOperationException("No active season found.");
+
+    var scoredRaces = await _dbContext
+        .TeamRaceWeekendScores.AsNoTracking()
+        .Include(s => s.RaceWeekend)
+        .Where(s => s.TeamId == team.Id && s.RaceWeekend.SeasonId == currentSeason.Id)
+        .ToListAsync();
+
+    var latest = scoredRaces.OrderByDescending(s => s.RaceWeekend.Round).FirstOrDefault();
+    return scoredRaces.ToResponseModel(latest);
+}
+```
+
+### Handler shape
+
+Matches `SeasonEndpoints.GetCurrentSeasonAsync` / `GetSeasonByIdAsync` precedent: null-check → `LogWarning` → `Results.Problem(detail:..., statusCode: Status404NotFound)`.
+
+```csharp
+var summary = await teamService.GetTeamSummaryAsync(user.Id);
+if (summary is null)
+{
+    logger.LogWarning("User {UserId} has no team", user.Id);
+    return Results.Problem(
+        detail: "User has no team",
+        statusCode: StatusCodes.Status404NotFound
+    );
+}
+return Results.Ok(summary);
+```
+
+### Tests
+
+Service is a thin EF query + trivial in-memory pick; no extractable pure logic. All tests at the HTTP seam via `IntegrationTestBase` + `CreateAuthenticatedAsync` + `TestDataBuilder`. Distinct failure modes only:
+
+- **Auth boundary** — unauthenticated → 401.
+- **No team** — authed caller with no team → 404.
+- **Team but no scored races** — populated response with null fields. Different EF code path from "no team," so warrants its own test.
+- **Happy path** — multiple current-season scored rounds + one prior-season race seeded to verify the season WHERE clause. Asserts sum, latest-round pick by `Round` (not insertion or `RaceDate`), and prior-season exclusion in a single fixture.
+
+---
+
+## Commit 2 — `GET /me/standings`
+
+### Files
+
+- `api/F1CompanionApi/Api/Models/MyLeagueStandingResponse.cs` (new) — `{ required int LeagueId, required string LeagueName, required int TotalTeams, int? Position, int? TotalPoints }`.
+- `api/F1CompanionApi/Api/Mappers/MyLeagueStandingResponseMapper.cs` (new) — `(this LeagueTeam membership, int totalTeams, TeamLeagueStanding? latestStanding) → MyLeagueStandingResponse`. Pure shape transformation; service pre-computes `totalTeams` and `latestStanding`.
+- `api/F1CompanionApi/Domain/Services/LeagueStandingsService.cs` + `ILeagueStandingsService.cs` — add `Task<IReadOnlyList<MyLeagueStandingResponse>> GetUserStandingsAsync(int userId)`.
+- `api/F1CompanionApi/Api/Endpoints/MeEndpoints.cs` — register `meGroup.MapGet("/standings", ...)` + handler.
+- `api/F1CompanionApi.IntegrationTests/Scenarios/MeStandingsTests.cs` (new) — integration tests.
+
+### Service shape
+
+Resolve team, league memberships, total-teams-per-league, and latest standing per (team, league) within the current season. Materialise standings then group in memory — bounded by `leagues-per-user × races-per-season` (max ~15 × ~24 ≈ 360 rows).
+
+```csharp
+public async Task<IReadOnlyList<MyLeagueStandingResponse>> GetUserStandingsAsync(int userId)
+{
+    _logger.LogDebug("Fetching standings for user {UserId}", userId);
+
+    var team = await _dbContext.Teams.FirstOrDefaultAsync(t => t.UserId == userId);
+    if (team is null) return Array.Empty<MyLeagueStandingResponse>();
+
+    var memberships = await _dbContext
+        .LeagueTeams.AsNoTracking()
+        .Include(lt => lt.League)
+        .Where(lt => lt.TeamId == team.Id)
+        .ToListAsync();
+    if (memberships.Count == 0) return Array.Empty<MyLeagueStandingResponse>();
+
+    var leagueIds = memberships.Select(m => m.LeagueId).ToList();
+
+    var totalTeamsByLeague = await _dbContext
+        .LeagueTeams.Where(lt => leagueIds.Contains(lt.LeagueId))
+        .GroupBy(lt => lt.LeagueId)
+        .Select(g => new { LeagueId = g.Key, Count = g.Count() })
+        .ToDictionaryAsync(x => x.LeagueId, x => x.Count);
+
+    var currentSeason =
+        await _seasonService.GetCurrentSeasonAsync()
+        ?? throw new InvalidOperationException("No active season found.");
+
+    var latestByLeague = (
+        await _dbContext.TeamLeagueStandings.AsNoTracking()
+            .Include(ls => ls.RaceWeekend)
+            .Where(ls => ls.TeamId == team.Id
+                      && leagueIds.Contains(ls.LeagueId)
+                      && ls.RaceWeekend.SeasonId == currentSeason.Id)
+            .ToListAsync()
+    )
+        .GroupBy(ls => ls.LeagueId)
+        .ToDictionary(g => g.Key, g => g.OrderByDescending(s => s.RaceWeekend.Round).First());
+
+    return memberships
+        .Select(m => m.ToResponseModel(
+            totalTeamsByLeague.GetValueOrDefault(m.LeagueId, 0),
+            latestByLeague.GetValueOrDefault(m.LeagueId)
+        ))
+        .ToList();
+}
+```
+
+### Handler shape
+
+Collection endpoint — always returns a list, no null-mapping needed:
+
+```csharp
+return Results.Ok(await leagueStandingsService.GetUserStandingsAsync(user.Id));
+```
+
+### Tests
+
+Same reasoning as Commit 1 — thin EF + in-memory grouping. All tests at the HTTP seam. Distinct failure modes only:
+
+- **Auth boundary** — unauthenticated → 401.
+- **Empty state** — authed caller with no team → `[]`. (Empty memberships collapse to the same path; one test covers both since the early-returns share a shape.)
+- **Happy path / multi-league fan-out** — caller's team in three leagues with mixed state: League A has multiple current-season scored rounds (asserts `position`/`totalPoints` reflect the latest round); League B is a member but has no scored race in the current season (asserts null fields while still listing the league); League C has a scored standing only in a *prior* season (asserts current-season WHERE clause excludes it, row remains listed with nulls). Each league has additional non-caller teams so `totalTeams` is exercised end-to-end.
+
+---
+
+## Verification
+
+From repo root:
+
+```bash
+npm run api:test:integration   # Testcontainers Postgres — Docker Desktop required
+npm run api:test:unit          # sanity
+npm run api:format:check       # CSharpier + dotnet format
+npm run api:build              # warns-as-errors
+```
+
+Manual smoke once both commits land:
+
+```bash
+npm run api:watch
+# in another terminal, with a valid Supabase JWT in $TOKEN:
+curl -H "Authorization: Bearer $TOKEN" http://localhost:5077/api/me/team/summary
+curl -H "Authorization: Bearer $TOKEN" http://localhost:5077/api/me/standings
+```
+
+Expected: shapes match the issue's documented JSON; nullable fields serialise as `null` when empty; `/me/team/summary` returns 404 (not 200-null) when the caller has no team.


### PR DESCRIPTION
Closes #205.

## Summary
- `GET /me/team/summary` — returns `{ seasonTotalPoints, lastRace }` for the authed caller's current-season team; 404 when the caller has no team, nullable fields when no scored race yet.
- `GET /me/standings` — returns one row per league membership with `{ leagueId, leagueName, totalTeams, position, totalPoints }`; nullable position/points when no scored round yet in that league, `[]` when the caller has no memberships.
- Both endpoints sit under the existing `/me/*` group with `RequireAuthorization()` and follow the established service + mapper + DTO layout.

## Test plan
- [x] `npm run api:test:unit` (473 passed)
- [x] `npm run api:test:integration` (39 passed) — Testcontainers Postgres covers auth boundary, no-team, no-scored-races, prior-season exclusion, multi-league fan-out
- [x] `npm run api:format:check`
- [x] `npm run api:build` (0 warnings, 0 errors)
- [x] Manual smoke against `localhost:5077` with a valid Supabase JWT