### PR TITLE
Land all post-auth flows on /

### DIFF
--- a/e2e/fixtures/session.ts
+++ b/e2e/fixtures/session.ts
@@ -4,9 +4,9 @@ import type { TestUser } from './auth';
 
 /**
  * Signs in via the real UI form and waits for the sign-in navigation to
- * settle. Callers still decide whether to assert the landing URL
- * (`/leagues`, `/create-team`, a preserved `redirect` target) — the wait
- * here only guarantees the session is usable, not where it landed.
+ * settle. Callers decide whether to assert the landing URL
+ * (`/` or a preserved `redirect` target) — the wait here only guarantees
+ * the session is usable, not where it landed.
  */
 export async function signInAs(page: Page, user: TestUser): Promise<void> {
   await page.goto('/sign-in');

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -15,7 +15,7 @@ test.describe('auth', () => {
     await clearAll();
   });
 
-  test('signs in with real credentials and lands on the leagues dashboard', async ({ page }) => {
+  test('signs in with real credentials and lands on home', async ({ page }) => {
     const user = await createTestUser();
     const season = await seedCurrentSeason();
     const grid = await seedMinimalGrid({ seasonId: season.id });
@@ -26,9 +26,9 @@ test.describe('auth', () => {
 
     await signInAs(page, user);
 
-    await expect(page).toHaveURL('/leagues');
-    await expect(page.getByRole('heading', { name: 'My Leagues' })).toBeVisible();
-    await expect(page.getByText(user.displayName)).toBeVisible();
+    await expect(page).toHaveURL('/');
+    await expect(page.getByText(/riding solo/i)).toBeVisible();
+    await expect(page.getByText(`Welcome back, ${user.displayName}`)).toBeVisible();
   });
 
   test('redirects unauthenticated visits to /my-team back to the landing page', async ({
@@ -245,12 +245,16 @@ test.describe('auth', () => {
     });
 
     await signInAs(page, user);
-    await expect(page).toHaveURL('/leagues');
+    await expect(page).toHaveURL('/');
 
     await page.getByRole('button', { name: 'Account menu' }).click();
     await page.getByRole('menuitem', { name: 'Sign Out' }).click();
 
+    // Sign-in and sign-out both land on `/`, so the URL can't confirm the
+    // session cleared. The landing page (with its Sign In button) renders
+    // only when logged out — wait for it before probing a protected route.
     await expect(page).toHaveURL('/');
+    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
 
     await page.goto('/my-team');
     await expect(page).toHaveURL('/');

--- a/e2e/tests/avatar.spec.ts
+++ b/e2e/tests/avatar.spec.ts
@@ -22,9 +22,6 @@ test.describe('avatar', () => {
     const user = await createTestUser();
 
     await signInAs(page, user);
-    // Teamless user lands here; irrelevant to this test, just a sanity
-    // beat on the post-sign-in state.
-    await expect(page).toHaveURL('/create-team');
 
     await page.goto('/account');
     await expect(page.getByRole('heading', { name: 'Profile Information' })).toBeVisible();

--- a/e2e/tests/league.spec.ts
+++ b/e2e/tests/league.spec.ts
@@ -31,8 +31,8 @@ test.describe('league', () => {
     const contextA = await browser.newContext();
     const pageA = await contextA.newPage();
     await signInAs(pageA, userA);
-    await expect(pageA).toHaveURL('/leagues');
 
+    await pageA.goto('/leagues');
     await pageA.getByRole('button', { name: 'Create League' }).click();
     const createDialog = pageA.getByRole('dialog', { name: 'Create League' });
     await createDialog.getByLabel('League Name').fill(leagueName);
@@ -51,7 +51,6 @@ test.describe('league', () => {
     const contextB = await browser.newContext();
     const pageB = await contextB.newPage();
     await signInAs(pageB, userB);
-    await expect(pageB).toHaveURL('/leagues');
 
     await pageB.goto(inviteUrl);
     await expect(pageB.getByText(leagueName)).toBeVisible();
@@ -80,7 +79,6 @@ test.describe('league', () => {
     const contextB = await browser.newContext();
     const pageB = await contextB.newPage();
     await signInAs(pageB, userB);
-    await expect(pageB).toHaveURL('/leagues');
 
     await pageB.goto('/browse-leagues');
 
@@ -115,7 +113,6 @@ test.describe('league', () => {
     const teamName = `Team ${randomUUID().slice(0, 8)}`;
 
     await signInAs(page, joiner);
-    await expect(page).toHaveURL('/create-team');
 
     await page.goto(joinPath);
     await expect(page.getByText(leagueName)).toBeVisible();

--- a/e2e/tests/team.spec.ts
+++ b/e2e/tests/team.spec.ts
@@ -17,8 +17,8 @@ test.describe('team', () => {
     const teamName = `Team ${randomUUID().slice(0, 8)}`;
 
     await signInAs(page, user);
-    await expect(page).toHaveURL('/create-team');
 
+    await page.goto('/create-team');
     await page.getByLabel('Team Name').fill(teamName);
     await page.locator('form').getByRole('button', { name: 'Create Team' }).click();
 
@@ -49,7 +49,6 @@ test.describe('team', () => {
     });
 
     await signInAs(page, user);
-    await expect(page).toHaveURL('/leagues');
 
     await page.goto('/my-team');
     await expect(page.getByText(`${alex.firstName} ${alex.lastName}`)).toBeVisible();
@@ -110,7 +109,6 @@ test.describe('team', () => {
     });
 
     await signInAs(page, user);
-    await expect(page).toHaveURL('/leagues');
 
     await page.goto('/my-team');
 

--- a/web/src/components/auth/ConfirmEmailNotice/ConfirmEmailNotice.tsx
+++ b/web/src/components/auth/ConfirmEmailNotice/ConfirmEmailNotice.tsx
@@ -1,9 +1,8 @@
 import { LoadingButton } from '@/components/LoadingButton/LoadingButton';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { useAuth } from '@/hooks/useAuth';
-import { defaultAuthedDestination } from '@/lib/router-context';
 import { supabase } from '@/lib/supabase';
-import { useNavigate, useRouteContext, useSearch } from '@tanstack/react-router';
+import { useNavigate, useSearch } from '@tanstack/react-router';
 import { useState } from 'react';
 
 function resolveNextDestination(next: string | undefined): string | null {
@@ -20,7 +19,6 @@ function resolveNextDestination(next: string | undefined): string | null {
 export function ConfirmEmailNotice() {
   const navigate = useNavigate();
   const search = useSearch({ from: '/auth/confirm' });
-  const { teamContext } = useRouteContext({ from: '/auth/confirm' });
   const { user } = useAuth();
   const [submitting, setSubmitting] = useState(false);
 
@@ -44,7 +42,7 @@ export function ConfirmEmailNotice() {
     }
 
     const internalNext = resolveNextDestination(search.next);
-    const destination = internalNext ?? defaultAuthedDestination(teamContext);
+    const destination = internalNext ?? '/';
     await navigate({ to: destination, replace: true });
   };
 

--- a/web/src/components/auth/SignInForm/SignInForm.test.tsx
+++ b/web/src/components/auth/SignInForm/SignInForm.test.tsx
@@ -108,4 +108,17 @@ describe('SignInForm', () => {
       expect(mockNavigate).toHaveBeenCalledWith({ to: '/team/123' });
     });
   });
+
+  it('navigates to / when no redirect search parameter is provided', async () => {
+    signInMock.mockResolvedValueOnce(undefined);
+    mockUseSearch.mockReturnValue({});
+    render(<SignInForm />);
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'user@example.com' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'password123' } });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({ to: '/' });
+    });
+  });
 });

--- a/web/src/components/auth/SignInForm/SignInForm.tsx
+++ b/web/src/components/auth/SignInForm/SignInForm.tsx
@@ -33,7 +33,7 @@ export function SignInForm() {
       if (search.redirect) {
         await navigate({ to: search.redirect });
       } else {
-        await navigate({ to: '/leagues' });
+        await navigate({ to: '/' });
       }
       completeAuthTransition();
     } catch (error) {

--- a/web/src/lib/router-context.ts
+++ b/web/src/lib/router-context.ts
@@ -24,9 +24,3 @@ export interface RouterContext {
 
   currentSeason: Season | null;
 }
-
-export function defaultAuthedDestination(
-  teamContext: Pick<RouterContext['teamContext'], 'hasTeam'>,
-): '/leagues' | '/create-team' {
-  return teamContext.hasTeam ? '/leagues' : '/create-team';
-}

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -13,7 +13,7 @@ import { SignUpForm } from '@/components/auth/SignUpForm/SignUpForm';
 import type { Team as TeamType } from '@/contracts/Team';
 import type { UserProfile } from '@/contracts/UserProfile';
 import { requireAuth, requireNoTeam, requireTeam } from '@/lib/route-guards';
-import { type RouterContext, defaultAuthedDestination } from '@/lib/router-context';
+import type { RouterContext } from '@/lib/router-context';
 import { getAvailableLeagues, getLeagueById, getMyLeagues } from '@/services/leagueService';
 import { getLeagueStandings, getMyStandings } from '@/services/standingsService';
 import { getMyTeam, getTeamById, getTeamSummary } from '@/services/teamService';
@@ -171,7 +171,7 @@ const unauthenticatedLayoutRoute = createRoute({
   beforeLoad: ({ context }) => {
     if (context.auth.user) {
       throw redirect({
-        to: defaultAuthedDestination(context.teamContext),
+        to: '/',
         replace: true,
       });
     }
@@ -257,7 +257,7 @@ const authConfirmRoute = createRoute({
     if (!search.token_hash || !search.type) {
       if (context.auth.user) {
         throw redirect({
-          to: defaultAuthedDestination(context.teamContext),
+          to: '/',
           replace: true,
         });
       }

--- a/web/src/tests/integration/auth-confirm.integration.test.tsx
+++ b/web/src/tests/integration/auth-confirm.integration.test.tsx
@@ -1,11 +1,10 @@
 import { ConfirmEmailNotice } from '@/components/auth/ConfirmEmailNotice/ConfirmEmailNotice';
-import { type RouterContext, defaultAuthedDestination } from '@/lib/router-context';
+import type { RouterContext } from '@/lib/router-context';
 import { supabase } from '@/lib/supabase';
 import {
   buildStubRoute,
   createAuthedAuth,
   createBaseRouterContext,
-  createTeamContext,
   createUnauthAuth,
   renderWithRouter,
 } from '@/tests/test-utils';
@@ -67,7 +66,7 @@ function buildAuthConfirmRouteTree() {
       if (!search.token_hash || !search.type) {
         if (context.auth.user) {
           throw redirect({
-            to: defaultAuthedDestination(context.teamContext),
+            to: '/',
             replace: true,
           });
         }
@@ -84,26 +83,16 @@ function buildAuthConfirmRouteTree() {
     component: SignUpStub,
   });
 
-  const leaguesRoute = buildStubRoute(rootRoute, {
-    path: '/leagues',
-    heading: 'Leagues Stub',
-  });
-  const createTeamRoute = buildStubRoute(rootRoute, {
-    path: '/create-team',
-    heading: 'Create Team Stub',
+  const homeRoute = buildStubRoute(rootRoute, {
+    path: '/',
+    heading: 'Home Stub',
   });
   const joinInviteRoute = buildStubRoute(rootRoute, {
     path: '/join/$token',
     heading: 'Join Invite Stub',
   });
 
-  return rootRoute.addChildren([
-    authConfirmRoute,
-    signUpRoute,
-    leaguesRoute,
-    createTeamRoute,
-    joinInviteRoute,
-  ]);
+  return rootRoute.addChildren([authConfirmRoute, signUpRoute, homeRoute, joinInviteRoute]);
 }
 
 function mockVerifyOtpSuccess() {
@@ -125,16 +114,15 @@ describe('/auth/confirm route', () => {
     vi.mocked(supabase.auth.verifyOtp).mockReset();
   });
 
-  it('verifies the token on the Continue click and navigates to /create-team for a no-team user', async () => {
+  it('verifies the token on the Continue click and navigates to / after verification', async () => {
     mockVerifyOtpSuccess();
-    const teamContext = createTeamContext({ hasTeam: false });
     const user = userEvent.setup();
 
     renderWithRouter({
       routeTree: buildAuthConfirmRouteTree(),
       initialEntry: '/auth/confirm?token_hash=abc123&type=signup',
       auth: createUnauthAuth(),
-      routerContext: createBaseRouterContext({ teamContext }),
+      routerContext: createBaseRouterContext(),
     });
 
     expect(await screen.findByRole('heading', { name: /confirm your email/i })).toBeInTheDocument();
@@ -146,29 +134,11 @@ describe('/auth/confirm route', () => {
       token_hash: 'abc123',
       type: 'signup',
     });
-    expect(await screen.findByRole('heading', { name: 'Create Team Stub' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Home Stub' })).toBeInTheDocument();
   });
 
-  it('navigates to /leagues after verification when the user has a team', async () => {
+  it('navigates to the same-origin next param, overriding the default', async () => {
     mockVerifyOtpSuccess();
-    const teamContext = createTeamContext({ myTeamId: 1, hasTeam: true });
-    const user = userEvent.setup();
-
-    renderWithRouter({
-      routeTree: buildAuthConfirmRouteTree(),
-      initialEntry: '/auth/confirm?token_hash=abc123&type=signup',
-      auth: createUnauthAuth(),
-      routerContext: createBaseRouterContext({ teamContext }),
-    });
-
-    await user.click(await screen.findByRole('button', { name: /continue/i }));
-
-    expect(await screen.findByRole('heading', { name: 'Leagues Stub' })).toBeInTheDocument();
-  });
-
-  it('navigates to the same-origin next param, overriding the team-state default', async () => {
-    mockVerifyOtpSuccess();
-    const teamContext = createTeamContext({ myTeamId: 1, hasTeam: true });
     const user = userEvent.setup();
 
     const sameOriginNext = `${window.location.origin}/join/abc`;
@@ -178,7 +148,7 @@ describe('/auth/confirm route', () => {
         sameOriginNext,
       )}`,
       auth: createUnauthAuth(),
-      routerContext: createBaseRouterContext({ teamContext }),
+      routerContext: createBaseRouterContext(),
     });
 
     await user.click(await screen.findByRole('button', { name: /continue/i }));
@@ -232,23 +202,20 @@ describe('/auth/confirm route', () => {
     expect(supabase.auth.verifyOtp).not.toHaveBeenCalled();
   });
 
-  it('redirects a signed-in visitor with a team and no token_hash to /leagues', async () => {
-    const teamContext = createTeamContext({ myTeamId: 1, hasTeam: true });
-
+  it('redirects a signed-in visitor with no token_hash to /', async () => {
     renderWithRouter({
       routeTree: buildAuthConfirmRouteTree(),
       initialEntry: '/auth/confirm',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext({ teamContext }),
+      routerContext: createBaseRouterContext(),
     });
 
-    expect(await screen.findByRole('heading', { name: 'Leagues Stub' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Home Stub' })).toBeInTheDocument();
     expect(supabase.auth.verifyOtp).not.toHaveBeenCalled();
   });
 
-  it('ignores a cross-origin next value and falls back to the team-state default', async () => {
+  it('ignores a cross-origin next value and falls back to the default', async () => {
     mockVerifyOtpSuccess();
-    const teamContext = createTeamContext({ myTeamId: 1, hasTeam: true });
     const user = userEvent.setup();
 
     renderWithRouter({
@@ -257,23 +224,22 @@ describe('/auth/confirm route', () => {
         'https://evil.example.com/foo',
       )}`,
       auth: createUnauthAuth(),
-      routerContext: createBaseRouterContext({ teamContext }),
+      routerContext: createBaseRouterContext(),
     });
 
     await user.click(await screen.findByRole('button', { name: /continue/i }));
 
-    expect(await screen.findByRole('heading', { name: 'Leagues Stub' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Home Stub' })).toBeInTheDocument();
   });
 
   it('does not verify the token on page load — only on the Continue click', async () => {
     mockVerifyOtpSuccess();
-    const teamContext = createTeamContext({ hasTeam: false });
 
     renderWithRouter({
       routeTree: buildAuthConfirmRouteTree(),
       initialEntry: '/auth/confirm?token_hash=abc123&type=signup',
       auth: createUnauthAuth(),
-      routerContext: createBaseRouterContext({ teamContext }),
+      routerContext: createBaseRouterContext(),
     });
 
     expect(await screen.findByRole('heading', { name: /confirm your email/i })).toBeInTheDocument();
@@ -292,19 +258,18 @@ describe('/auth/confirm route', () => {
   });
 
   it('skips verifyOtp for an already signed-in visitor and navigates straight through', async () => {
-    const teamContext = createTeamContext({ hasTeam: false });
     const user = userEvent.setup();
 
     renderWithRouter({
       routeTree: buildAuthConfirmRouteTree(),
       initialEntry: '/auth/confirm?token_hash=abc123&type=signup',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext({ teamContext }),
+      routerContext: createBaseRouterContext(),
     });
 
     await user.click(await screen.findByRole('button', { name: /continue/i }));
 
-    expect(await screen.findByRole('heading', { name: 'Create Team Stub' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Home Stub' })).toBeInTheDocument();
     expect(supabase.auth.verifyOtp).not.toHaveBeenCalled();
   });
 });

--- a/web/src/tests/test-utils/routeTreeBuilders.tsx
+++ b/web/src/tests/test-utils/routeTreeBuilders.tsx
@@ -2,7 +2,7 @@
 // with `RouterContext`. If a test needs a different context shape, drop down to
 // `createRoute` directly — these helpers won't fit.
 import { requireAuth, requireNoTeam, requireTeam } from '@/lib/route-guards';
-import { type RouterContext, defaultAuthedDestination } from '@/lib/router-context';
+import type { RouterContext } from '@/lib/router-context';
 import { type AnyRoute, Outlet, createRoute, redirect } from '@tanstack/react-router';
 
 /**
@@ -43,7 +43,7 @@ export function buildUnauthenticatedLayout(rootRoute: AnyRoute) {
     beforeLoad: ({ context }: { context: RouterContext }) => {
       if (context.auth.user) {
         throw redirect({
-          to: defaultAuthedDestination(context.teamContext),
+          to: '/',
           replace: true,
         });
       }


### PR DESCRIPTION
## What

Make `/` (Home) the single default post-auth destination, selected by **auth state alone, never team state** — codifying the decision already accepted in ADR 002. The code had drifted: sign-in landed on `/leagues` and the auth guards/confirm flow used a team-state-dependent helper, almost certainly because the Home work (#198) landed afterward.

`/` already renders the right surface for every team state (`IndexRoute` → `Home` branches on no-team / no-leagues / scored), so entry flows no longer recompute a team-state-dependent landing.

## Changes

- **`router-context.ts`** — delete the `defaultAuthedDestination` helper.
- **`router.tsx`** — both guards (`_unauthenticated`, `/auth/confirm`) redirect to `/`; import narrowed to `import type { RouterContext }`.
- **`SignInForm.tsx`** — no-deep-link branch `/leagues` → `/`.
- **`ConfirmEmailNotice.tsx`** — post-verify fallback `internalNext ?? '/'`; remove the now-unused `teamContext` / `useRouteContext` read.
- **Tests** — `auth-confirm.integration.test.tsx` reworked (Home stub, collapse the two team-state landing cases into one, repoint assertions); `SignInForm.test.tsx` gains a no-redirect → `/` assertion. `routeTreeBuilders.tsx` test util tracks the production guard change to `/`.

## Out of scope (unchanged)

- `teamContext.hasTeam` stays — still read by `JoinInvite.tsx` / `AppSidebar.tsx`.
- `requireNoTeam` and other route-access guards.
- `redirect` / `next` param names; `confirmation.html`.
- `SignUpForm` already lands on `/`.

## E2E (second commit)

The landing change rippled into the e2e suite, which asserted the old team-state landing (`/leagues` / `/create-team`) right after sign-in:

- `auth.spec` now owns the landing assertion — "lands on home" checks `/` plus the authed Home surface. Its sign-out test re-syncs on the anon landing page, since sign-in and sign-out now share the `/` URL and `toHaveURL('/')` no longer waits for the session to clear.
- `team` / `league` / `avatar` specs drop the incidental post-sign-in landing checkpoints (they don't own that behavior) and just establish a session before navigating to what they actually test; two add an explicit `goto` for controls that live off Home (the create-team form, the Create League button).

Suite green: 16/16, plus a 35/35 `--repeat-each=5` stress run on the affected specs.

## Why deep links are safe

`?redirect` (sign-in/sign-up) and `next` (`/auth/confirm`) always took precedence over the fallback the helper governed, so repointing the fallback to `/` cannot regress deep links — they never flowed through it.

## Verification

Automated (all green): `web:test` (604 passed), `web:lint`, `web:format:check`, `web:build`.

Manual (Chrome DevTools against the local stack, all four changed call sites exercised live):

| Call site | Check | Result |
|---|---|---|
| `SignInForm` fallback | fresh sign-in, no `?redirect` | → `/` |
| `_unauthenticated` guard | authed → `/sign-in` | → `/` |
| `authConfirmRoute` guard | authed → `/auth/confirm` (no token) | → `/` |
| `ConfirmEmailNotice` fallback | signup → real Mailpit token → Continue (no `next`) | → `/` |

Plus no-regression checks: `?redirect=/create-team` still honored; anon `/` → marketing LandingPage.

Closes #224
