### PR TITLE
Auto-merge non-major Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for non-major updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that turns on GitHub auto-merge for Dependabot PRs, except major bumps.

- Reads the update type via `dependabot/fetch-metadata` and enables auto-merge (squash) unless it's a `version-update:semver-major`.
- The existing required checks (Web, API, API Docker, API Integration, E2E) still gate every merge — auto-merge only fires once they pass and the branch is up to date.
- Major bumps fall through with no auto-merge, left for manual review.
- Uses `on: pull_request` with an explicit `permissions` block (the documented safe variant — no `pull_request_target`, no checkout of PR code).

Why: the strict up-to-date branch protection means each Dependabot merge knocks the rest out of date, forcing a serialized rebase → CI → merge chain. This drains that queue on its own instead of merging each PR by hand.