### PR TITLE
Pin @types/node to the Node 24 LTS runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
     groups:
       vite:
         patterns:
@@ -65,6 +67,8 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "nuget"
     directory: "/api"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -48,7 +48,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
         "@trivago/prettier-plugin-sort-imports": "^6.0.2",
-        "@types/node": "^25.9.1",
+        "@types/node": "^24.1.0",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
@@ -4185,13 +4185,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/react": {
@@ -7495,9 +7495,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "devOptional": true,
       "license": "MIT"
     },

--- a/web/package.json
+++ b/web/package.json
@@ -61,7 +61,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
-    "@types/node": "^25.9.1",
+    "@types/node": "^24.1.0",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",


### PR DESCRIPTION
## What

- Align `web`'s `@types/node` from `^25.9.1` → `^24.1.0`, matching the Node 24 runtime (`.nvmrc`) and the e2e suite (already `^24.1.0`).
- Add a `semver-major` `ignore` for `@types/node` to both the `web` and `e2e` npm Dependabot entries.

## Why

`@types/node`'s major is meant to track the Node runtime you actually run on. web had drifted to `^25` — so it typechecked against the Node 25 API surface while running Node 24, risking false-negative type checks (code that compiles but throws at runtime on a Node-25-only API). Node 25 is also a non-LTS "Current" release that reached **EOL on 2026-06-01**, so it was never a runtime we'd adopt.

web drifted there via an auto-merged Dependabot PR because nothing tied `@types/node` to the runtime. The `ignore` closes that gap: Dependabot still ships `@types/node` patch/minor updates within the 24 line, but no longer proposes major bumps that race ahead of the runtime.

## Maintenance model

The `ignore` is permanent and needs no calendar-watching. `@types/node` only moves majors when **you** bump the Node runtime (`.nvmrc`) — at which point you change both together in one PR. Node 24 is LTS until **April 2028**, so that's not imminent.

## Verification

`npm run web:build` + full web test suite (617 tests) pass with `@types/node` 24.