### PR TITLE
Remove unused framer-motion dependency

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -31,7 +31,6 @@
         "@tanstack/router-devtools": "^1.167.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "framer-motion": "^12.23.12",
         "lucide-react": "^1.17.0",
         "next-themes": "^0.4.6",
         "react": "^19.2.1",
@@ -4878,33 +4877,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/framer-motion": {
-      "version": "12.38.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
-      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-dom": "^12.38.0",
-        "motion-utils": "^12.36.0",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5758,21 +5730,6 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/motion-dom": {
-      "version": "12.38.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
-      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-utils": "^12.36.0"
-      }
-    },
-    "node_modules/motion-utils": {
-      "version": "12.36.0",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
-      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
-      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/web/package.json
+++ b/web/package.json
@@ -44,7 +44,6 @@
     "@tanstack/router-devtools": "^1.167.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "framer-motion": "^12.23.12",
     "lucide-react": "^1.17.0",
     "next-themes": "^0.4.6",
     "react": "^19.2.1",


### PR DESCRIPTION
## Summary

`framer-motion` was declared as a direct dependency in `web/package.json` but imported nowhere in the codebase, and nothing pulled it in transitively (`npm ls framer-motion` shows no dependents). Removing it trims the dependency tree with no behavioral change.

## Verification

All suites pass with the dependency removed:

| Suite | Result |
|---|---|
| Frontend (Vitest) | 602 passed (70 files) |
| API unit (xUnit) | 473 passed |
| API integration (Testcontainers Postgres) | 39 passed |
| E2E (Playwright/Chromium) | 16 passed |

`npm run web:build` also succeeds, and the pre-commit hooks (format, lint, build, frontend tests) passed on commit.