### PR TITLE
Add issue and PR writing conventions

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -1,0 +1,43 @@
+---
+name: Issue
+about: A bug, task, or idea.
+labels: needs-triage
+---
+
+<!--
+Title: verb-first or a symptom, ~6–10 words, no conventional-commit prefix.
+See docs/agents/issue-pr-style.md.
+-->
+
+## Problem
+
+<!-- When <situation>, <what happens> — which is a problem because <impact>. -->
+
+## Outcome
+
+<!-- The resolved state in one line. -->
+
+## Acceptance criteria
+
+<!-- The checkable conditions that prove the outcome — each maps to a test or an observation. -->
+
+- [ ]
+
+## Scope
+
+- In:
+- Out:
+
+## Pointers
+
+<!-- Relevant files, docs (docs/research/…, docs/adr/…), related issues. -->
+
+## Reproduction
+
+<!-- Bugs only — delete this section otherwise. -->
+
+1.
+
+**Expected:**
+**Actual:**
+**Environment:** <!-- browser / dev vs e2e stack / commit -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!--
+Title: imperative, no conventional-commit prefix, ≤70 chars, what-not-how.
+Keep this body lean — say only what the diff, CI, the linked issue, and commits don't.
+See docs/agents/issue-pr-style.md.
+-->
+
+<!-- 1–2 sentences: what this changes, and the why that isn't visible in the diff. -->
+
+Closes #
+
+<!--
+Add either section below ONLY if it has real content — otherwise leave it out.
+
+## Verification
+Checks that left no artifact, e.g. a browser check against the dev stack.
+Don't list the automated tests.
+
+## Risk & scope
+A real risk, a shortcut taken, or something deliberately left out (with a pointer).
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,8 @@ Keep this body lean — say only what the diff, CI, the linked issue, and commit
 See docs/agents/issue-pr-style.md.
 -->
 
+## Summary
+
 <!-- 1–2 sentences: what this changes, and the why that isn't visible in the diff. -->
 
 Closes #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,10 @@ Hosted on Fly.io + Supabase (free tier).
 
 GitHub issues in `emsqrd/f1fantasyapp` via the `gh` CLI. See `docs/agents/issue-tracker.md`.
 
+### Issue & PR writing
+
+Title and body conventions for issues and PRs; create new issues labeled `needs-triage`. See `docs/agents/issue-pr-style.md`.
+
 ### Triage labels
 
 Canonical role names used as-is (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.

--- a/docs/agents/issue-pr-style.md
+++ b/docs/agents/issue-pr-style.md
@@ -34,7 +34,7 @@ Imperative. No conventional-commit prefix. ≤70 characters. What, not how.
 
 ### Body
 
-Open with 1–2 sentences of the why that isn't visible in the diff, plus `Closes #N`. Add a section below only when it has real content:
+Under **`## Summary`**, give 1–2 sentences of the why that isn't visible in the diff, plus `Closes #N`. Add a section below only when it has real content:
 
 - **`## Verification`** — give the checks that left no artifact (e.g. a browser check against the dev stack). Don't list the automated tests.
 - **`## Risk & scope`** — name a genuine risk, a shortcut taken, or something deliberately left out, with a pointer. Don't restate the commit messages.
@@ -44,6 +44,7 @@ Small fix:
 ```
 Title: Fix lap-count off-by-one in sprint scoring
 
+## Summary
 Sprint laps were counted 0-indexed; F1 rounds are 1-indexed, so points landed on
 the wrong driver. Closes #142.
 ```
@@ -53,6 +54,7 @@ Larger change:
 ```
 Title: Persist standings instead of recomputing per request
 
+## Summary
 Standings were recomputed on every /me/standings call, which got slow once leagues
 filled up. Now materialized on score ingest. Closes #51.
 

--- a/docs/agents/issue-pr-style.md
+++ b/docs/agents/issue-pr-style.md
@@ -1,0 +1,73 @@
+# Issue & PR writing
+
+How to write issue and PR bodies for this repo.
+
+## Issues
+
+### Title
+
+Lead with a verb, or state the symptom. ~6–10 words. No conventional-commit prefix. Make it specific enough to recognise in a backlog; put detail in the body. Name one concern.
+
+| Off-the-cuff          | Template-shaped                                    |
+| --------------------- | -------------------------------------------------- |
+| `fix: lock bug`       | `Roster picker stays editable after lock deadline` |
+| `Countdown`           | `Add live countdown to roster lock deadline`       |
+| `Issue with leagues`  | `Private league invite link returns 404`           |
+| `feat: scoring stuff` | `Add captain multiplier to scoring engine`         |
+
+### Body
+
+- **Problem** — state the gap as a problem, not a solution: _When &lt;situation&gt;, &lt;what happens&gt; — which is a problem because &lt;impact&gt;._
+- **Outcome** — give the resolved state in one line.
+- **Acceptance criteria** — list the checkable conditions that prove the outcome; map each to a test or an observation.
+- **Scope** — state what's in and what's explicitly out.
+- **Pointers** — link relevant files, docs (`docs/research/…`, `docs/adr/…`), related issues.
+- **Reproduction** (bugs only) — give numbered steps, then **Expected**, **Actual**, **Environment**.
+
+## Pull requests
+
+Keep the body lean: include only what the diff, CI, the linked issue, and the commit messages don't already carry. Put anything you want acted on — a constraint, a convention, the intent behind an odd line — in the commit message, a code comment, or CLAUDE.md, not the body.
+
+### Title
+
+Imperative. No conventional-commit prefix. ≤70 characters. What, not how.
+
+### Body
+
+Open with 1–2 sentences of the why that isn't visible in the diff, plus `Closes #N`. Add a section below only when it has real content:
+
+- **`## Verification`** — give the checks that left no artifact (e.g. a browser check against the dev stack). Don't list the automated tests.
+- **`## Risk & scope`** — name a genuine risk, a shortcut taken, or something deliberately left out, with a pointer. Don't restate the commit messages.
+
+Small fix:
+
+```
+Title: Fix lap-count off-by-one in sprint scoring
+
+Sprint laps were counted 0-indexed; F1 rounds are 1-indexed, so points landed on
+the wrong driver. Closes #142.
+```
+
+Larger change:
+
+```
+Title: Persist standings instead of recomputing per request
+
+Standings were recomputed on every /me/standings call, which got slow once leagues
+filled up. Now materialized on score ingest. Closes #51.
+
+## Verification
+Manually checked the leaderboard against the dev stack after ingesting a full race
+weekend — matches the old recompute path. Materialization math is unit-tested.
+
+## Risk & scope
+Backfill migration runs once over existing seasons; idempotent upsert, safe to re-run
+if it fails midway. Doesn't touch sprint scoring — that's #58.
+```
+
+## Shared style
+
+- Imperative, present tense, plain. No business jargon.
+- Be concise. One concern per artifact.
+- Describe the state, not the diff or the history.
+- Link, don't repeat.


### PR DESCRIPTION
## Summary
Off-the-cuff issue and PR writing was inconsistent, so this establishes one convention for both: a reference guide (docs/agents/issue-pr-style.md), a CLAUDE.md pointer, and GitHub web templates that mirror it.

## Risk & scope
GitHub issue and PR templates only activate from the repo's default branch, so their on-web behavior (the template chooser and needs-triage auto-label) can't be verified until this merges.