### PR TITLE
Clean up web test infrastructure deferred from #247

### DIFF
--- a/docs/plans/263-test-infra-cleanups.md
+++ b/docs/plans/263-test-infra-cleanups.md
@@ -1,0 +1,97 @@
+# Plan: Test-infra cleanups deferred from the #247 migration (issue #263)
+
+## Context
+
+Two behavior-neutral test-infra cleanups surfaced by the #247 `RouterContext` migration, split out of that PR to keep it reviewable. Both are pure refactors of the `web/` Vitest test infrastructure — no production code changes, the existing suite is the regression guard. They land as **two self-contained commits**, each independently green on build, lint, test, and format.
+
+The cleanups remove two patterns that no longer reflect best practice:
+
+1. **`setupTests.ts` leaks exports.** A Vitest [`setupFiles`](https://vitest.dev/config/setupfiles) entry runs for side effects before each test file; the runner ignores its exports. Yet `setupTests.ts` re-exports `server`/`API_BASE` as a back-compat shim and defines `setMobileViewport` + the `matchMedia` stub inline, so 16 tests import values *from the setup file* — a pattern the tool doesn't intend. MSW's [Node integration](https://mswjs.io/docs/integrations/node) keeps `server` in a module tests import directly, with the setup file only wiring lifecycle.
+
+2. **`createBaseRouterContext` is vestigial.** Since #247 narrowed `RouterContext` to `{ auth, queryClient }`, the helper returns `{}`, and `renderWithRouter` already defaults `routerContext` to `{}` — so `routerContext: createBaseRouterContext()` is equivalent to omitting the arg. Three local test wrappers exist only to run a `server.use(...)` side effect and then return that empty `{}`.
+
+Per repo convention, each commit is a review gate — the second commit does not begin until the first is approved.
+
+---
+
+## Commit 1 — Side-effect-only `setupTests.ts` + `@/mocks` import surface
+
+Make `setupTests.ts` export nothing; route shared fixtures through dedicated modules tests import directly.
+
+### New files
+
+- **`web/src/mocks/index.ts`** — barrel matching the existing `@/tests/test-utils` pattern:
+  ```ts
+  export { API_BASE } from './handlers';
+  export { server } from './server';
+  ```
+- **`web/src/tests/test-utils/matchMedia.ts`** — move the `matchMedia` machinery out of `setupTests.ts`. Holds the module-level `let mobileViewport = false` flag plus:
+  - `installMatchMediaMock()` — assigns `window.matchMedia` (the stub body currently at `setupTests.ts:39-49`), for the setup-file side effect.
+  - `setMobileViewport(value: boolean)` — flips the flag (currently `setupTests.ts:32-34`), for tests. Keep the existing doc comment.
+
+### Edits
+
+- **`web/src/setupTests.ts`**: remove the two re-export lines (`10-11`), the inline `setMobileViewport` (`27-34`), the `matchMedia` stub + `mobileViewport` var (`25`, `36-49`). Import `installMatchMediaMock` + `setMobileViewport` from `./tests/test-utils/matchMedia`; call `installMatchMediaMock()` at top level (where the stub was) and `setMobileViewport(false)` in the `afterEach` (replacing the `mobileViewport = false` on line 56). Keep the existing internal `import { API_BASE }`/`import { server }` (lines 5-6) — those stay for env-stub + lifecycle wiring. **Net result: `setupTests.ts` exports nothing.**
+- **`web/src/mocks/handlers.ts`**: rewrite the stale comment (lines ~5-7) that references "re-exported from setupTests" — `API_BASE` is no longer re-exported there. Trim to state what `API_BASE` is (the base URL the suite targets); drop the setupTests/cycle framing.
+- **`web/src/tests/test-utils/index.ts`**: add `export { setMobileViewport } from './matchMedia';`.
+- **Repoint the 16 `@/setupTests` importers** (15 in `src/tests/integration/*.integration.test.tsx`, plus `src/hooks/useCurrentAvatar.test.tsx`): change `import { API_BASE, server } from '@/setupTests'` → `from '@/mocks'`. The one exception is `navigation.integration.test.tsx`, which also imports `setMobileViewport`: split it — `server`/`API_BASE` from `@/mocks`, `setMobileViewport` from `@/tests/test-utils`.
+- **`web/CLAUDE.md`**: update the two references — the Stack paragraph's "(both re-exported from `setupTests.ts` as `server` / `API_BASE`)" and "Build URLs from `API_BASE` exported by `setupTests.ts`" — to point at `@/mocks`.
+
+### Gate
+
+`setupTests.ts` exports nothing; no file imports `server`/`API_BASE` from `@/setupTests`; tests get them from `@/mocks` and `setMobileViewport` from `@/tests/test-utils`.
+
+---
+
+## Commit 2 — Drop the vestigial `createBaseRouterContext` helper
+
+Remove the no-op helper and the `routerContext` plumbing it fed; convert the three side-effect-only wrappers to `stub…` seed functions.
+
+### Edits
+
+- **`web/src/tests/test-utils/renderContexts.ts`**: delete `createBaseRouterContext` (keep `createUnauthAuth`, `createAuthedAuth`).
+- **`web/src/tests/test-utils/index.ts`**: drop `createBaseRouterContext` from the `./renderContexts` re-export line.
+- **`web/src/tests/test-utils/renderWithRouter.tsx`**: remove the `routerContext` field from `RenderWithRouterOptions` (and its doc block), the `routerContext = {}` param, and the `...routerContext` spread — context becomes `{ auth: routerAuth, queryClient }`.
+- **Drop `routerContext: createBaseRouterContext()` at its direct call sites** — ~42 occurrences across 11 integration test files (`account`, `account-menu`, `auth-confirm`, `auth-toggle`, `create-team`, `leaderboard`, `league-loader`, `navigation`, `root-routing`, `route-guards`, `signup-resend`). Each just loses that one line from the `renderWithRouter({...})` object. (The issue estimated 40; actual is ~42 — the pattern covers all.)
+- **Convert the three local wrappers to `stub…` side-effect functions** (each lives in one file, used in one file; keep them local). Each keeps its `server.use(...)` body, drops the `return createBaseRouterContext()`, and returns nothing. At every call site, hoist the call to a statement *before* `renderWithRouter(...)` and omit `routerContext`:
+  - `leagues.integration.test.tsx`: `authedRouterContext()` → `stubMyTeam()` — 16 sites.
+  - `league-invite-dialog.integration.test.tsx`: `ownerRouterContext()` → `stubLeagueOwner()` — 5 sites.
+  - `join-invite.integration.test.tsx`: `makeRouterContext(team)` → `stubProfileForTeam(team)` — 11 sites (keeps the `team` param).
+
+  Transformation shape:
+  ```ts
+  // before
+  renderWithRouter({ routeTree, initialEntry, auth: createAuthedAuth(), routerContext: authedRouterContext() });
+  // after
+  stubMyTeam();
+  renderWithRouter({ routeTree, initialEntry, auth: createAuthedAuth() });
+  ```
+- **`web/CLAUDE.md`**: in the `renderWithRouter` signature note, drop the `routerContext` mention — signature becomes `routeTree`, `initialEntry`, `auth`.
+
+### Gate
+
+`createBaseRouterContext` and the `routerContext` param/type are gone; tests seed via the `stub…` side effects.
+
+---
+
+## Verification (run per commit)
+
+```bash
+npm run web:test          # full frontend suite — the regression guard for both refactors
+npm run web:lint          # catches unused imports / dangling symbols
+npm run web:format:check
+npm run web:build         # tsc type-check (catches removed-type references)
+```
+
+Grep gates:
+
+```bash
+# Commit 1
+grep -rn "from '@/setupTests'" web/src        # → no matches
+grep -n "export" web/src/setupTests.ts        # → no `export` statements
+
+# Commit 2
+grep -rn "createBaseRouterContext\|routerContext" web/src   # → no matches
+```
+
+This is a pure refactor — no manual browser check needed; a green `web:test` proves behavior is unchanged.

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -152,7 +152,7 @@ See root `CLAUDE.md` `## Testing Strategy` for when to reach for this layer vs. 
 - **Don't introduce per-service path constants** (e.g. `USER_PROFILE_PATH = '/me/profile'`). The service module is already the single source of truth for each path. Strict-mode MSW reports the exact unhandled URL on a typo or rename, so drift is caught loudly — constants would just add a second place to maintain.
 - For 4xx/5xx, use `new HttpResponse(null, { status })`. For success bodies, use `HttpResponse.json(factoryOutput)` so the response shape is typed via the factory.
 
-**`renderWithRouter` signature:** `routeTree`, `initialEntry`, `auth`, and an optional `routerContext` (rarely needed — `auth` and `queryClient` are wired automatically, and nothing else remains in `RouterContext`). The helper creates a fresh per-test `QueryClient`, wraps the tree in its provider, and returns it, so tests can seed or assert the Query cache directly (e.g. `queryClient.setQueryData(teamKeys.all, mockTeam)`).
+**`renderWithRouter` signature:** `routeTree`, `initialEntry`, and `auth` (`auth` and `queryClient` are wired into router context automatically). The helper creates a fresh per-test `QueryClient`, wraps the tree in its provider, and returns it, so tests can seed or assert the Query cache directly (e.g. `queryClient.setQueryData(teamKeys.all, mockTeam)`).
 
 ```typescript
 const { queryClient } = renderWithRouter({

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -129,7 +129,7 @@ See root `CLAUDE.md` `## Testing Strategy` for when to reach for this layer vs. 
 
 **Run:** `npm run web:test:integration` (focused) or `npm run web:test` (full suite).
 
-**Stack:** Vitest + jsdom + MSW intercepting at the `fetch` boundary. Tests exercise the real router, real loaders, real components, and the real `apiClient` — only the network is mocked. The MSW server lives in `src/mocks/server.ts` with the shared default handlers in `src/mocks/handlers.ts` (both re-exported from `setupTests.ts` as `server` / `API_BASE`); it runs in strict mode (`onUnhandledRequest: 'error'`) and resets handlers after each test.
+**Stack:** Vitest + jsdom + MSW intercepting at the `fetch` boundary. Tests exercise the real router, real loaders, real components, and the real `apiClient` — only the network is mocked. The MSW server lives in `src/mocks/server.ts` with the shared default handlers in `src/mocks/handlers.ts` (tests import `server` / `API_BASE` from the `@/mocks` barrel); it runs in strict mode (`onUnhandledRequest: 'error'`) and resets handlers after each test.
 
 **Reference test:** `src/tests/integration/account.integration.test.tsx`. Copy its shape for new flows.
 
@@ -146,7 +146,7 @@ See root `CLAUDE.md` `## Testing Strategy` for when to reach for this layer vs. 
 
 **MSW handlers:**
 
-- Build URLs from `API_BASE` exported by `setupTests.ts`: ``http.get(`${API_BASE}/me/profile`, ...)``. Don't hardcode the base.
+- Build URLs from `API_BASE` exported by `@/mocks`: ``http.get(`${API_BASE}/me/profile`, ...)``. Don't hardcode the base.
 - **Defaults cover the cross-route reads** every authenticated tree touches: `src/mocks/handlers.ts` seeds `/me/profile` (a profile with `hasTeam: false`), `/me/team` (404 — no team), and `/seasons/current`. They model a freshly-authenticated user without a team; a test mounting a `_team-required` route overrides `/me/team` with a present team via `server.use(...)`.
 - Declare everything else per test via `server.use(...)` — strict mode forces each test to spell out the rest of its network surface. Promote a handler to a default only once it's copy-pasted across three or more flow tests.
 - **Don't introduce per-service path constants** (e.g. `USER_PROFILE_PATH = '/me/profile'`). The service module is already the single source of truth for each path. Strict-mode MSW reports the exact unhandled URL on a typo or rename, so drift is caught loudly — constants would just add a second place to maintain.

--- a/web/src/hooks/useCurrentAvatar.test.tsx
+++ b/web/src/hooks/useCurrentAvatar.test.tsx
@@ -3,12 +3,7 @@ import { useCurrentAvatar } from '@/hooks/useCurrentAvatar';
 import { avatarEvents } from '@/lib/avatarEvents';
 import type { RouterContext } from '@/lib/router-context';
 import { API_BASE, server } from '@/mocks';
-import {
-  createAuthedAuth,
-  createBaseRouterContext,
-  createMockUserProfile,
-  renderWithRouter,
-} from '@/tests/test-utils';
+import { createAuthedAuth, createMockUserProfile, renderWithRouter } from '@/tests/test-utils';
 import { Outlet, createRootRouteWithContext, createRoute } from '@tanstack/react-router';
 import { act, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
@@ -51,7 +46,6 @@ function renderProbe(profile: UserProfile) {
     routeTree: rootRoute.addChildren([indexRoute]),
     initialEntry: '/',
     auth: createAuthedAuth(),
-    routerContext: createBaseRouterContext(),
   });
 }
 

