### PR TITLE
Dedupe drivers & constructors across routes via TanStack Query

### DIFF
--- a/docs/plans/255-dedupe-drivers-constructors.md
+++ b/docs/plans/255-dedupe-drivers-constructors.md
@@ -1,0 +1,101 @@
+# Plan: Dedupe drivers & constructors across routes via TanStack Query (#255)
+
+## Context
+
+Each route loader fetches the active-driver and active-constructor lists independently,
+and the router's loader cache keys by route — so navigating `my-team` ↔ `team/$teamId`
+re-fetches these large, slow-changing lists every time (latency only, no correctness
+issue). Moving both onto the TanStack Query cache (keyed by query key, not route — the
+ADR 006 foundation already used for profile/team/season) makes them fetch once and share.
+Scope is drivers + constructors only; race-weekends are split to #278.
+
+One focused commit — services, loaders, and components must change together (the build
+breaks otherwise), and the updated tests ship with it.
+
+`getDrivers` / `getConstructors` have no callers besides the two loaders below
+(`CreateTeam` doesn't use them), so this is the complete change surface.
+
+## 1. Services — add `queryOptions`
+
+`web/src/services/driverService.ts` (mirror in `constructorService.ts`), leaving
+`getDrivers` / `getConstructors` unchanged:
+
+```ts
+import { queryOptions } from '@tanstack/react-query';
+
+export const driverKeys = { all: ['drivers'] as const };
+
+export const driversQuery = queryOptions({
+  queryKey: driverKeys.all,
+  queryFn: () => getDrivers(),
+  staleTime: 5 * 60_000,
+});
+```
+
+- **Wrap the `queryFn` in an arrow**, not a bare `queryFn: getDrivers` like `seasonQuery` —
+  these take an optional `seasonYear`, so the bare form fails `strict` tsc (TanStack's
+  context arg doesn't fit the param). Parameterless matches the fixed `['drivers']` /
+  `['constructors']` keys.
+- `staleTime: 5 * 60_000`, default `gcTime` — mirrors `profileQuery`.
+
+## 2. Loaders — `web/src/router.tsx`
+
+In `teamRoute` (`team/$teamId`) and `myTeamRoute` (`my-team`): replace `getDrivers()` /
+`getConstructors()` with `context.queryClient.ensureQueryData(driversQuery)` /
+`ensureQueryData(constructorsQuery)`, and drop `activeDrivers` / `activeConstructors` from
+the returned object. Reorder `Promise.all` so route-owned reads come first:
+
+```ts
+const [team, races] = await Promise.all([
+  getTeamById(teamId),
+  season ? getRaceWeekends(season.id) : Promise.resolve([]),
+  context.queryClient.ensureQueryData(driversQuery),
+  context.queryClient.ensureQueryData(constructorsQuery),
+]);
+return { team, races };          // myTeamRoute → return { races };
+```
+
+- **Delete the loaders' explicit inline return-type annotation** (`): Promise<{...}> =>`)
+  and let it infer, as `indexRoute` already does — don't rewrite the annotation.
+- Update imports: drop `getDrivers` / `getConstructors` and the now-unused `Driver` /
+  `Constructor` types; add the two queries. Leave `indexRoute` alone — it doesn't read
+  these.
+
+## 3. Components — `web/src/components/Team/Team.tsx`
+
+In `MyTeamRoute` and `TeamRoute`, read the two lists via `useSuspenseQuery` instead of
+`useLoaderData`:
+
+```ts
+const { data: activeDrivers } = useSuspenseQuery(driversQuery);
+const { data: activeConstructors } = useSuspenseQuery(constructorsQuery);
+```
+
+Keep `useLoaderData` for `team` (TeamRoute) and `races` (both); `MyTeamRoute` still reads
+`team` via `useSuspenseQuery(myTeamQuery)`. `TeamView` and the pickers stay prop-driven —
+unchanged. Add the query imports.
+
+## 4. Tests
+
+Update the two integration trees that mirror these loaders —
+**`view-team.integration.test.tsx`** and **`team-lineup.integration.test.tsx`**: change
+their inline loaders the same way (ensureQueryData, drop the two fields, swap the service
+imports for the query imports), and **keep** their local `/drivers` + `/constructors` MSW
+handlers (the queries still hit those endpoints). These already mount the routes and
+assert the pickers populate — that's the coverage for the new read path.
+
+No new automated test: the dedup is the library's by-key caching and a latency-only
+optimization with no rendered difference (verified manually below); key-sharing is
+structural via the single `driversQuery`. The `getDrivers` / `getConstructors` unit tests
+and the default MSW handlers are untouched.
+
+## Verification
+
+1. `npm run web:test` — full frontend suite green (the two updated trees populate their
+   pickers through the new read path).
+2. `npm run web:lint`, `npm run web:format:check`, `npm run web:build` — clean (no unused
+   imports in `router.tsx`; loader inference + component switch typecheck).
+3. **Manual — where the latency win is verified:** `npm run web:dev`, open DevTools
+   Network, sign in, visit `/my-team`, then open a league and click another member's team
+   (`/team/$teamId`). Confirm `/drivers` and `/constructors` each fire **once** across
+   both views, not once per route.

--- a/web/src/components/Team/Team.tsx
+++ b/web/src/components/Team/Team.tsx
@@ -4,6 +4,8 @@ import type { Team } from '@/contracts/Team';
 import { useLockCountdown } from '@/hooks/useLockCountdown';
 import { useSetCaptain } from '@/hooks/useSetCaptain';
 import { formatBudget } from '@/lib/utils';
+import { constructorsQuery } from '@/services/constructorService';
+import { driversQuery } from '@/services/driverService';
 import { myTeamQuery } from '@/services/teamService';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { notFound, useLoaderData } from '@tanstack/react-router';
@@ -24,7 +26,9 @@ export interface TeamViewProps {
 
 export function MyTeamRoute() {
   const { data: team } = useSuspenseQuery(myTeamQuery);
-  const { activeDrivers, activeConstructors, races } = useLoaderData({
+  const { data: activeDrivers } = useSuspenseQuery(driversQuery);
+  const { data: activeConstructors } = useSuspenseQuery(constructorsQuery);
+  const { races } = useLoaderData({
     from: '/_authenticated/_team-required/my-team',
   });
 
@@ -44,7 +48,9 @@ export function MyTeamRoute() {
 }
 
 export function TeamRoute() {
-  const { team, activeDrivers, activeConstructors, races } = useLoaderData({
+  const { data: activeDrivers } = useSuspenseQuery(driversQuery);
+  const { data: activeConstructors } = useSuspenseQuery(constructorsQuery);
+  const { team, races } = useLoaderData({
     from: '/_authenticated/_team-required/team/$teamId',
   });
 

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -10,7 +10,6 @@ import { ConfirmEmailNotice } from '@/components/auth/ConfirmEmailNotice/Confirm
 import { SignInForm } from '@/components/auth/SignInForm/SignInForm';
 import { SignUpForm } from '@/components/auth/SignUpForm/SignUpForm';
 import { Button } from '@/components/ui/button';
-import type { Team as TeamType } from '@/contracts/Team';
 import { redirectIfAuthenticated, requireAuth, requireTeam } from '@/lib/route-guards';
 import type { RouterContext } from '@/lib/router-context';
 import { safeInternalPath } from '@/lib/safeInternalPath';
@@ -33,12 +32,10 @@ import { z } from 'zod';
 
 import { BrowseLeagues } from './components/BrowseLeagues/BrowseLeagues';
 import { JoinInvite } from './components/JoinInvite/JoinInvite';
-import type { RaceWeekend } from './contracts/RaceWeekend';
-import type { Constructor, Driver } from './contracts/Role';
 import { routerAuth } from './lib/authStore';
 import { queryClient } from './lib/queryClient';
-import { getConstructors } from './services/constructorService';
-import { getDrivers } from './services/driverService';
+import { constructorsQuery } from './services/constructorService';
+import { driversQuery } from './services/driverService';
 import { previewInvite } from './services/leagueInviteService';
 import { getRaceWeekends } from './services/raceWeekendService';
 import { seasonQuery } from './services/seasonService';
@@ -507,15 +504,7 @@ const teamRoute = createRoute({
       throw redirect({ to: '/my-team', replace: true });
     }
   },
-  loader: async ({
-    params,
-    context,
-  }): Promise<{
-    team: TeamType;
-    activeDrivers: Driver[];
-    activeConstructors: Constructor[];
-    races: RaceWeekend[];
-  }> => {
+  loader: async ({ params, context }) => {
     const TEAM_ROUTE_ID = '/_authenticated/_team-required/team/$teamId';
 
     // Validate and parse params using Zod schema
@@ -531,11 +520,11 @@ const teamRoute = createRoute({
     const season = await context.queryClient.ensureQueryData(seasonQuery);
 
     // Fetch all data in parallel
-    const [team, activeDrivers, activeConstructors, races] = await Promise.all([
+    const [team, races] = await Promise.all([
       getTeamById(teamId),
-      getDrivers(),
-      getConstructors(),
       season ? getRaceWeekends(season.id) : Promise.resolve([]),
+      context.queryClient.ensureQueryData(driversQuery),
+      context.queryClient.ensureQueryData(constructorsQuery),
     ]);
 
     // Return 404 if team doesn't exist
@@ -543,7 +532,7 @@ const teamRoute = createRoute({
       throw notFound({ routeId: TEAM_ROUTE_ID });
     }
 
-    return { team, activeDrivers, activeConstructors, races };
+    return { team, races };
   },
   component: TeamRoute,
   pendingComponent: () => (
@@ -574,25 +563,19 @@ const myTeamRoute = createRoute({
   staticData: {
     pageTitle: 'My Team',
   },
-  loader: async ({
-    context,
-  }): Promise<{
-    activeDrivers: Driver[];
-    activeConstructors: Constructor[];
-    races: RaceWeekend[];
-  }> => {
+  loader: async ({ context }) => {
     const season = await context.queryClient.ensureQueryData(seasonQuery);
     // Warm-cache hit after the `_team-required` guard; pairs with the component's
     // useSuspenseQuery(myTeamQuery).
     await context.queryClient.ensureQueryData(myTeamQuery);
 
-    const [activeDrivers, activeConstructors, races] = await Promise.all([
-      getDrivers(),
-      getConstructors(),
+    const [races] = await Promise.all([
       season ? getRaceWeekends(season.id) : Promise.resolve([]),
+      context.queryClient.ensureQueryData(driversQuery),
+      context.queryClient.ensureQueryData(constructorsQuery),
     ]);
 
-    return { activeDrivers, activeConstructors, races };
+    return { races };
   },
   component: MyTeamRoute,
   pendingComponent: () => (

--- a/web/src/services/constructorService.ts
+++ b/web/src/services/constructorService.ts
@@ -1,7 +1,16 @@
 import type { Constructor } from '@/contracts/Role';
 import { apiClient } from '@/lib/api';
+import { queryOptions } from '@tanstack/react-query';
 
 export function getConstructors(seasonYear?: number): Promise<Constructor[]> {
   const url = seasonYear ? `/constructors?seasonYear=${seasonYear}` : '/constructors';
   return apiClient.get<Constructor[]>(url, 'get constructors');
 }
+
+export const constructorKeys = { all: ['constructors'] as const };
+
+export const constructorsQuery = queryOptions({
+  queryKey: constructorKeys.all,
+  queryFn: () => getConstructors(),
+  staleTime: 5 * 60_000,
+});

--- a/web/src/services/driverService.ts
+++ b/web/src/services/driverService.ts
@@ -1,7 +1,16 @@
 import type { Driver } from '@/contracts/Role';
 import { apiClient } from '@/lib/api';
+import { queryOptions } from '@tanstack/react-query';
 
 export async function getDrivers(seasonYear?: number): Promise<Driver[]> {
   const url = seasonYear ? `/drivers?seasonYear=${seasonYear}` : '/drivers';
   return apiClient.get<Driver[]>(url, 'get drivers');
 }
+
+export const driverKeys = { all: ['drivers'] as const };
+
+export const driversQuery = queryOptions({
+  queryKey: driverKeys.all,
+  queryFn: () => getDrivers(),
+  staleTime: 5 * 60_000,
+});

--- a/web/src/tests/integration/team-lineup.integration.test.tsx
+++ b/web/src/tests/integration/team-lineup.integration.test.tsx
@@ -1,8 +1,8 @@
 import { MyTeamRoute } from '@/components/Team/Team';
 import type { Team } from '@/contracts/Team';
 import type { RouterContext } from '@/lib/router-context';
-import { getConstructors } from '@/services/constructorService';
-import { getDrivers } from '@/services/driverService';
+import { constructorsQuery } from '@/services/constructorService';
+import { driversQuery } from '@/services/driverService';
 import { getRaceWeekends } from '@/services/raceWeekendService';
 import { seasonQuery } from '@/services/seasonService';
 import { myTeamQuery } from '@/services/teamService';
@@ -46,12 +46,12 @@ function buildMyTeamRouteTree() {
     loader: async ({ context }) => {
       const season = await context.queryClient.ensureQueryData(seasonQuery);
       await context.queryClient.ensureQueryData(myTeamQuery);
-      const [activeDrivers, activeConstructors, races] = await Promise.all([
-        getDrivers(),
-        getConstructors(),
+      const [races] = await Promise.all([
         season ? getRaceWeekends(season.id) : Promise.resolve([]),
+        context.queryClient.ensureQueryData(driversQuery),
+        context.queryClient.ensureQueryData(constructorsQuery),
       ]);
-      return { activeDrivers, activeConstructors, races };
+      return { races };
     },
     component: MyTeamRoute,
   });

--- a/web/src/tests/integration/view-team.integration.test.tsx
+++ b/web/src/tests/integration/view-team.integration.test.tsx
@@ -1,7 +1,7 @@
 import { TeamRoute } from '@/components/Team/Team';
 import type { RouterContext } from '@/lib/router-context';
-import { getConstructors } from '@/services/constructorService';
-import { getDrivers } from '@/services/driverService';
+import { constructorsQuery } from '@/services/constructorService';
+import { driversQuery } from '@/services/driverService';
 import { getRaceWeekends } from '@/services/raceWeekendService';
 import { seasonQuery } from '@/services/seasonService';
 import { getTeamById, myTeamQuery } from '@/services/teamService';
@@ -58,16 +58,16 @@ function buildTeamByIdRouteTree() {
     loader: async ({ params, context }) => {
       const season = await context.queryClient.ensureQueryData(seasonQuery);
       const teamId = Number(params.teamId);
-      const [team, activeDrivers, activeConstructors, races] = await Promise.all([
+      const [team, races] = await Promise.all([
         getTeamById(teamId),
-        getDrivers(),
-        getConstructors(),
         season ? getRaceWeekends(season.id) : Promise.resolve([]),
+        context.queryClient.ensureQueryData(driversQuery),
+        context.queryClient.ensureQueryData(constructorsQuery),
       ]);
       if (!team) {
         throw notFound({ routeId: '/_authenticated/_team-required/team/$teamId' });
       }
-      return { team, activeDrivers, activeConstructors, races };
+      return { team, races };
     },
     component: TeamRoute,
     notFoundComponent: () => <h1>Team Not Found</h1>,


### PR DESCRIPTION
Closes #255.

## What

Route loaders fetched the active-driver and active-constructor lists independently, and the router cached by route — so navigating `my-team` ↔ `team/$teamId` refetched both large, slow-changing lists every time. This moves them onto the TanStack Query cache (fixed `['drivers']` / `['constructors']` keys, 5-minute `staleTime`), the same ADR-006 pattern already used for profile/team/season, so both routes share a single fetch.

Latency-only optimization — no rendered difference. Scope is drivers + constructors only; race-weekends are split to #278.

## Changes

- **Services** — add `driversQuery` / `constructorsQuery` `queryOptions` (`driverService.ts`, `constructorService.ts`); `getDrivers` / `getConstructors` unchanged.
- **Loaders** (`router.tsx`) — `teamRoute` and `myTeamRoute` prime via `ensureQueryData(driversQuery/constructorsQuery)` inside the parallel batch and drop the two fields from their return; inline loader return-type annotations removed (now inferred); unused imports dropped.
- **Components** (`Team.tsx`) — `MyTeamRoute` / `TeamRoute` read the lists via `useSuspenseQuery`; `team` / `races` still come from `useLoaderData`.
- **Tests** — `view-team` and `team-lineup` integration trees updated to mirror the new read path; their `/drivers` + `/constructors` MSW handlers kept.

## Verification

- `web:test` — 617 tests passing
- `web:lint`, `web:format:check`, `web:build` — clean
- Manual: with DevTools Network open, visiting `/my-team` then another member's team (`/team/$teamId`) fetches `/drivers` and `/constructors` once each across both views, not once per route.