### PR TITLE
Cap the E2E job at 15 minutes so the Playwright install hang fails fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
   e2e:
     name: E2E
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## What this does

Adds `timeout-minutes: 15` to the E2E job so a hung run fails fast instead of running to GitHub's 6-hour default.

## Why not the ubuntu-22.04 pin (this branch's original intent)

The GitHub `ubuntu-24.04` image (20260525 cycle) hangs while extracting the Chromium build that `playwright install` downloads — it finishes the ~170 MB download in ~2s, then extraction hangs until the job is killed. Pinning to `ubuntu-22.04` was tried on this branch and **hung identically** (an 18-minute install step before the cap fired): the same image cycle landed on both LTS images, and our hang is in Playwright's own bundled Chromium, unrelated to the system Chrome that upstream actions/runner-images#14169 tracks.

So the pin is dropped. This PR keeps only the fail-fast cap, which is good hygiene regardless.

## The 15-minute value

Across 84 healthy E2E runs: p50 4m35s, p95 5m47s, worst 12m07s. 15m clears the worst healthy run with margin while killing a hang ~24x faster than the 6-hour default.

## The E2E check stays red — on purpose

E2E remains a required check. It will flip green on its own once a fixed runner image rolls out, which is the signal that the upstream regression cleared. Until then, run `npm run e2e` locally before merging. Tracked in #216.