--- a/web/src/hooks/useCurrentAvatar.test.tsx
+++ b/web/src/hooks/useCurrentAvatar.test.tsx
@@ -2,7 +2,7 @@ import type { UserProfile } from '@/contracts/UserProfile';
 import { useCurrentAvatar } from '@/hooks/useCurrentAvatar';
 import { avatarEvents } from '@/lib/avatarEvents';
 import type { RouterContext } from '@/lib/router-context';
-import { API_BASE, server } from '@/setupTests';
+import { API_BASE, server } from '@/mocks';
 import {
   createAuthedAuth,
   createBaseRouterContext,

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -2,9 +2,7 @@ import { createMockSeason, createMockUserProfile } from '@/tests/test-utils/mock
 import { HttpResponse, http } from 'msw';
 
 /**
- * Base URL the test suite's apiClient targets. Defined here rather than in
- * setupTests so the default handlers can build full URLs without importing back
- * through setupTests (a cycle); re-exported from setupTests for existing imports.
+ * Base URL the test suite's apiClient targets.
  */
 export const API_BASE = 'http://localhost/api';
 

--- a/web/src/mocks/index.ts
+++ b/web/src/mocks/index.ts
@@ -1,0 +1,2 @@
+export { API_BASE } from './handlers';
+export { server } from './server';

--- a/web/src/setupTests.ts
+++ b/web/src/setupTests.ts
@@ -4,11 +4,7 @@ import { afterAll, afterEach, beforeAll, vi } from 'vitest';
 
 import { API_BASE } from './mocks/handlers';
 import { server } from './mocks/server';
-
-// Re-exported so existing tests can import `API_BASE` / `server` from
-// `@/setupTests`; the shared default handlers live in `mocks/`.
-export { API_BASE } from './mocks/handlers';
-export { server } from './mocks/server';
+import { installMatchMediaMock, setMobileViewport } from './tests/test-utils/matchMedia';
 
 vi.stubEnv('VITE_SUPABASE_URL', 'http://localhost');
 vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'test-anon-key');
@@ -22,38 +18,14 @@ class MockResizeObserver {
 }
 globalThis.ResizeObserver = MockResizeObserver;
 
