### PR TITLE
Upgrade Playwright to 1.61 to fix E2E install timeout

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,15 @@ updates:
           - "@types/react"
           - "@types/react-dom"
 
+  - package-ecosystem: "npm"
+    directory: "/e2e"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+
   - package-ecosystem: "nuget"
     directory: "/api"
     schedule:

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -8,7 +8,7 @@
       "name": "f1-fantasy-e2e",
       "version": "0.0.0",
       "devDependencies": {
-        "@playwright/test": "^1.50.0",
+        "@playwright/test": "^1.61.0",
         "@trivago/prettier-plugin-sort-imports": "^6.0.2",
         "@types/node": "^24.1.0",
         "@types/pg": "^8.11.10",
@@ -187,13 +187,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -494,13 +494,13 @@
       "license": "ISC"
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -513,9 +513,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -14,7 +14,7 @@
     "format:check": "prettier --check ."
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.0",
+    "@playwright/test": "^1.61.0",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "@types/node": "^24.1.0",
     "@types/pg": "^8.11.10",


### PR DESCRIPTION
## Problem

Every E2E run was hitting the 15-minute job timeout. Step-level timings showed `npx playwright install --with-deps chromium` hanging for 12–13 minutes doing nothing, after which the job was killed. Every other step finished in seconds.

## Root cause

Node 24.16.0 introduced a regression in `extract-zip`/`yauzl` that makes Chromium's zip extraction hang at 100% ([microsoft/playwright#41000](https://github.com/microsoft/playwright/issues/41000)). The e2e suite was on `@playwright/test` 1.59.1 — below the fix line — and CI's `.nvmrc` (`24`) resolves to the latest 24.x, which is now ≥ 24.16.

This never surfaced as a Dependabot PR because `/e2e` was not in `dependabot.yml`; only `/web` (npm) and `/api` (nuget) were watched.

## Fix

- Bump `@playwright/test` 1.59.1 → 1.61.0. 1.60 fixes the install hang; 1.61 also adds Ubuntu 26.04 support ([microsoft/playwright#40117](https://github.com/microsoft/playwright/issues/40117)), ahead of the eventual `ubuntu-latest` flip from 24.04.
- Add a weekly npm Dependabot entry for `/e2e` so these dependencies no longer drift unwatched.

## Verification

The hang only reproduces on Node ≥ 24.16 (local dev is 24.4.1), so the definitive check is this PR's E2E run: the **Install Playwright browsers** step should finish in ~30–60s instead of timing out.