-let mobileViewport = false;
-
-/**
- * Drives `useIsMobile()` in tests by setting whether `matchMedia` reports the
- * mobile breakpoint as matching. The `change` listeners are no-ops, so flip
- * this before mount, not mid-render.
- */
-export function setMobileViewport(value: boolean): void {
-  mobileViewport = value;
-}
-
-// jsdom has no `matchMedia`. Report the mobile breakpoint query against the
-// `mobileViewport` flag (everything else, e.g. `next-themes`'s color-scheme
-// query, stays unmatched).
-window.matchMedia = ((query: string): MediaQueryList =>
-  ({
-    matches: query.includes('max-width') ? mobileViewport : false,
-    media: query,
-    onchange: null,
-    addListener: () => {},
-    removeListener: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    dispatchEvent: () => false,
-  }) as unknown as MediaQueryList) as typeof window.matchMedia;
+installMatchMediaMock();
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 
 afterEach(async () => {
   cleanup();
   server.resetHandlers();
-  mobileViewport = false;
+  setMobileViewport(false);
 
   // Imported lazily: a static import would evaluate `lib/supabase` before the
   // env stubs above run and would pin the real module ahead of per-file

--- a/web/src/tests/integration/account-menu.integration.test.tsx
+++ b/web/src/tests/integration/account-menu.integration.test.tsx
@@ -6,7 +6,6 @@ import { API_BASE, server } from '@/mocks';
 import {
   buildStubRoute,
   createAuthedAuth,
-  createBaseRouterContext,
   createMockUserProfile,
   renderWithRouter,
 } from '@/tests/test-utils';
@@ -81,7 +80,6 @@ function renderMenu(options: {
     routeTree: buildMenuTree(options.withTheme),
     initialEntry: options.initialEntry ?? '/',
     auth: options.auth,
-    routerContext: createBaseRouterContext(),
   });
 }
 

--- a/web/src/tests/integration/account-menu.integration.test.tsx
+++ b/web/src/tests/integration/account-menu.integration.test.tsx
@@ -2,7 +2,7 @@ import { AccountMenu } from '@/components/AccountMenu/AccountMenu';
 import type { UserProfile } from '@/contracts/UserProfile';
 import type { Auth } from '@/lib/authStore';
 import type { RouterContext } from '@/lib/router-context';
-import { API_BASE, server } from '@/setupTests';
+import { API_BASE, server } from '@/mocks';
 import {
   buildStubRoute,
   createAuthedAuth,

--- a/web/src/tests/integration/account.integration.test.tsx
+++ b/web/src/tests/integration/account.integration.test.tsx
@@ -2,8 +2,8 @@ import { Account } from '@/components/Account/Account';
 import { RouteErrorComponent } from '@/components/RouteErrorComponent/RouteErrorComponent';
 import type { UserProfile } from '@/contracts/UserProfile';
 import type { RouterContext } from '@/lib/router-context';
+import { API_BASE, server } from '@/mocks';
 import { profileQuery } from '@/services/userProfileService';
-import { API_BASE, server } from '@/setupTests';
 import {
   buildAuthenticatedLayout,
   createAuthedAuth,

--- a/web/src/tests/integration/account.integration.test.tsx
+++ b/web/src/tests/integration/account.integration.test.tsx
@@ -7,7 +7,6 @@ import { profileQuery } from '@/services/userProfileService';
 import {
   buildAuthenticatedLayout,
   createAuthedAuth,
-  createBaseRouterContext,
   createMockUserProfile,
   renderWithRouter,
 } from '@/tests/test-utils';
@@ -57,7 +56,6 @@ describe('Account page', () => {
       routeTree: buildAccountRouteTree(),
       initialEntry: '/account',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     expect(await screen.findByDisplayValue('Ada Lovelace')).toBeInTheDocument();
@@ -70,7 +68,6 @@ describe('Account page', () => {
       routeTree: buildAccountRouteTree(),
       initialEntry: '/account',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     expect(
@@ -93,7 +90,6 @@ describe('Account page', () => {
       routeTree: buildAccountRouteTree(),
       initialEntry: '/account',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     const displayName = await screen.findByDisplayValue('Original');

--- a/web/src/tests/integration/auth-confirm.integration.test.tsx
+++ b/web/src/tests/integration/auth-confirm.integration.test.tsx
@@ -4,7 +4,6 @@ import { supabase } from '@/lib/supabase';
 import {
   buildStubRoute,
   createAuthedAuth,
-  createBaseRouterContext,
   createUnauthAuth,
   renderWithRouter,
 } from '@/tests/test-utils';
@@ -122,7 +121,6 @@ describe('/auth/confirm route', () => {
       routeTree: buildAuthConfirmRouteTree(),
       initialEntry: '/auth/confirm?token_hash=abc123&type=signup',
       auth: createUnauthAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     expect(await screen.findByRole('heading', { name: /confirm your email/i })).toBeInTheDocument();
@@ -148,7 +146,6 @@ describe('/auth/confirm route', () => {
         sameOriginNext,
       )}`,
       auth: createUnauthAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     await user.click(await screen.findByRole('button', { name: /continue/i }));
@@ -164,7 +161,6 @@ describe('/auth/confirm route', () => {
       routeTree: buildAuthConfirmRouteTree(),
       initialEntry: '/auth/confirm?token_hash=stale&type=signup',
       auth: createUnauthAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     await user.click(await screen.findByRole('button', { name: /continue/i }));
@@ -181,7 +177,6 @@ describe('/auth/confirm route', () => {
       routeTree: buildAuthConfirmRouteTree(),
       initialEntry: '/auth/confirm?token_hash=stale&type=signup',
       auth: createUnauthAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     await user.click(await screen.findByRole('button', { name: /continue/i }));
@@ -195,7 +190,6 @@ describe('/auth/confirm route', () => {
       routeTree: buildAuthConfirmRouteTree(),
       initialEntry: '/auth/confirm',
       auth: createUnauthAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     expect(await screen.findByRole('heading', { name: 'Sign-up Stub' })).toBeInTheDocument();
@@ -207,7 +201,6 @@ describe('/auth/confirm route', () => {
       routeTree: buildAuthConfirmRouteTree(),
       initialEntry: '/auth/confirm',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     expect(await screen.findByRole('heading', { name: 'Home Stub' })).toBeInTheDocument();
@@ -224,7 +217,6 @@ describe('/auth/confirm route', () => {
         'https://evil.example.com/foo',
       )}`,
       auth: createUnauthAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     await user.click(await screen.findByRole('button', { name: /continue/i }));
@@ -239,7 +231,6 @@ describe('/auth/confirm route', () => {
       routeTree: buildAuthConfirmRouteTree(),
       initialEntry: '/auth/confirm?token_hash=abc123&type=signup',
       auth: createUnauthAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     expect(await screen.findByRole('heading', { name: /confirm your email/i })).toBeInTheDocument();
@@ -264,7 +255,6 @@ describe('/auth/confirm route', () => {
       routeTree: buildAuthConfirmRouteTree(),
       initialEntry: '/auth/confirm?token_hash=abc123&type=signup',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     await user.click(await screen.findByRole('button', { name: /continue/i }));

--- a/web/src/tests/integration/auth-store.integration.test.ts
+++ b/web/src/tests/integration/auth-store.integration.test.ts
@@ -1,5 +1,5 @@
 import { getAuthActions, getAuthSnapshot, initAuthStore } from '@/lib/authStore';
-import { server } from '@/setupTests';
+import { server } from '@/mocks';
 import { HttpResponse, http } from 'msw';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 

--- a/web/src/tests/integration/auth-toggle.integration.test.tsx
+++ b/web/src/tests/integration/auth-toggle.integration.test.tsx
@@ -2,12 +2,7 @@ import { SignInForm } from '@/components/auth/SignInForm/SignInForm';
 import { SignUpForm } from '@/components/auth/SignUpForm/SignUpForm';
 import type { RouterContext } from '@/lib/router-context';
 import { safeInternalPath } from '@/lib/safeInternalPath';
-import {
-  buildUnauthenticatedLayout,
-  createBaseRouterContext,
-  createUnauthAuth,
-  renderWithRouter,
-} from '@/tests/test-utils';
+import { buildUnauthenticatedLayout, createUnauthAuth, renderWithRouter } from '@/tests/test-utils';
 import { Outlet, createRootRouteWithContext, createRoute } from '@tanstack/react-router';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -58,7 +53,6 @@ describe('sign-in ↔ sign-up toggle', () => {
       routeTree: buildAuthToggleRouteTree(),
       initialEntry: '/sign-in?redirect=/league/5',
       auth: createUnauthAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     await user.click(await screen.findByRole('link', { name: /sign up/i }));
@@ -74,7 +68,6 @@ describe('sign-in ↔ sign-up toggle', () => {
       routeTree: buildAuthToggleRouteTree(),
       initialEntry: '/sign-up?redirect=/league/5',
       auth: createUnauthAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     await user.click(await screen.findByRole('link', { name: /sign in/i }));

--- a/web/src/tests/integration/create-team.integration.test.tsx
+++ b/web/src/tests/integration/create-team.integration.test.tsx
@@ -1,7 +1,7 @@
 import { CreateTeam } from '@/components/CreateTeam/CreateTeam';
 import { safeInternalPath } from '@/lib/safeInternalPath';
+import { API_BASE, server } from '@/mocks';
 import { myTeamQuery } from '@/services/teamService';
-import { API_BASE, server } from '@/setupTests';
 import {
   buildAuthenticatedLayout,
   buildRootRoute,

--- a/web/src/tests/integration/create-team.integration.test.tsx
+++ b/web/src/tests/integration/create-team.integration.test.tsx
@@ -7,7 +7,6 @@ import {
   buildRootRoute,
   buildStubRoute,
   createAuthedAuth,
-  createBaseRouterContext,
   createMockTeam,
   createMockUserProfile,
   renderWithRouter,
@@ -59,7 +58,6 @@ describe('Create team', () => {
       routeTree: buildCreateTeamRouteTree(),
       initialEntry: '/create-team',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     expect(await screen.findByLabelText(/team name/i)).toBeInTheDocument();
@@ -77,7 +75,6 @@ describe('Create team', () => {
       routeTree: buildCreateTeamRouteTree(),
       initialEntry: '/create-team',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     expect(await screen.findByText(/only have one team per season/i)).toBeInTheDocument();
@@ -100,7 +97,6 @@ describe('Create team', () => {
       routeTree: buildCreateTeamRouteTree(),
       initialEntry: '/create-team',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     await user.type(await screen.findByLabelText(/team name/i), '  My Racing Team  ');
@@ -123,7 +119,6 @@ describe('Create team', () => {
       routeTree: buildCreateTeamRouteTree(),
       initialEntry: '/create-team',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     await user.type(await screen.findByLabelText(/team name/i), 'Team Name');
@@ -143,7 +138,6 @@ describe('Create team', () => {
       routeTree: buildCreateTeamRouteTree(),
       initialEntry: '/create-team',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     await user.click(await screen.findByRole('button', { name: /create team/i }));
@@ -160,7 +154,6 @@ describe('Create team', () => {
       routeTree: buildCreateTeamRouteTree(),
       initialEntry: '/create-team?redirect=/leagues',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     await user.type(await screen.findByLabelText(/team name/i), 'My Racing Team');

--- a/web/src/tests/integration/join-invite.integration.test.tsx
+++ b/web/src/tests/integration/join-invite.integration.test.tsx
@@ -7,7 +7,6 @@ import { previewInvite } from '@/services/leagueInviteService';
 import { standingsKeys } from '@/services/standingsService';
 import {
   createAuthedAuth,
-  createBaseRouterContext,
   createMockLeague,
   createMockTeam,
   createMockUserProfile,
@@ -125,13 +124,12 @@ function buildJoinInviteRouteTree() {
 // query on the authed branches), not from context — so seed the profile here and
 // keep the `team` arg as the test's has-team intent. Unauthenticated renders
 // never fetch it, so the handler is harmless there.
-function makeRouterContext(team: Team | null): Omit<RouterContext, 'auth' | 'queryClient'> {
+function stubProfileForTeam(team: Team | null): void {
   server.use(
     http.get(`${API_BASE}/me/profile`, () =>
       HttpResponse.json(createMockUserProfile({ hasTeam: team !== null })),
     ),
   );
-  return createBaseRouterContext();
 }
 
 const TOKEN = 'abc-token';
@@ -154,11 +152,11 @@ describe('Join via invite token', () => {
   it('shows sign-in and create-account links carrying a redirect back to the invite for unauthenticated users', async () => {
     server.use(previewHandler());
 
+    stubProfileForTeam(null);
     renderWithRouter({
       routeTree: buildJoinInviteRouteTree(),
       initialEntry: `/join/${TOKEN}`,
       auth: createUnauthAuth(),
-      routerContext: makeRouterContext(null),
     });
 
     const signInLink = await screen.findByRole('link', { name: /sign in to join/i });
@@ -179,11 +177,11 @@ describe('Join via invite token', () => {
   it('shows a create-team link carrying a redirect back to the invite for authed users without a team', async () => {
     server.use(previewHandler());
 
+    stubProfileForTeam(null);
     renderWithRouter({
       routeTree: buildJoinInviteRouteTree(),
       initialEntry: `/join/${TOKEN}`,
       auth: createAuthedAuth(),
-      routerContext: makeRouterContext(null),
     });
 
     const createTeamLink = await screen.findByRole('link', { name: /create team/i });
@@ -199,11 +197,11 @@ describe('Join via invite token', () => {
   it('shows the join-league button for authed users with a team', async () => {
     server.use(previewHandler());
 
+    stubProfileForTeam(createMockTeam());
     renderWithRouter({
       routeTree: buildJoinInviteRouteTree(),
       initialEntry: `/join/${TOKEN}`,
       auth: createAuthedAuth(),
-      routerContext: makeRouterContext(createMockTeam()),
     });
 
     expect(await screen.findByRole('button', { name: /join league/i })).toBeInTheDocument();
@@ -221,11 +219,11 @@ describe('Join via invite token', () => {
       ),
     );
 
+    stubProfileForTeam(createMockTeam());
     const { queryClient } = renderWithRouter({
       routeTree: buildJoinInviteRouteTree(),
       initialEntry: `/join/${TOKEN}`,
       auth: createAuthedAuth(),
-      routerContext: makeRouterContext(createMockTeam()),
     });
 
     // A cached standings entry is required for the invalidation to be observable.
@@ -246,11 +244,11 @@ describe('Join via invite token', () => {
       ),
     );
 
+    stubProfileForTeam(null);
     renderWithRouter({
       routeTree: buildJoinInviteRouteTree(),
       initialEntry: `/join/${TOKEN}`,
       auth: createUnauthAuth(),
-      routerContext: makeRouterContext(null),
     });
 
     expect(await screen.findByRole('heading', { name: /invite not found/i })).toBeInTheDocument();
@@ -267,11 +265,11 @@ describe('Join via invite token', () => {
       ),
     );
 
+    stubProfileForTeam(null);
     renderWithRouter({
       routeTree: buildJoinInviteRouteTree(),
       initialEntry: `/join/${TOKEN}`,
       auth: createUnauthAuth(),
-      routerContext: makeRouterContext(null),
     });
 
     expect(
@@ -287,11 +285,11 @@ describe('Join via invite token', () => {
   it('shows the league-full alert and hides action buttons when preview reports the league is full', async () => {
     server.use(previewHandler({ isLeagueFull: true }));
 
+    stubProfileForTeam(createMockTeam());
     renderWithRouter({
       routeTree: buildJoinInviteRouteTree(),
       initialEntry: `/join/${TOKEN}`,
       auth: createAuthedAuth(),
-      routerContext: makeRouterContext(createMockTeam()),
     });
 
     expect(await screen.findByRole('alert')).toHaveTextContent(
@@ -317,11 +315,11 @@ describe('Join via invite token', () => {
       ),
     );
 
+    stubProfileForTeam(createMockTeam());
     renderWithRouter({
       routeTree: buildJoinInviteRouteTree(),
       initialEntry: `/join/${TOKEN}`,
       auth: createAuthedAuth(),
-      routerContext: makeRouterContext(createMockTeam()),
     });
 
     await user.click(await screen.findByRole('button', { name: /join league/i }));
@@ -340,11 +338,11 @@ describe('Join via invite token', () => {
       http.post(`${API_BASE}/leagues/join/${TOKEN}`, () => new HttpResponse(null, { status: 204 })),
     );
 
+    stubProfileForTeam(createMockTeam());
     renderWithRouter({
       routeTree: buildJoinInviteRouteTree(),
       initialEntry: `/join/${TOKEN}`,
       auth: createAuthedAuth(),
-      routerContext: makeRouterContext(createMockTeam()),
     });
 
     await user.click(await screen.findByRole('button', { name: /join league/i }));
@@ -373,11 +371,11 @@ describe('Join via invite token', () => {
       }),
     );
 
+    stubProfileForTeam(createMockTeam());
     renderWithRouter({
       routeTree: buildJoinInviteRouteTree(),
       initialEntry: `/join/${TOKEN}`,
       auth: createAuthedAuth(),
-      routerContext: makeRouterContext(createMockTeam()),
     });
 
     const joinButton = await screen.findByRole('button', { name: /join league/i });
@@ -402,11 +400,11 @@ describe('Join via invite token', () => {
       }),
     );
 
+    stubProfileForTeam(createMockTeam());
     renderWithRouter({
       routeTree: buildJoinInviteRouteTree(),
       initialEntry: `/join/${TOKEN}`,
       auth: createAuthedAuth(),
-      routerContext: makeRouterContext(createMockTeam()),
     });
 
     await user.click(await screen.findByRole('button', { name: /join league/i }));

--- a/web/src/tests/integration/join-invite.integration.test.tsx
+++ b/web/src/tests/integration/join-invite.integration.test.tsx
@@ -2,9 +2,9 @@ import { JoinInvite } from '@/components/JoinInvite/JoinInvite';
 import { RouteErrorComponent } from '@/components/RouteErrorComponent/RouteErrorComponent';
 import type { Team } from '@/contracts/Team';
 import type { RouterContext } from '@/lib/router-context';
+import { API_BASE, server } from '@/mocks';
 import { previewInvite } from '@/services/leagueInviteService';
 import { standingsKeys } from '@/services/standingsService';
-import { API_BASE, server } from '@/setupTests';
 import {
   createAuthedAuth,
   createBaseRouterContext,

--- a/web/src/tests/integration/leaderboard.integration.test.tsx
+++ b/web/src/tests/integration/leaderboard.integration.test.tsx
@@ -1,9 +1,9 @@
 import { League } from '@/components/League/League';
 import type { LeagueStandings, TeamLeagueStanding } from '@/contracts/LeagueStandings';
 import type { RouterContext } from '@/lib/router-context';
+import { API_BASE, server } from '@/mocks';
 import { getLeagueById } from '@/services/leagueService';
 import { getLeagueStandings } from '@/services/standingsService';
-import { API_BASE, server } from '@/setupTests';
 import {
   buildAuthenticatedLayout,
   buildTeamRequiredLayout,

--- a/web/src/tests/integration/leaderboard.integration.test.tsx
+++ b/web/src/tests/integration/leaderboard.integration.test.tsx
@@ -8,7 +8,6 @@ import {
   buildAuthenticatedLayout,
   buildTeamRequiredLayout,
   createAuthedAuth,
-  createBaseRouterContext,
   createMockLeague,
   createMockLeagueStandings,
   createMockTeam,
@@ -74,7 +73,6 @@ function renderLeaguePage(standings: LeagueStandings) {
     routeTree: buildLeagueRouteTree(),
     initialEntry: '/league/1',
     auth: createAuthedAuth(),
-    routerContext: createBaseRouterContext(),
   });
 }
 

--- a/web/src/tests/integration/league-invite-dialog.integration.test.tsx
+++ b/web/src/tests/integration/league-invite-dialog.integration.test.tsx
@@ -7,7 +7,6 @@ import {
   buildAuthenticatedLayout,
   buildTeamRequiredLayout,
   createAuthedAuth,
-  createBaseRouterContext,
   createMockLeague,
   createMockLeagueStandings,
   createMockTeam,
@@ -68,14 +67,13 @@ const ownerAuth = () => createAuthedAuth({ user: { id: 'user-owner' } as User })
 // Profile id matches the league's ownerId so the Invite button renders (it only
 // shows for the owner of a private league); served via the profile query. The
 // `/me/team` handler satisfies the `requireTeam` guard on the layout.
-function ownerRouterContext(): Omit<RouterContext, 'auth' | 'queryClient'> {
+function stubLeagueOwner(): void {
   server.use(
     http.get(`${API_BASE}/me/profile`, () =>
       HttpResponse.json(createMockUserProfile({ id: OWNER_ID })),
     ),
     http.get(`${API_BASE}/me/team`, () => HttpResponse.json(createMockTeam())),
   );
-  return createBaseRouterContext();
 }
 
 function privateLeagueHandler() {
@@ -142,11 +140,11 @@ describe('Share invite dialog', () => {
       http.post(`${API_BASE}/leagues/${LEAGUE_ID}/invite`, inviteFetch),
     );
 
+    stubLeagueOwner();
     renderWithRouter({
       routeTree: buildLeagueRouteTree(),
       initialEntry: `/league/${LEAGUE_ID}`,
       auth: ownerAuth(),
-      routerContext: ownerRouterContext(),
     });
 
     expect(inviteFetch).not.toHaveBeenCalled();
@@ -169,11 +167,11 @@ describe('Share invite dialog', () => {
       ),
     );
 
+    stubLeagueOwner();
     renderWithRouter({
       routeTree: buildLeagueRouteTree(),
       initialEntry: `/league/${LEAGUE_ID}`,
       auth: ownerAuth(),
-      routerContext: ownerRouterContext(),
     });
 
     await user.click(await screen.findByRole('button', { name: 'Invite' }));
@@ -199,11 +197,11 @@ describe('Share invite dialog', () => {
       http.post(`${API_BASE}/leagues/${LEAGUE_ID}/invite`, inviteFetch),
     );
 
+    stubLeagueOwner();
     renderWithRouter({
       routeTree: buildLeagueRouteTree(),
       initialEntry: `/league/${LEAGUE_ID}`,
       auth: ownerAuth(),
-      routerContext: ownerRouterContext(),
     });
 
     await user.click(await screen.findByRole('button', { name: 'Invite' }));
@@ -237,11 +235,11 @@ describe('Share invite dialog', () => {
       ),
     );
 
+    stubLeagueOwner();
     renderWithRouter({
       routeTree: buildLeagueRouteTree(),
       initialEntry: `/league/${LEAGUE_ID}`,
       auth: ownerAuth(),
-      routerContext: ownerRouterContext(),
     });
 
     await user.click(await screen.findByRole('button', { name: 'Invite' }));
@@ -268,11 +266,11 @@ describe('Share invite dialog', () => {
       ),
     );
 
+    stubLeagueOwner();
     renderWithRouter({
       routeTree: buildLeagueRouteTree(),
       initialEntry: `/league/${LEAGUE_ID}`,
       auth: ownerAuth(),
-      routerContext: ownerRouterContext(),
     });
 
     await user.click(await screen.findByRole('button', { name: 'Invite' }));

--- a/web/src/tests/integration/league-invite-dialog.integration.test.tsx
+++ b/web/src/tests/integration/league-invite-dialog.integration.test.tsx
@@ -1,8 +1,8 @@
 import { League } from '@/components/League/League';
 import type { RouterContext } from '@/lib/router-context';
+import { API_BASE, server } from '@/mocks';
 import { getLeagueById } from '@/services/leagueService';
 import { getLeagueStandings } from '@/services/standingsService';
-import { API_BASE, server } from '@/setupTests';
 import {
   buildAuthenticatedLayout,
   buildTeamRequiredLayout,

--- a/web/src/tests/integration/league-loader.integration.test.tsx
+++ b/web/src/tests/integration/league-loader.integration.test.tsx
@@ -7,7 +7,6 @@ import {
   buildAuthenticatedLayout,
   buildTeamRequiredLayout,
   createAuthedAuth,
-  createBaseRouterContext,
   createMockLeague,
   createMockLeagueStandings,
   createMockTeam,
@@ -70,7 +69,6 @@ function renderLeagueRoute() {
     routeTree: buildLeagueRouteTree(),
     initialEntry: '/league/1',
     auth: createAuthedAuth(),
-    routerContext: createBaseRouterContext(),
   });
 }
 

--- a/web/src/tests/integration/league-loader.integration.test.tsx
+++ b/web/src/tests/integration/league-loader.integration.test.tsx
@@ -1,8 +1,8 @@
 import { League } from '@/components/League/League';
 import type { RouterContext } from '@/lib/router-context';
+import { API_BASE, server } from '@/mocks';
 import { getLeagueById } from '@/services/leagueService';
 import { getLeagueStandings } from '@/services/standingsService';
-import { API_BASE, server } from '@/setupTests';
 import {
   buildAuthenticatedLayout,
   buildTeamRequiredLayout,

--- a/web/src/tests/integration/leagues.integration.test.tsx
+++ b/web/src/tests/integration/leagues.integration.test.tsx
@@ -10,7 +10,6 @@ import {
   buildAuthenticatedLayout,
   buildTeamRequiredLayout,
   createAuthedAuth,
-  createBaseRouterContext,
   createMockLeague,
   createMockLeagueStandings,
   createMockTeam,
@@ -104,11 +103,10 @@ function buildLeaguesListRouteTree() {
   ]);
 }
 
-function authedRouterContext(): Omit<RouterContext, 'auth' | 'queryClient'> {
+function stubMyTeam(): void {
   // The League/BrowseLeagues pages read profile through the query (default
   // handler); the `/me/team` handler satisfies the `requireTeam` guard.
   server.use(http.get(`${API_BASE}/me/team`, () => HttpResponse.json(createMockTeam())));
-  return createBaseRouterContext();
 }
 
 describe('Browse leagues', () => {
@@ -136,11 +134,11 @@ describe('Browse leagues', () => {
       ),
     );
 
+    stubMyTeam();
     renderWithRouter({
       routeTree: buildBrowseLeaguesRouteTree(),
       initialEntry: '/browse-leagues',
       auth: createAuthedAuth(),
-      routerContext: authedRouterContext(),
     });
 
     expect(await screen.findByRole('heading', { name: 'Open Grid' })).toBeInTheDocument();
@@ -163,11 +161,11 @@ describe('Browse leagues', () => {
       ),
     );
 
+    stubMyTeam();
     renderWithRouter({
       routeTree: buildBrowseLeaguesRouteTree(),
       initialEntry: '/browse-leagues',
       auth: createAuthedAuth(),
-      routerContext: authedRouterContext(),
     });
 
     expect(await screen.findByRole('button', { name: /join league/i })).toBeDisabled();
@@ -182,11 +180,11 @@ describe('Browse leagues', () => {
       ),
     );
 
+    stubMyTeam();
     renderWithRouter({
       routeTree: buildBrowseLeaguesRouteTree(),
       initialEntry: '/browse-leagues',
       auth: createAuthedAuth(),
-      routerContext: authedRouterContext(),
     });
 
     await user.click(await screen.findByRole('button', { name: /join league/i }));
@@ -209,11 +207,11 @@ describe('Browse leagues', () => {
       ),
     );
 
+    stubMyTeam();
     renderWithRouter({
       routeTree: buildBrowseLeaguesRouteTree(),
       initialEntry: '/browse-leagues',
       auth: createAuthedAuth(),
-      routerContext: authedRouterContext(),
     });
 
     const joinButtons = await screen.findAllByRole('button', { name: /join league/i });
@@ -232,11 +230,11 @@ describe('Browse leagues', () => {
   it('renders the empty state when no leagues are available', async () => {
     server.use(http.get(`${API_BASE}/leagues/available`, () => HttpResponse.json([])));
 
+    stubMyTeam();
     renderWithRouter({
       routeTree: buildBrowseLeaguesRouteTree(),
       initialEntry: '/browse-leagues',
       auth: createAuthedAuth(),
-      routerContext: authedRouterContext(),
     });
 
     expect(
@@ -249,11 +247,11 @@ describe('Browse leagues', () => {
       http.get(`${API_BASE}/leagues/available`, () => new HttpResponse(null, { status: 500 })),
     );
 
+    stubMyTeam();
     renderWithRouter({
       routeTree: buildBrowseLeaguesRouteTree(),
       initialEntry: '/browse-leagues',
       auth: createAuthedAuth(),
-      routerContext: authedRouterContext(),
     });
 
     expect(
@@ -278,11 +276,11 @@ describe('Browse leagues', () => {
       ),
     );
 
+    stubMyTeam();
     renderWithRouter({
       routeTree: buildBrowseLeaguesRouteTree(),
       initialEntry: '/browse-leagues',
       auth: createAuthedAuth(),
-      routerContext: authedRouterContext(),
     });
 
     await user.click(await screen.findByRole('button', { name: /join league/i }));
@@ -302,11 +300,11 @@ describe('Browse leagues', () => {
       http.post(`${API_BASE}/leagues/99/join`, () => HttpResponse.error()),
     );
 
+    stubMyTeam();
     renderWithRouter({
       routeTree: buildBrowseLeaguesRouteTree(),
       initialEntry: '/browse-leagues',
       auth: createAuthedAuth(),
-      routerContext: authedRouterContext(),
     });
 
     await user.click(await screen.findByRole('button', { name: /join league/i }));
@@ -327,11 +325,11 @@ describe('Browse leagues', () => {
       ),
     );
 
+    stubMyTeam();
     const { queryClient } = renderWithRouter({
       routeTree: buildBrowseLeaguesRouteTree(),
       initialEntry: '/browse-leagues',
       auth: createAuthedAuth(),
-      routerContext: authedRouterContext(),
     });
 
     // A cached standings entry is required for the invalidation to be observable.
@@ -357,11 +355,11 @@ describe('My leagues', () => {
       ),
     );
 
+    stubMyTeam();
     renderWithRouter({
       routeTree: buildLeaguesListRouteTree(),
       initialEntry: '/leagues',
       auth: createAuthedAuth(),
-      routerContext: authedRouterContext(),
     });
 
     expect(await screen.findByRole('link', { name: /open apex hunters/i })).toHaveAttribute(
@@ -377,11 +375,11 @@ describe('My leagues', () => {
   it('renders the empty state when no leagues have been joined', async () => {
     server.use(http.get(`${API_BASE}/me/leagues`, () => HttpResponse.json([])));
 
+    stubMyTeam();
     renderWithRouter({
       routeTree: buildLeaguesListRouteTree(),
       initialEntry: '/leagues',
       auth: createAuthedAuth(),
-      routerContext: authedRouterContext(),
     });
 
     expect(await screen.findByText(/you haven't joined any leagues yet/i)).toBeInTheDocument();
@@ -399,11 +397,11 @@ describe('My leagues', () => {
       }),
     );
 
+    stubMyTeam();
     const { queryClient } = renderWithRouter({
       routeTree: buildLeaguesListRouteTree(),
       initialEntry: '/leagues',
       auth: createAuthedAuth(),
-      routerContext: authedRouterContext(),
     });
 
     queryClient.setQueryData(standingsKeys.all, []);
@@ -434,11 +432,11 @@ describe('My leagues', () => {
       http.post(`${API_BASE}/leagues`, () => new HttpResponse(null, { status: 500 })),
     );
 
+    stubMyTeam();
     renderWithRouter({
       routeTree: buildLeaguesListRouteTree(),
       initialEntry: '/leagues',
       auth: createAuthedAuth(),
-      routerContext: authedRouterContext(),
     });
 
     await user.click(await screen.findByRole('button', { name: /create league/i }));
@@ -461,11 +459,11 @@ describe('League page', () => {
       ),
     );
 
+    stubMyTeam();
     renderWithRouter({
       routeTree: buildLeagueRouteTree(),
       initialEntry: '/league/7',
       auth: createAuthedAuth(),
-      routerContext: authedRouterContext(),
     });
 
     expect(
@@ -481,11 +479,11 @@ describe('League page', () => {
       ),
     );
 
+    stubMyTeam();
     renderWithRouter({
       routeTree: buildLeagueRouteTree(),
       initialEntry: '/league/123',
       auth: createAuthedAuth(),
-      routerContext: authedRouterContext(),
     });
 
     expect(await screen.findByRole('heading', { name: 'League Not Found' })).toBeInTheDocument();
@@ -499,11 +497,11 @@ describe('League page', () => {
       ),
     );
 
+    stubMyTeam();
     renderWithRouter({
       routeTree: buildLeagueRouteTree(),
       initialEntry: '/league/500',
       auth: createAuthedAuth(),
-      routerContext: authedRouterContext(),
     });
 
     expect(

--- a/web/src/tests/integration/leagues.integration.test.tsx
+++ b/web/src/tests/integration/leagues.integration.test.tsx
@@ -3,9 +3,9 @@ import { League } from '@/components/League/League';
 import { LeagueList } from '@/components/LeagueList/LeagueList';
 import { RouteErrorComponent } from '@/components/RouteErrorComponent/RouteErrorComponent';
 import type { RouterContext } from '@/lib/router-context';
+import { API_BASE, server } from '@/mocks';
 import { getAvailableLeagues, getLeagueById, getMyLeagues } from '@/services/leagueService';
 import { getLeagueStandings, standingsKeys } from '@/services/standingsService';
-import { API_BASE, server } from '@/setupTests';
 import {
   buildAuthenticatedLayout,
   buildTeamRequiredLayout,

--- a/web/src/tests/integration/navigation.integration.test.tsx
+++ b/web/src/tests/integration/navigation.integration.test.tsx
@@ -5,7 +5,6 @@ import { API_BASE, server } from '@/mocks';
 import {
   buildStubRoute,
   createAuthedAuth,
-  createBaseRouterContext,
   createMockUserProfile,
   renderWithRouter,
   setMobileViewport,
@@ -54,7 +53,6 @@ function renderNav(options: {
     routeTree: buildNavRouteTree(),
     initialEntry: options.initialEntry ?? '/',
     auth: createAuthedAuth(),
-    routerContext: createBaseRouterContext(),
   });
 }
 

--- a/web/src/tests/integration/navigation.integration.test.tsx
+++ b/web/src/tests/integration/navigation.integration.test.tsx
@@ -1,13 +1,14 @@
 import { Layout } from '@/components/Layout/Layout';
 import type { UserProfile } from '@/contracts/UserProfile';
 import type { RouterContext } from '@/lib/router-context';
-import { API_BASE, server, setMobileViewport } from '@/setupTests';
+import { API_BASE, server } from '@/mocks';
 import {
   buildStubRoute,
   createAuthedAuth,
   createBaseRouterContext,
   createMockUserProfile,
   renderWithRouter,
+  setMobileViewport,
 } from '@/tests/test-utils';
 import { createRootRouteWithContext } from '@tanstack/react-router';
 import { screen, within } from '@testing-library/react';

--- a/web/src/tests/integration/root-routing.integration.test.tsx
+++ b/web/src/tests/integration/root-routing.integration.test.tsx
@@ -1,10 +1,10 @@
 import { IndexRoute } from '@/components/IndexRoute/IndexRoute';
 import { RouteErrorComponent } from '@/components/RouteErrorComponent/RouteErrorComponent';
 import type { RouterContext } from '@/lib/router-context';
+import { API_BASE, server } from '@/mocks';
 import { getRaceWeekends } from '@/services/raceWeekendService';
 import { seasonQuery } from '@/services/seasonService';
 import { getTeamSummary } from '@/services/teamService';
-import { API_BASE, server } from '@/setupTests';
 import {
   createAuthedAuth,
   createBaseRouterContext,

--- a/web/src/tests/integration/root-routing.integration.test.tsx
+++ b/web/src/tests/integration/root-routing.integration.test.tsx
@@ -7,7 +7,6 @@ import { seasonQuery } from '@/services/seasonService';
 import { getTeamSummary } from '@/services/teamService';
 import {
   createAuthedAuth,
-  createBaseRouterContext,
   createMockUserProfile,
   createUnauthAuth,
   renderWithRouter,
@@ -80,7 +79,6 @@ describe('routing at /', () => {
       routeTree: buildIndexRouteTree(),
       initialEntry: '/',
       auth: createUnauthAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     expect(
@@ -122,7 +120,6 @@ describe('routing at /', () => {
       routeTree: buildIndexRouteTree(),
       initialEntry: '/',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     expect(await screen.findByRole('heading', { name: 'Red Bull Racing' })).toBeInTheDocument();
@@ -156,7 +153,6 @@ describe('routing at /', () => {
       routeTree: buildIndexRouteTree(),
       initialEntry: '/',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     expect(await screen.findByText("You're riding solo")).toBeInTheDocument();
@@ -182,7 +178,6 @@ describe('routing at /', () => {
       routeTree: buildIndexRouteTree(),
       initialEntry: '/',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     expect(await screen.findByRole('heading', { name: 'Red Bull Racing' })).toBeInTheDocument();
@@ -223,7 +218,6 @@ describe('routing at /', () => {
       routeTree: buildIndexRouteTree(),
       initialEntry: '/',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     const retry = await screen.findByRole('button', { name: /try again/i });
@@ -256,7 +250,6 @@ describe('routing at /', () => {
       routeTree: buildIndexRouteTree(),
       initialEntry: '/',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     expect(
@@ -288,7 +281,6 @@ describe('routing at /', () => {
       routeTree: buildIndexRouteTree(),
       initialEntry: '/',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     // The team name still comes from the summary; the greeting name is just blank.
@@ -314,7 +306,6 @@ describe('routing at /', () => {
       routeTree: buildIndexRouteTree(),
       initialEntry: '/',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     expect(await screen.findByRole('heading', { name: 'Welcome, Ada' })).toBeInTheDocument();

--- a/web/src/tests/integration/route-error-recovery.integration.test.tsx
+++ b/web/src/tests/integration/route-error-recovery.integration.test.tsx
@@ -1,7 +1,7 @@
 import { RouteErrorComponent } from '@/components/RouteErrorComponent/RouteErrorComponent';
 import type { RouterContext } from '@/lib/router-context';
+import { API_BASE, server } from '@/mocks';
 import { getAvailableLeagues } from '@/services/leagueService';
-import { API_BASE, server } from '@/setupTests';
 import { createUnauthAuth, renderWithRouter } from '@/tests/test-utils';
 import { Outlet, createRootRouteWithContext, createRoute } from '@tanstack/react-router';
 import { screen } from '@testing-library/react';

--- a/web/src/tests/integration/route-guards.integration.test.tsx
+++ b/web/src/tests/integration/route-guards.integration.test.tsx
@@ -10,7 +10,6 @@ import {
   buildTeamRequiredLayout,
   buildUnauthenticatedLayout,
   createAuthedAuth,
-  createBaseRouterContext,
   createUnauthAuth,
   renderWithRouter,
 } from '@/tests/test-utils';
@@ -63,7 +62,6 @@ describe('route guard wiring', () => {
       routeTree: buildGuardRouteTree(),
       initialEntry: '/my-team',
       auth: createUnauthAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     expect(await screen.findByRole('heading', { name: 'Sign In Page' })).toBeInTheDocument();
@@ -77,7 +75,6 @@ describe('route guard wiring', () => {
       routeTree: buildGuardRouteTree(),
       initialEntry: '/league/5?tab=roster',
       auth: createUnauthAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     expect(await screen.findByRole('heading', { name: 'Sign In Page' })).toBeInTheDocument();
@@ -93,7 +90,6 @@ describe('route guard wiring', () => {
       routeTree: buildGuardRouteTree(),
       initialEntry: '/my-team',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     expect(await screen.findByRole('heading', { name: 'Create Team Page' })).toBeInTheDocument();
@@ -214,7 +210,6 @@ describe('already-authed bounce wiring on the sign-in/sign-up routes', () => {
       routeTree: buildAuthedBounceRouteTree(),
       initialEntry: '/sign-in?redirect=/league/5',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     expect(await screen.findByRole('heading', { name: 'League Page' })).toBeInTheDocument();
@@ -227,7 +222,6 @@ describe('already-authed bounce wiring on the sign-in/sign-up routes', () => {
       routeTree: buildAuthedBounceRouteTree(),
       initialEntry: '/sign-up?redirect=/account',
       auth: createAuthedAuth(),
-      routerContext: createBaseRouterContext(),
     });
 
     expect(await screen.findByRole('heading', { name: 'Account Page' })).toBeInTheDocument();

--- a/web/src/tests/integration/route-guards.integration.test.tsx
+++ b/web/src/tests/integration/route-guards.integration.test.tsx
@@ -2,7 +2,7 @@ import { RouteErrorComponent } from '@/components/RouteErrorComponent/RouteError
 import { redirectIfAuthenticated, requireAuth, requireTeam } from '@/lib/route-guards';
 import type { RouterContext } from '@/lib/router-context';
 import { safeInternalPath } from '@/lib/safeInternalPath';
-import { API_BASE, server } from '@/setupTests';
+import { API_BASE, server } from '@/mocks';
 import {
   buildAuthenticatedLayout,
   buildRootRoute,

--- a/web/src/tests/integration/signup-resend.integration.test.tsx
+++ b/web/src/tests/integration/signup-resend.integration.test.tsx
@@ -2,12 +2,7 @@ import { SignUpForm } from '@/components/auth/SignUpForm/SignUpForm';
 import type { RouterContext } from '@/lib/router-context';
 import { safeInternalPath } from '@/lib/safeInternalPath';
 import { supabase } from '@/lib/supabase';
-import {
-  buildUnauthenticatedLayout,
-  createBaseRouterContext,
-  createUnauthAuth,
-  renderWithRouter,
-} from '@/tests/test-utils';
+import { buildUnauthenticatedLayout, createUnauthAuth, renderWithRouter } from '@/tests/test-utils';
 import { AuthApiError } from '@supabase/supabase-js';
 import { Outlet, createRootRouteWithContext, createRoute } from '@tanstack/react-router';
 import { screen, waitFor } from '@testing-library/react';
@@ -72,7 +67,6 @@ describe('Signup resend confirmation', () => {
       routeTree: buildSignUpRouteTree(),
       initialEntry: '/sign-up?redirect=/leagues/123',
       auth: createUnauthAuth({ signUp }),
-      routerContext: createBaseRouterContext(),
     });
 
     await driveFormToPending(user);
@@ -100,7 +94,6 @@ describe('Signup resend confirmation', () => {
       routeTree: buildSignUpRouteTree(),
       initialEntry: '/sign-up?redirect=/leagues/123',
       auth: createUnauthAuth({ signUp }),
-      routerContext: createBaseRouterContext(),
     });
 
     await driveFormToPending(user);

--- a/web/src/tests/integration/team-lineup.integration.test.tsx
+++ b/web/src/tests/integration/team-lineup.integration.test.tsx
@@ -1,12 +1,12 @@
 import { MyTeamRoute } from '@/components/Team/Team';
 import type { Team } from '@/contracts/Team';
 import type { RouterContext } from '@/lib/router-context';
+import { API_BASE, server } from '@/mocks';
 import { constructorsQuery } from '@/services/constructorService';
 import { driversQuery } from '@/services/driverService';
 import { getRaceWeekends } from '@/services/raceWeekendService';
 import { seasonQuery } from '@/services/seasonService';
 import { myTeamQuery } from '@/services/teamService';
-import { API_BASE, server } from '@/setupTests';
 import {
   buildAuthenticatedLayout,
   buildStubRoute,

--- a/web/src/tests/integration/view-team.integration.test.tsx
+++ b/web/src/tests/integration/view-team.integration.test.tsx
@@ -1,11 +1,11 @@
 import { TeamRoute } from '@/components/Team/Team';
 import type { RouterContext } from '@/lib/router-context';
+import { API_BASE, server } from '@/mocks';
 import { constructorsQuery } from '@/services/constructorService';
 import { driversQuery } from '@/services/driverService';
 import { getRaceWeekends } from '@/services/raceWeekendService';
 import { seasonQuery } from '@/services/seasonService';
 import { getTeamById, myTeamQuery } from '@/services/teamService';
-import { API_BASE, server } from '@/setupTests';
 import {
   buildAuthenticatedLayout,
   buildStubRoute,

--- a/web/src/tests/test-utils/index.ts
+++ b/web/src/tests/test-utils/index.ts
@@ -24,7 +24,7 @@ export {
   createMockTeamDriver,
   createMockUserProfile,
 } from './mockFactories';
-export { createAuthedAuth, createBaseRouterContext, createUnauthAuth } from './renderContexts';
+export { createAuthedAuth, createUnauthAuth } from './renderContexts';
 export { renderWithRouter } from './renderWithRouter';
 export type { RenderWithRouterOptions } from './renderWithRouter';
 export {

--- a/web/src/tests/test-utils/index.ts
+++ b/web/src/tests/test-utils/index.ts
@@ -8,6 +8,7 @@
  * import { createMockTeam, createMockDriver } from '@/tests/test-utils';
  */
 
+export { setMobileViewport } from './matchMedia';
 export {
   createMockConstructor,
   createMockConstructorList,

--- a/web/src/tests/test-utils/matchMedia.ts
+++ b/web/src/tests/test-utils/matchMedia.ts
@@ -1,0 +1,27 @@
+let mobileViewport = false;
+
+/**
+ * Drives `useIsMobile()` in tests by setting whether `matchMedia` reports the
+ * mobile breakpoint as matching. The `change` listeners are no-ops, so flip
+ * this before mount, not mid-render.
+ */
+export function setMobileViewport(value: boolean): void {
+  mobileViewport = value;
+}
+
+// jsdom has no `matchMedia`. Report the mobile breakpoint query against the
+// `mobileViewport` flag (everything else, e.g. `next-themes`'s color-scheme
+// query, stays unmatched).
+export function installMatchMediaMock(): void {
+  window.matchMedia = ((query: string): MediaQueryList =>
+    ({
+      matches: query.includes('max-width') ? mobileViewport : false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList) as typeof window.matchMedia;
+}

--- a/web/src/tests/test-utils/renderContexts.ts
+++ b/web/src/tests/test-utils/renderContexts.ts
@@ -1,5 +1,4 @@
 import type { Auth } from '@/lib/authStore';
-import type { RouterContext } from '@/lib/router-context';
 import type { Session, User } from '@supabase/supabase-js';
 import { vi } from 'vitest';
 
@@ -37,13 +36,4 @@ export function createAuthedAuth(overrides: Partial<Auth> = {}): Auth {
     session: {} as Session,
     ...overrides,
   };
-}
-
-/**
- * Test utility: Creates the `routerContext` arg for `renderWithRouter`. With
- * `auth` and the per-test `queryClient` wired separately, nothing else remains in
- * `RouterContext`, so this returns an empty object.
- */
-export function createBaseRouterContext(): Omit<RouterContext, 'auth' | 'queryClient'> {
-  return {};
 }

--- a/web/src/tests/test-utils/renderWithRouter.tsx
+++ b/web/src/tests/test-utils/renderWithRouter.tsx
@@ -1,5 +1,4 @@
 import { type Auth, routerAuth, seedAuthStore } from '@/lib/authStore';
-import type { RouterContext } from '@/lib/router-context';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   type AnyRoute,
@@ -13,14 +12,6 @@ export interface RenderWithRouterOptions {
   routeTree: AnyRoute;
   initialEntry: string;
   auth: Auth;
-  /**
-   * Router-level context for `createRouter` beyond `auth` and `queryClient`
-   * (both wired automatically — `auth` from the option above, `queryClient` as a
-   * fresh per-test client — so route guards and the React tree always see the
-   * same values). Profile/team/season are read through the Query cache, so
-   * nothing else remains in `RouterContext` to supply — hence optional.
-   */
-  routerContext?: Omit<RouterContext, 'auth' | 'queryClient'>;
 }
 
 /**
@@ -40,12 +31,7 @@ export interface RenderWithRouterOptions {
  * Returns the React Testing Library result plus the per-test `queryClient`, so
  * tests can seed or assert against the Query cache directly.
  */
-export function renderWithRouter({
-  routeTree,
-  initialEntry,
-  auth,
-  routerContext = {},
-}: RenderWithRouterOptions) {
+export function renderWithRouter({ routeTree, initialEntry, auth }: RenderWithRouterOptions) {
   seedAuthStore(auth);
 
   const queryClient = new QueryClient({
@@ -55,7 +41,7 @@ export function renderWithRouter({
   const router = createRouter({
     routeTree,
     history: createMemoryHistory({ initialEntries: [initialEntry] }),
-    context: { ...routerContext, auth: routerAuth, queryClient },
+    context: { auth: routerAuth, queryClient },
   });
 
   return {


### PR DESCRIPTION
## Summary
Two behavior-neutral test-infra cleanups surfaced by the #247 RouterContext migration, split out to keep that PR reviewable: `setupTests.ts` now runs for side effects only (shared fixtures move to a `@/mocks` barrel that tests import directly), and the vestigial no-op `createBaseRouterContext` helper plus its `routerContext` plumbing are gone. Closes #263.

## Risk & scope
Pure refactor of the web Vitest test infrastructure — no production code changes. The existing suite is the regression guard.