### PR TITLE
Adopt per-resource query factories across the query layer

### DIFF
--- a/docs/adr/003-index-route-loader-guards-on-auth.md
+++ b/docs/adr/003-index-route-loader-guards-on-auth.md
@@ -26,7 +26,7 @@ loader: async ({ context }) => {
 component: IndexRoute,
 ```
 
-> `context.currentSeason` in this snippet has since moved to the TanStack Query cache — the loader now reads the season via `queryClient.ensureQueryData(seasonQuery)`; see [ADR 006](006-tanstack-query-for-cross-route-reads.md). The auth-guard decision is unchanged.
+> `context.currentSeason` in this snippet has since moved to the TanStack Query cache — the loader now reads the season from the Query cache; see [ADR 006](006-tanstack-query-for-cross-route-reads.md). The auth-guard decision is unchanged.
 
 ## Consequences
 

--- a/docs/adr/006-tanstack-query-for-cross-route-reads.md
+++ b/docs/adr/006-tanstack-query-for-cross-route-reads.md
@@ -52,5 +52,5 @@ Rejected — profile is consumed only by the always-on `Layout`, never by a load
 ## References
 
 - Tracking: #254. Closes #247; co-fixes #249, which closes once its regression tests confirm a transient failure no longer reads as "no team." Unblocks #248, #252, #255.
-- Builds on ADR 002 (`/` renders Home for authed users) and ADR 003 (index loader guards on auth — its `context.currentSeason!.id` read now goes through `seasonQuery`).
+- Builds on ADR 002 (`/` renders Home for authed users) and ADR 003 (index loader guards on auth — its `context.currentSeason!.id` read now goes through the Query cache).
 - Composes with ADR 004 (apiClient owns token refresh): the QueryClient's `retry: 1` layers onto `makeRequest`'s recovery.

--- a/docs/plans/305-per-resource-query-factories.md
+++ b/docs/plans/305-per-resource-query-factories.md
@@ -1,0 +1,92 @@
+# Adopt per-resource query factories across the query layer (#305)
+
+## Context
+
+Each of the six cached resources (team, profile, season, standings, drivers, constructors) exposes a single-member key factory like `teamKeys = { all: ['me','team'] }` plus a standalone `…Query`. That shape uses the `all` base _as the query's own key_, so there's no way to invalidate a resource's reads as a group versus a single read — they share one key. It also diverges from the idiomatic TanStack Query factory.
+
+This is a **mechanical, no-behavior-change refactor**. Each resource will expose one per-resource `…Queries` factory: an `all` base key, then one named member per read whose key _extends_ `all`. Invalidate a whole resource through `all`; address a single read through the member's `.queryKey`. Cache keys are ephemeral (rebuilt each session; user-switch reset is `queryClient.clear()` — key-agnostic), so changing the key strings has no observable effect as long as every reader and writer stays consistent.
+
+Reference pattern: [TkDodo — Effective React Query Keys](https://tkdodo.eu/blog/effective-react-query-keys) and [The Query Options API](https://tkdodo.eu/blog/the-query-options-api).
+
+## Target factory shape
+
+`all` stays a **value** (so group-invalidation reads `…Queries.all`, matching today's `…Keys.all` usage). Members are **functions returning `queryOptions`** — required so `list(seasonYear?)` can take a param, and so a member can spread `…Queries.all` into its key without the object-literal init-order trap (the spread runs lazily at call time).
+
+```ts
+// teamService.ts
+export const teamQueries = {
+  all: ['me', 'team'] as const,
+  mine: () =>
+    queryOptions({
+      queryKey: [...teamQueries.all, 'mine'] as const,
+      queryFn: getMyTeam,
+      staleTime: 5 * 60_000,
+    }),
+};
+```
+
+Per resource (member name → resulting key):
+
+| Service     | Factory              | `all`              | Member             | Key                                   | Notes                                                  |
+| ----------- | -------------------- | ------------------ | ------------------ | ------------------------------------- | ------------------------------------------------------ |
+| team        | `teamQueries`        | `['me','team']`    | `mine()`           | `['me','team','mine']`                | wraps `getMyTeam`, `staleTime 5m`                      |
+| userProfile | `profileQueries`     | `['me','profile']` | `current()`        | `['me','profile','current']`          | wraps `getCurrentProfile`, `staleTime 5m`              |
+| season      | `seasonQueries`      | `['season']`       | `current()`        | `['season','current']`                | **key unchanged** from today; no `staleTime`           |
+| standings   | `standingsQueries`   | `['me','standings']` | `mine()`         | `['me','standings','mine']`           | wraps `getMyStandings`; no `staleTime`                 |
+| driver      | `driverQueries`      | `['drivers']`      | `list(seasonYear?)`  | `['drivers','list', seasonYear ?? null]`      | `queryFn: () => getDrivers(seasonYear)`, `staleTime 5m`      |
+| constructor | `constructorQueries` | `['constructors']` | `list(seasonYear?)`  | `['constructors','list', seasonYear ?? null]` | `queryFn: () => getConstructors(seasonYear)`, `staleTime 5m` |
+
+The standalone `…Keys` and `…Query` exports are removed. Non-query reads stay as plain service functions, untouched: team `getTeamById`/`getTeamSummary`, standings `getLeagueStandings`.
+
+Service files: `web/src/services/{team,userProfile,season,standings,driver,constructor}Service.ts`.
+
+## The one nuance that breaks tests if missed
+
+Today several sites **seed/read a specific query at the bare `…Keys.all`**. Now the real query lives at the member key (e.g. `['me','team','mine']`), while `all` (`['me','team']`) is only its prefix. Sort every touchpoint into one of two buckets:
+
+- **Group invalidation → keep `…Queries.all`** (prefix match still hits the member): the standings invalidations in `CreateLeague.tsx`, `JoinInvite.tsx`, `BrowseLeagues.tsx`.
+- **Specific read/seed → move to `…Queries.<member>().queryKey`**: anywhere code seeds, reads, removes, or asserts one query.
+  - `route-guards.test.ts` — `setQueryData(teamKeys.all, …)` → `teamQueries.mine().queryKey`. **Critical:** `requireTeam` reads `teamQueries.mine()`; seeding at `.all` would leave the guard's read unseeded and trigger a real fetch.
+  - `leagues.integration.test.tsx` and `join-invite.integration.test.tsx` — `setQueryData(standingsKeys.all, [])` + `getQueryState(...).isInvalidated` → `standingsQueries.mine().queryKey`. Production still invalidates via `standingsQueries.all`; the member key extends it, so the prefix invalidation marks it — and now the test verifies the _real_ read is invalidated, not a synthetic group entry.
+  - `web/CLAUDE.md` renderWithRouter snippet `setQueryData(teamKeys.all, mockTeam)` → `teamQueries.mine().queryKey`.
+
+## Consumer migration (mechanical)
+
+Pattern across all consumers: rename the import, then replace the symbol. Reads `myTeamQuery` → `teamQueries.mine()`, `profileQuery` → `profileQueries.current()`, `seasonQuery` → `seasonQueries.current()`, `standingsQuery` → `standingsQueries.mine()`, `driversQuery` → `driverQueries.list()`, `constructorsQuery` → `constructorQueries.list()`. Keys: `myTeamQuery.queryKey` → `teamQueries.mine().queryKey`, etc.
+
+Production consumers:
+
+- `router.tsx` — loaders/guards: `ensureQueryData(profileQuery|seasonQuery|myTeamQuery|driversQuery|constructorsQuery)`. Update the stale `useSuspenseQuery(myTeamQuery)` comment.
+- `route-guards.ts` — `ensureQueryData(myTeamQuery)` → `teamQueries.mine()`.
+- `Team.tsx` — three `useSuspenseQuery(...)` reads (team/drivers/constructors), drivers+constructors appear twice.
+- `MyLeaguesList.tsx` — `useQuery(standingsQuery)` → `useQuery(standingsQueries.mine())`.
+- `CreateTeam.tsx` — `useQuery({ ...profileQuery, enabled })`, `removeQueries({ queryKey: myTeamQuery.queryKey })` (specific read → `mine().queryKey`), `invalidateQueries(profileQuery)`.
+- `Account.tsx` — `useSuspenseQuery(profileQuery)` + two `invalidateQueries(profileQuery)`.
+- Profile-shell `useQuery({ ...profileQuery, enabled: !!user })` → `{ ...profileQueries.current(), enabled: !!user }`: `IndexRoute.tsx`, `Leaderboard.tsx`, `AccountMenu.tsx`, `AppSidebar.tsx`, `League.tsx`, `JoinInvite.tsx`, `useCurrentAvatar.ts`, `useNavDestinations.ts`.
+- `useSetCaptain.ts` — four `myTeamQuery.queryKey` sites (cancel/get/set/invalidate); hoist `const teamKey = teamQueries.mine().queryKey;` once in the hook to avoid rebuilding. Update the `useSetCaptain` comment (in `useSetCaptain.test.ts`, references `myTeamQuery`/`teamKeys`) to the new symbol.
+- `useLineupPicker.ts` — two `invalidateQueries({ queryKey: myTeamQuery.queryKey })`.
+
+Test consumers (besides the seed/read nuance above): `account.integration.test.tsx` (`ensureQueryData(profileQuery)`, `getQueryData(profileQuery.queryKey)`), `create-team.integration.test.tsx` (`getQueryData(myTeamQuery.queryKey)`), `view-team.integration.test.tsx` + `team-lineup.integration.test.tsx` (`ensureQueryData` of team/season/drivers/constructors), `root-routing.integration.test.tsx` (`ensureQueryData(seasonQuery)`), `useSetCaptain.test.ts` (`setQueryData`/`getQueryData` on `myTeamQuery.queryKey`).
+
+## Docs
+
+- **`web/CLAUDE.md` → Data Loading Pattern.** Add the convention note (verbatim from the issue):
+  > **Query definitions.** Each resource's reads live in a per-resource `…Queries` factory in its service module, structured most-generic to most-specific: an `all` base key, then one member per read — named for the read, its key extending `all`.
+
+  Also update the inline example `useQuery({ ...profileQuery, enabled: !!user })` → `{ ...profileQueries.current(), enabled: !!user }`, and the renderWithRouter snippet `setQueryData(teamKeys.all, mockTeam)` → `teamQueries.mine().queryKey`.
+
+- **`docs/adr/003-index-route-loader-guards-on-auth.md`** — de-specify: drop the `queryClient.ensureQueryData(seasonQuery)` symbol; say the loader reads the season from the TanStack Query cache (still link ADR 006).
+- **`docs/adr/006-tanstack-query-for-cross-route-reads.md`** — de-specify: `…its 'context.currentSeason!.id' read now goes through 'seasonQuery'` → `…now goes through the Query cache`. (The line that already delegates query definitions/keys to the plan stays — no new ADR.)
+
+## Commits
+
+1. **Query factories + consumers + tests.** Replace the six `…Keys`/`…Query` pairs with `…Queries` factories; update every consumer and test (including the seed/read-vs-invalidate split). Must pass build, lint, test, format with no behavior change.
+2. **Docs.** `web/CLAUDE.md` convention note + example updates; ADR 003 & 006 de-specify.
+
+## Verification
+
+- `npm run web:test` — full frontend suite stays green (integration tests exercise the real router/loaders/guards through MSW, so they catch any seed/read key mismatch).
+- `npm run web:lint` and `npm run web:format:check` — clean (no dangling `…Keys`/`…Query` imports).
+- `rg "teamKeys|profileKeys|seasonKeys|standingsKeys|driverKeys|constructorKeys|myTeamQuery|profileQuery|seasonQuery|standingsQuery|driversQuery|constructorsQuery" web/src` returns nothing.
+- `npm run web:build` — type-checks the new factory shapes.
+- Optional smoke check against the dev stack: sign in, view Home (standings + leagues), open My Team (team/drivers/constructors load), set a captain (optimistic update + rollback path), create/join a league (standings refreshes).

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -47,8 +47,10 @@ Centralized `ApiClient` class handles all HTTP requests:
 Three kinds of reads:
 
 - **Route-owned data** — the route's loader fetches it before the component renders; the component reads `Route.useLoaderData()` without loading states.
-- **Cross-route reads** — each defined once as a `queryOptions` in its service module. Guards and loaders prime them with `context.queryClient.ensureQueryData(...)`; components read `useSuspenseQuery(...)` when a loader guarantees the data, or `useQuery({ ...profileQuery, enabled: !!user })` for shell that also renders for anonymous users (sidebar, account menu).
+- **Cross-route reads** — each defined once as a `queryOptions` in its service module. Guards and loaders prime them with `context.queryClient.ensureQueryData(...)`; components read `useSuspenseQuery(...)` when a loader guarantees the data, or `useQuery({ ...profileQueries.current(), enabled: !!user })` for shell that also renders for anonymous users.
 - **Component-owned reads** — a single component issues the read with `useQuery`, not loader-primed. Use for data that must load or fail independently of its route, or whose key isn't known until render (dialogs, typeahead, pagination).
+
+**Query definitions.** Each resource's reads live in a per-resource `…Queries` factory in its service module, structured most-generic to most-specific: an `all` base key, then one member per read — named for the read, its key extending `all`.
 
 Writes that change a query-cached resource use `useMutation` and reconcile the cache via `invalidateQueries` in `onSuccess`/`onSettled`. Optimistic writes additionally snapshot + `setQueryData` in `onMutate` with an `onError` rollback (see `useSetCaptain`). `router.invalidate()` only re-runs loaders, and `ensureQueryData` then serves the stale cache entry, so it won't refresh these reads.
 
@@ -152,7 +154,7 @@ See root `CLAUDE.md` `## Testing Strategy` for when to reach for this layer vs. 
 - **Don't introduce per-service path constants** (e.g. `USER_PROFILE_PATH = '/me/profile'`). The service module is already the single source of truth for each path. Strict-mode MSW reports the exact unhandled URL on a typo or rename, so drift is caught loudly — constants would just add a second place to maintain.
 - For 4xx/5xx, use `new HttpResponse(null, { status })`. For success bodies, use `HttpResponse.json(factoryOutput)` so the response shape is typed via the factory.
 
-**`renderWithRouter` signature:** `routeTree`, `initialEntry`, and `auth` (`auth` and `queryClient` are wired into router context automatically). The helper creates a fresh per-test `QueryClient`, wraps the tree in its provider, and returns it, so tests can seed or assert the Query cache directly (e.g. `queryClient.setQueryData(teamKeys.all, mockTeam)`).
+**`renderWithRouter` signature:** `routeTree`, `initialEntry`, and `auth` (`auth` and `queryClient` are wired into router context automatically). The helper creates a fresh per-test `QueryClient`, wraps the tree in its provider, and returns it, so tests can seed or assert the Query cache directly (e.g. `queryClient.setQueryData(teamQueries.mine().queryKey, mockTeam)`).
 
 ```typescript
 const { queryClient } = renderWithRouter({

--- a/web/src/components/Account/Account.tsx
+++ b/web/src/components/Account/Account.tsx
@@ -2,7 +2,7 @@ import type { UserProfile } from '@/contracts/UserProfile';
 import { useAuth } from '@/hooks/useAuth';
 import { useLiveRegion } from '@/hooks/useLiveRegion';
 import { avatarEvents } from '@/lib/avatarEvents';
-import { profileQuery, userProfileService } from '@/services/userProfileService';
+import { profileQueries, userProfileService } from '@/services/userProfileService';
 import {
   type UserProfileFormData,
   userProfileFormSchema,
@@ -25,7 +25,7 @@ import { Card, CardContent, CardHeader } from '../ui/card';
 export function Account() {
   const { user } = useAuth();
   const queryClient = useQueryClient();
-  const { data: userProfile } = useSuspenseQuery(profileQuery);
+  const { data: userProfile } = useSuspenseQuery(profileQueries.current());
 
   const handleAvatarChange = async (avatarUrl: string) => {
     if (!userProfile) return;
@@ -33,7 +33,7 @@ export function Account() {
     try {
       await userProfileService.updateUserProfile({ ...userProfile, avatarUrl });
       avatarEvents.emit(avatarUrl);
-      await queryClient.invalidateQueries(profileQuery);
+      await queryClient.invalidateQueries({ queryKey: profileQueries.current().queryKey });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to update avatar';
       toast.error(message);
@@ -44,7 +44,7 @@ export function Account() {
     if (!userProfile) return;
 
     await userProfileService.updateUserProfile({ ...userProfile, ...formData });
-    await queryClient.invalidateQueries(profileQuery);
+    await queryClient.invalidateQueries({ queryKey: profileQueries.current().queryKey });
   };
 
   return (

--- a/web/src/components/AccountMenu/AccountMenu.tsx
+++ b/web/src/components/AccountMenu/AccountMenu.tsx
@@ -1,6 +1,6 @@
 import { useAuth } from '@/hooks/useAuth';
 import { useCurrentAvatar } from '@/hooks/useCurrentAvatar';
-import { profileQuery } from '@/services/userProfileService';
+import { profileQueries } from '@/services/userProfileService';
 import * as Sentry from '@sentry/react';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
@@ -39,7 +39,7 @@ export function AccountMenu({ trigger, side }: AccountMenuProps) {
   const navigate = useNavigate();
   const avatar = useCurrentAvatar();
 
-  const { data: profile } = useQuery({ ...profileQuery, enabled: !!user });
+  const { data: profile } = useQuery({ ...profileQueries.current(), enabled: !!user });
 
   const handleAccountClick = () => {
     navigate({ to: '/account' });

--- a/web/src/components/AppSidebar/AppSidebar.tsx
+++ b/web/src/components/AppSidebar/AppSidebar.tsx
@@ -1,7 +1,7 @@
 import { useAuth } from '@/hooks/useAuth';
 import { useCurrentAvatar } from '@/hooks/useCurrentAvatar';
 import { useNavDestinations } from '@/hooks/useNavDestinations';
-import { profileQuery } from '@/services/userProfileService';
+import { profileQueries } from '@/services/userProfileService';
 import { useQuery } from '@tanstack/react-query';
 import { Link, useMatchRoute, useNavigate } from '@tanstack/react-router';
 import { ChevronUpIcon, TrophyIcon } from 'lucide-react';
@@ -27,7 +27,7 @@ export function AppSidebar() {
   const destinations = useNavDestinations();
   const avatar = useCurrentAvatar();
 
-  const { data: profile } = useQuery({ ...profileQuery, enabled: !!user });
+  const { data: profile } = useQuery({ ...profileQueries.current(), enabled: !!user });
 
   const handleLogoClick = () => {
     navigate({ to: '/' });

--- a/web/src/components/BrowseLeagues/BrowseLeagues.tsx
+++ b/web/src/components/BrowseLeagues/BrowseLeagues.tsx
@@ -1,7 +1,7 @@
 import type { League } from '@/contracts/League';
 import { useLiveRegion } from '@/hooks/useLiveRegion';
 import { joinLeague } from '@/services/leagueService';
-import { standingsKeys } from '@/services/standingsService';
+import { standingsQueries } from '@/services/standingsService';
 import * as Sentry from '@sentry/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useLoaderData, useNavigate } from '@tanstack/react-router';
@@ -54,7 +54,7 @@ export function BrowseLeagues() {
         await joinLeague(league.id);
 
         // Joining changes the user's standings.
-        queryClient.invalidateQueries({ queryKey: standingsKeys.all });
+        queryClient.invalidateQueries({ queryKey: standingsQueries.all });
 
         Sentry.logger.info('User joined league from browse page', {
           leagueId: league.id,

--- a/web/src/components/CreateLeague/CreateLeague.tsx
+++ b/web/src/components/CreateLeague/CreateLeague.tsx
@@ -1,7 +1,7 @@
 import type { League } from '@/contracts/League';
 import { useLiveRegion } from '@/hooks/useLiveRegion';
 import { createLeague } from '@/services/leagueService';
-import { standingsKeys } from '@/services/standingsService';
+import { standingsQueries } from '@/services/standingsService';
 import {
   type CreateLeagueFormData,
   createLeagueFormSchema,
@@ -63,7 +63,7 @@ export function CreateLeague({ onLeagueCreated }: CreateLeagueProps) {
       });
 
       // Creating a league adds it to the user's standings.
-      queryClient.invalidateQueries({ queryKey: standingsKeys.all });
+      queryClient.invalidateQueries({ queryKey: standingsQueries.all });
 
       setIsOpen(false);
       reset();

--- a/web/src/components/CreateTeam/CreateTeam.tsx
+++ b/web/src/components/CreateTeam/CreateTeam.tsx
@@ -1,7 +1,7 @@
 import { useAuth } from '@/hooks/useAuth';
 import { useLiveRegion } from '@/hooks/useLiveRegion';
-import { createTeam, myTeamQuery } from '@/services/teamService';
-import { profileQuery } from '@/services/userProfileService';
+import { createTeam, teamQueries } from '@/services/teamService';
+import { profileQueries } from '@/services/userProfileService';
 import { type CreateTeamFormData, createTeamFormSchema } from '@/validations/teamSchemas';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
@@ -24,7 +24,7 @@ export function CreateTeam() {
 
   const { user } = useAuth();
   const queryClient = useQueryClient();
-  const { data: profile } = useQuery({ ...profileQuery, enabled: !!user });
+  const { data: profile } = useQuery({ ...profileQueries.current(), enabled: !!user });
 
   const {
     register,
@@ -51,8 +51,8 @@ export function CreateTeam() {
       // Evict instead — including the `null` cached for a no-team user — and
       // the destination's requireTeam fetches the full shape. The profile
       // refresh flips `hasTeam` for the sidebar and invite CTAs.
-      queryClient.removeQueries({ queryKey: myTeamQuery.queryKey });
-      queryClient.invalidateQueries(profileQuery);
+      queryClient.removeQueries({ queryKey: teamQueries.mine().queryKey });
+      queryClient.invalidateQueries({ queryKey: profileQueries.current().queryKey });
 
       // Navigate - TanStack Router handles navigation transitions
       if (search.redirect) {

--- a/web/src/components/Home/MyLeaguesList.tsx
+++ b/web/src/components/Home/MyLeaguesList.tsx
@@ -1,7 +1,7 @@
 import { InlineError } from '@/components/InlineError/InlineError';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { standingsQuery } from '@/services/standingsService';
+import { standingsQueries } from '@/services/standingsService';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 
@@ -16,7 +16,7 @@ const rowHover = 'md:hover:bg-accent';
 const rowFocus = 'focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none';
 
 export function MyLeaguesList() {
-  const { data, isPending, isError, refetch } = useQuery(standingsQuery);
+  const { data, isPending, isError, refetch } = useQuery(standingsQueries.mine());
 
   if (isPending) {
     return null;

--- a/web/src/components/IndexRoute/IndexRoute.tsx
+++ b/web/src/components/IndexRoute/IndexRoute.tsx
@@ -1,5 +1,5 @@
 import { useAuth } from '@/hooks/useAuth';
-import { profileQuery } from '@/services/userProfileService';
+import { profileQueries } from '@/services/userProfileService';
 import { useQuery } from '@tanstack/react-query';
 import { useLoaderData } from '@tanstack/react-router';
 
@@ -9,7 +9,7 @@ import { LandingPage } from '../LandingPage/LandingPage';
 export function IndexRoute() {
   const { user } = useAuth();
   const { home } = useLoaderData({ from: '/' });
-  const { data: profile } = useQuery({ ...profileQuery, enabled: !!user });
+  const { data: profile } = useQuery({ ...profileQueries.current(), enabled: !!user });
 
   if (home === null) {
     return <LandingPage />;

--- a/web/src/components/JoinInvite/JoinInvite.tsx
+++ b/web/src/components/JoinInvite/JoinInvite.tsx
@@ -7,8 +7,8 @@ import type { LeagueInvitePreviewResponse } from '@/contracts/LeagueInvitePrevie
 import { useAuth } from '@/hooks/useAuth';
 import { useLiveRegion } from '@/hooks/useLiveRegion';
 import { joinViaInvite } from '@/services/leagueInviteService';
-import { standingsKeys } from '@/services/standingsService';
-import { profileQuery } from '@/services/userProfileService';
+import { standingsQueries } from '@/services/standingsService';
+import { profileQueries } from '@/services/userProfileService';
 import * as Sentry from '@sentry/react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link, useLoaderData, useNavigate, useParams } from '@tanstack/react-router';
@@ -44,7 +44,7 @@ export function JoinInvite() {
   // Auth and team state
   const { user } = useAuth();
   const queryClient = useQueryClient();
-  const { data: profile } = useQuery({ ...profileQuery, enabled: !!user });
+  const { data: profile } = useQuery({ ...profileQueries.current(), enabled: !!user });
   const hasTeam = profile?.hasTeam ?? false;
 
   // Join operation state
@@ -71,7 +71,7 @@ export function JoinInvite() {
       }
 
       // Joining changes the user's standings.
-      queryClient.invalidateQueries({ queryKey: standingsKeys.all });
+      queryClient.invalidateQueries({ queryKey: standingsQueries.all });
 
       announce(`Successfully joined ${league.name}`);
 

--- a/web/src/components/Leaderboard/Leaderboard.tsx
+++ b/web/src/components/Leaderboard/Leaderboard.tsx
@@ -2,7 +2,7 @@ import { LeaderboardHeader } from '@/components/LeaderboardHeader/LeaderboardHea
 import { PositionDelta } from '@/components/PositionDelta/PositionDelta';
 import { useAuth } from '@/hooks/useAuth';
 import { cn } from '@/lib/utils';
-import { profileQuery } from '@/services/userProfileService';
+import { profileQueries } from '@/services/userProfileService';
 import { useQuery } from '@tanstack/react-query';
 import { Link, getRouteApi } from '@tanstack/react-router';
 import { ChevronRightIcon } from 'lucide-react';
@@ -27,7 +27,7 @@ interface LeaderboardProps {
 export function Leaderboard({ actions, inlineAction }: LeaderboardProps = {}) {
   const { league, standings } = routeApi.useLoaderData();
   const { user } = useAuth();
-  const { data: profile } = useQuery({ ...profileQuery, enabled: !!user });
+  const { data: profile } = useQuery({ ...profileQueries.current(), enabled: !!user });
 
   const entries = standings.standings;
 

--- a/web/src/components/League/League.tsx
+++ b/web/src/components/League/League.tsx
@@ -2,7 +2,7 @@ import type { LeagueInvite } from '@/contracts/LeagueInvite';
 import { useAuth } from '@/hooks/useAuth';
 import { useClipboard } from '@/hooks/useClipboard';
 import { getOrCreateLeagueInvite } from '@/services/leagueInviteService';
-import { profileQuery } from '@/services/userProfileService';
+import { profileQueries } from '@/services/userProfileService';
 import * as Sentry from '@sentry/react';
 import { useQuery } from '@tanstack/react-query';
 import { getRouteApi } from '@tanstack/react-router';
@@ -21,7 +21,7 @@ const routeApi = getRouteApi('/_authenticated/_team-required/league/$leagueId');
 
 export function League() {
   const { user } = useAuth();
-  const { data: profile } = useQuery({ ...profileQuery, enabled: !!user });
+  const { data: profile } = useQuery({ ...profileQueries.current(), enabled: !!user });
   const { league } = routeApi.useLoaderData();
 
   const [isDialogOpen, setIsDialogOpen] = useState(false);

--- a/web/src/components/Team/Team.tsx
+++ b/web/src/components/Team/Team.tsx
@@ -4,9 +4,9 @@ import type { Team } from '@/contracts/Team';
 import { useLockCountdown } from '@/hooks/useLockCountdown';
 import { useSetCaptain } from '@/hooks/useSetCaptain';
 import { formatBudget } from '@/lib/utils';
-import { constructorsQuery } from '@/services/constructorService';
-import { driversQuery } from '@/services/driverService';
-import { myTeamQuery } from '@/services/teamService';
+import { constructorQueries } from '@/services/constructorService';
+import { driverQueries } from '@/services/driverService';
+import { teamQueries } from '@/services/teamService';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { notFound, useLoaderData } from '@tanstack/react-router';
 
@@ -25,9 +25,9 @@ export interface TeamViewProps {
 }
 
 export function MyTeamRoute() {
-  const { data: team } = useSuspenseQuery(myTeamQuery);
-  const { data: activeDrivers } = useSuspenseQuery(driversQuery);
-  const { data: activeConstructors } = useSuspenseQuery(constructorsQuery);
+  const { data: team } = useSuspenseQuery(teamQueries.mine());
+  const { data: activeDrivers } = useSuspenseQuery(driverQueries.list());
+  const { data: activeConstructors } = useSuspenseQuery(constructorQueries.list());
   const { races } = useLoaderData({
     from: '/_authenticated/_team-required/my-team',
   });
@@ -48,8 +48,8 @@ export function MyTeamRoute() {
 }
 
 export function TeamRoute() {
-  const { data: activeDrivers } = useSuspenseQuery(driversQuery);
-  const { data: activeConstructors } = useSuspenseQuery(constructorsQuery);
+  const { data: activeDrivers } = useSuspenseQuery(driverQueries.list());
+  const { data: activeConstructors } = useSuspenseQuery(constructorQueries.list());
   const { team, races } = useLoaderData({
     from: '/_authenticated/_team-required/team/$teamId',
   });

--- a/web/src/hooks/useCurrentAvatar.ts
+++ b/web/src/hooks/useCurrentAvatar.ts
@@ -1,6 +1,6 @@
 import { useAuth } from '@/hooks/useAuth';
 import { avatarEvents } from '@/lib/avatarEvents';
-import { profileQuery } from '@/services/userProfileService';
+import { profileQueries } from '@/services/userProfileService';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 
@@ -18,7 +18,7 @@ export interface CurrentAvatar {
  */
 export function useCurrentAvatar(): CurrentAvatar {
   const { user } = useAuth();
-  const { data: profile } = useQuery({ ...profileQuery, enabled: !!user });
+  const { data: profile } = useQuery({ ...profileQueries.current(), enabled: !!user });
 
   const [uploadedAvatarUrl, setUploadedAvatarUrl] = useState<string | undefined>();
   const [isLoading, setIsLoading] = useState(false);

--- a/web/src/hooks/useLineupPicker.ts
+++ b/web/src/hooks/useLineupPicker.ts
@@ -1,4 +1,4 @@
-import { myTeamQuery } from '@/services/teamService';
+import { teamQueries } from '@/services/teamService';
 import * as Sentry from '@sentry/react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useMemo, useState } from 'react';
@@ -35,7 +35,7 @@ export function useLineupPicker<T extends { id: number }>({
   const addToLineupMutation = useMutation({
     mutationFn: ({ position, item }: { position: number; item: T }) => addToTeam(item.id, position),
     onMutate: () => setError(null),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: myTeamQuery.queryKey }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: teamQueries.mine().queryKey }),
     onError: (err, { position, item }) => {
       Sentry.logger.error(`Failed to add ${itemType} to lineup`, {
         itemType,
@@ -53,7 +53,7 @@ export function useLineupPicker<T extends { id: number }>({
   const removeFromLineupMutation = useMutation({
     mutationFn: (position: number) => removeFromTeam(position),
     onMutate: () => setError(null),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: myTeamQuery.queryKey }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: teamQueries.mine().queryKey }),
     onError: (err, position) => {
       Sentry.logger.error(`Failed to remove ${itemType} from lineup`, {
         itemType,

--- a/web/src/hooks/useNavDestinations.ts
+++ b/web/src/hooks/useNavDestinations.ts
@@ -1,5 +1,5 @@
 import { useAuth } from '@/hooks/useAuth';
-import { profileQuery } from '@/services/userProfileService';
+import { profileQueries } from '@/services/userProfileService';
 import { useQuery } from '@tanstack/react-query';
 import { ChartNoAxesGantt, Home, type LucideIcon, Search, Users } from 'lucide-react';
 
@@ -13,7 +13,7 @@ export interface NavDestination {
 
 export function useNavDestinations(): NavDestination[] {
   const { user } = useAuth();
-  const { data: profile } = useQuery({ ...profileQuery, enabled: !!user });
+  const { data: profile } = useQuery({ ...profileQueries.current(), enabled: !!user });
   const hasTeam = profile?.hasTeam ?? false;
 
   const destinations: NavDestination[] = [

--- a/web/src/hooks/useSetCaptain.test.ts
+++ b/web/src/hooks/useSetCaptain.test.ts
@@ -1,5 +1,5 @@
 import type { Team } from '@/contracts/Team';
-import { myTeamQuery, setCaptain } from '@/services/teamService';
+import { setCaptain, teamQueries } from '@/services/teamService';
 import { createMockTeam, createMockTeamDriver } from '@/tests/test-utils';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
@@ -8,9 +8,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useSetCaptain } from './useSetCaptain';
 
-// Keep `myTeamQuery`/`teamKeys` at their production values so the hook's
-// optimistic patch and the test's assertions read the same cache key; only the
-// network call is stubbed.
+// Keep `teamQueries` at its production value so the hook's optimistic patch and
+// the test's assertions read the same cache key; only the network call is
+// stubbed.
 vi.mock('@/services/teamService', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/services/teamService')>();
   return { ...actual, setCaptain: vi.fn() };
@@ -20,7 +20,7 @@ function renderSetCaptain(team: Team | null) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
-  queryClient.setQueryData(myTeamQuery.queryKey, team);
+  queryClient.setQueryData(teamQueries.mine().queryKey, team);
 
   const wrapper = ({ children }: { children: ReactNode }) =>
     createElement(QueryClientProvider, { client: queryClient }, children);
@@ -51,10 +51,10 @@ describe('useSetCaptain', () => {
     });
 
     await waitFor(() => {
-      const cached = queryClient.getQueryData<Team>(myTeamQuery.queryKey)!;
+      const cached = queryClient.getQueryData<Team>(teamQueries.mine().queryKey)!;
       expect(cached.drivers.find((d) => d.id === 2)?.isCaptain).toBe(true);
     });
-    const cached = queryClient.getQueryData<Team>(myTeamQuery.queryKey)!;
+    const cached = queryClient.getQueryData<Team>(teamQueries.mine().queryKey)!;
     expect(cached.drivers.find((d) => d.id === 1)?.isCaptain).toBe(false);
   });
 
@@ -66,23 +66,23 @@ describe('useSetCaptain', () => {
     });
 
     await waitFor(() => {
-      const cached = queryClient.getQueryData<Team>(myTeamQuery.queryKey)!;
+      const cached = queryClient.getQueryData<Team>(teamQueries.mine().queryKey)!;
       expect(cached.drivers.some((d) => d.isCaptain)).toBe(false);
     });
   });
 
   it('patches the cache with new team and drivers references', async () => {
     const { result, queryClient } = renderSetCaptain(teamWithCaptain(1));
-    const before = queryClient.getQueryData<Team>(myTeamQuery.queryKey)!;
+    const before = queryClient.getQueryData<Team>(teamQueries.mine().queryKey)!;
 
     act(() => {
       result.current.mutate(2);
     });
 
     await waitFor(() => {
-      expect(queryClient.getQueryData<Team>(myTeamQuery.queryKey)).not.toBe(before);
+      expect(queryClient.getQueryData<Team>(teamQueries.mine().queryKey)).not.toBe(before);
     });
-    const after = queryClient.getQueryData<Team>(myTeamQuery.queryKey)!;
+    const after = queryClient.getQueryData<Team>(teamQueries.mine().queryKey)!;
     expect(after.drivers).not.toBe(before.drivers);
   });
 
@@ -95,7 +95,7 @@ describe('useSetCaptain', () => {
     });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
-    const cached = queryClient.getQueryData<Team>(myTeamQuery.queryKey)!;
+    const cached = queryClient.getQueryData<Team>(teamQueries.mine().queryKey)!;
     expect(cached.drivers.find((d) => d.id === 1)?.isCaptain).toBe(true);
     expect(cached.drivers.find((d) => d.id === 2)?.isCaptain).toBe(false);
   });

--- a/web/src/hooks/useSetCaptain.ts
+++ b/web/src/hooks/useSetCaptain.ts
@@ -1,16 +1,17 @@
 import type { Team } from '@/contracts/Team';
-import { myTeamQuery, setCaptain } from '@/services/teamService';
+import { setCaptain, teamQueries } from '@/services/teamService';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export function useSetCaptain() {
   const queryClient = useQueryClient();
+  const myTeamKey = teamQueries.mine().queryKey;
 
   return useMutation({
     mutationFn: setCaptain,
     onMutate: async (driverId) => {
-      await queryClient.cancelQueries({ queryKey: myTeamQuery.queryKey });
-      const previous = queryClient.getQueryData<Team | null>(myTeamQuery.queryKey);
-      queryClient.setQueryData<Team | null>(myTeamQuery.queryKey, (team) =>
+      await queryClient.cancelQueries({ queryKey: myTeamKey });
+      const previous = queryClient.getQueryData<Team | null>(myTeamKey);
+      queryClient.setQueryData<Team | null>(myTeamKey, (team) =>
         team
           ? { ...team, drivers: team.drivers.map((d) => ({ ...d, isCaptain: d.id === driverId })) }
           : team,
@@ -18,8 +19,8 @@ export function useSetCaptain() {
       return { previous };
     },
     onError: (_err, _driverId, context) => {
-      queryClient.setQueryData(myTeamQuery.queryKey, context?.previous);
+      queryClient.setQueryData(myTeamKey, context?.previous);
     },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: myTeamQuery.queryKey }),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: myTeamKey }),
   });
 }

--- a/web/src/lib/route-guards.test.ts
+++ b/web/src/lib/route-guards.test.ts
@@ -1,6 +1,6 @@
 import { redirectIfAuthenticated, requireAuth, requireTeam } from '@/lib/route-guards';
 import type { RouterContext } from '@/lib/router-context';
-import { teamKeys } from '@/services/teamService';
+import { teamQueries } from '@/services/teamService';
 import { createAuthedAuth, createMockTeam } from '@/tests/test-utils';
 import type { User } from '@supabase/supabase-js';
 import { QueryClient } from '@tanstack/react-query';
@@ -119,7 +119,7 @@ describe('route-guards', () => {
   describe('requireTeam', () => {
     it('throws redirect to /create-team when the team query resolves to null', async () => {
       const teamlessClient = new QueryClient();
-      teamlessClient.setQueryData(teamKeys.all, null);
+      teamlessClient.setQueryData(teamQueries.mine().queryKey, null);
       const context: RouterContext = {
         auth: createAuthedAuth(),
         queryClient: teamlessClient,
@@ -134,7 +134,7 @@ describe('route-guards', () => {
 
     it('resolves without redirecting when the team query has a team', async () => {
       const teamClient = new QueryClient();
-      teamClient.setQueryData(teamKeys.all, createMockTeam());
+      teamClient.setQueryData(teamQueries.mine().queryKey, createMockTeam());
       const context: RouterContext = {
         auth: createAuthedAuth(),
         queryClient: teamClient,

--- a/web/src/lib/route-guards.ts
+++ b/web/src/lib/route-guards.ts
@@ -1,5 +1,5 @@
 import type { RouterContext } from '@/lib/router-context';
-import { myTeamQuery } from '@/services/teamService';
+import { teamQueries } from '@/services/teamService';
 import { redirect } from '@tanstack/react-router';
 
 /**
@@ -41,7 +41,7 @@ export function redirectIfAuthenticated(context: RouterContext, redirectTo?: str
  * real owner to /create-team on a transient blip.
  */
 export async function requireTeam(context: RouterContext): Promise<void> {
-  const team = await context.queryClient.ensureQueryData(myTeamQuery);
+  const team = await context.queryClient.ensureQueryData(teamQueries.mine());
   if (!team) {
     throw redirect({
       to: '/create-team',

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -15,8 +15,8 @@ import type { RouterContext } from '@/lib/router-context';
 import { safeInternalPath } from '@/lib/safeInternalPath';
 import { getAvailableLeagues, getLeagueById, getMyLeagues } from '@/services/leagueService';
 import { getLeagueStandings } from '@/services/standingsService';
-import { getTeamById, getTeamSummary, myTeamQuery } from '@/services/teamService';
-import { profileQuery } from '@/services/userProfileService';
+import { getTeamById, getTeamSummary, teamQueries } from '@/services/teamService';
+import { profileQueries } from '@/services/userProfileService';
 import { isApiError } from '@/utils/errors';
 import {
   Link,
@@ -34,11 +34,11 @@ import { BrowseLeagues } from './components/BrowseLeagues/BrowseLeagues';
 import { JoinInvite } from './components/JoinInvite/JoinInvite';
 import { routerAuth } from './lib/authStore';
 import { queryClient } from './lib/queryClient';
-import { constructorsQuery } from './services/constructorService';
-import { driversQuery } from './services/driverService';
+import { constructorQueries } from './services/constructorService';
+import { driverQueries } from './services/driverService';
 import { previewInvite } from './services/leagueInviteService';
 import { getRaceWeekends } from './services/raceWeekendService';
-import { seasonQuery } from './services/seasonService';
+import { seasonQueries } from './services/seasonService';
 
 /**
  * Zod schema for validating league ID route parameter.
@@ -94,7 +94,7 @@ const rootRoute = createRootRouteWithContext<RouterContext>()({
     // Prime the profile query so the app shell and the index greeting serve it
     // from cache. Tolerate a failure — a profile blip must not fail the whole tree.
     if (context.auth.user) {
-      await context.queryClient.ensureQueryData(profileQuery).catch(() => null);
+      await context.queryClient.ensureQueryData(profileQueries.current()).catch(() => null);
     }
   },
   component: () => (
@@ -141,7 +141,7 @@ const indexRoute = createRoute({
       return { home: null };
     }
 
-    const season = await context.queryClient.ensureQueryData(seasonQuery);
+    const season = await context.queryClient.ensureQueryData(seasonQueries.current());
 
     const [summary, races] = await Promise.all([
       getTeamSummary(),
@@ -297,7 +297,7 @@ const accountRoute = createRoute({
     pageTitle: 'Account Settings',
   },
   loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData(profileQuery);
+    await context.queryClient.ensureQueryData(profileQueries.current());
   },
   component: Account,
   pendingComponent: () => (
@@ -498,7 +498,7 @@ const teamRoute = createRoute({
     const validationResult = teamIdParamsSchema.safeParse(params);
     if (!validationResult.success) return;
 
-    const team = await context.queryClient.ensureQueryData(myTeamQuery);
+    const team = await context.queryClient.ensureQueryData(teamQueries.mine());
     if (team?.id === validationResult.data.teamId) {
       throw redirect({ to: '/my-team', replace: true });
     }
@@ -516,14 +516,14 @@ const teamRoute = createRoute({
     }
 
     const { teamId } = validationResult.data;
-    const season = await context.queryClient.ensureQueryData(seasonQuery);
+    const season = await context.queryClient.ensureQueryData(seasonQueries.current());
 
     // Fetch all data in parallel
     const [team, races] = await Promise.all([
       getTeamById(teamId),
       season ? getRaceWeekends(season.id) : Promise.resolve([]),
-      context.queryClient.ensureQueryData(driversQuery),
-      context.queryClient.ensureQueryData(constructorsQuery),
+      context.queryClient.ensureQueryData(driverQueries.list()),
+      context.queryClient.ensureQueryData(constructorQueries.list()),
     ]);
 
     // Return 404 if team doesn't exist
@@ -563,15 +563,15 @@ const myTeamRoute = createRoute({
     pageTitle: 'My Team',
   },
   loader: async ({ context }) => {
-    const season = await context.queryClient.ensureQueryData(seasonQuery);
+    const season = await context.queryClient.ensureQueryData(seasonQueries.current());
     // Warm-cache hit after the `_team-required` guard; pairs with the component's
-    // useSuspenseQuery(myTeamQuery).
-    await context.queryClient.ensureQueryData(myTeamQuery);
+    // useSuspenseQuery(teamQueries.mine()).
+    await context.queryClient.ensureQueryData(teamQueries.mine());
 
     const [races] = await Promise.all([
       season ? getRaceWeekends(season.id) : Promise.resolve([]),
-      context.queryClient.ensureQueryData(driversQuery),
-      context.queryClient.ensureQueryData(constructorsQuery),
+      context.queryClient.ensureQueryData(driverQueries.list()),
+      context.queryClient.ensureQueryData(constructorQueries.list()),
     ]);
 
     return { races };

--- a/web/src/services/constructorService.ts
+++ b/web/src/services/constructorService.ts
@@ -7,10 +7,12 @@ export function getConstructors(seasonYear?: number): Promise<Constructor[]> {
   return apiClient.get<Constructor[]>(url, 'get constructors');
 }
 
-export const constructorKeys = { all: ['constructors'] as const };
-
-export const constructorsQuery = queryOptions({
-  queryKey: constructorKeys.all,
-  queryFn: () => getConstructors(),
-  staleTime: 5 * 60_000,
-});
+export const constructorQueries = {
+  all: ['constructors'] as const,
+  list: (seasonYear?: number) =>
+    queryOptions({
+      queryKey: [...constructorQueries.all, 'list', seasonYear ?? null] as const,
+      queryFn: () => getConstructors(seasonYear),
+      staleTime: 5 * 60_000,
+    }),
+};

--- a/web/src/services/driverService.ts
+++ b/web/src/services/driverService.ts
@@ -7,10 +7,12 @@ export async function getDrivers(seasonYear?: number): Promise<Driver[]> {
   return apiClient.get<Driver[]>(url, 'get drivers');
 }
 
-export const driverKeys = { all: ['drivers'] as const };
-
-export const driversQuery = queryOptions({
-  queryKey: driverKeys.all,
-  queryFn: () => getDrivers(),
-  staleTime: 5 * 60_000,
-});
+export const driverQueries = {
+  all: ['drivers'] as const,
+  list: (seasonYear?: number) =>
+    queryOptions({
+      queryKey: [...driverQueries.all, 'list', seasonYear ?? null] as const,
+      queryFn: () => getDrivers(seasonYear),
+      staleTime: 5 * 60_000,
+    }),
+};

--- a/web/src/services/seasonService.ts
+++ b/web/src/services/seasonService.ts
@@ -14,9 +14,11 @@ export async function getCurrentSeason(): Promise<Season | null> {
   }
 }
 
-export const seasonKeys = { current: ['season', 'current'] as const };
-
-export const seasonQuery = queryOptions({
-  queryKey: seasonKeys.current,
-  queryFn: getCurrentSeason,
-});
+export const seasonQueries = {
+  all: ['season'] as const,
+  current: () =>
+    queryOptions({
+      queryKey: [...seasonQueries.all, 'current'] as const,
+      queryFn: getCurrentSeason,
+    }),
+};

--- a/web/src/services/standingsService.ts
+++ b/web/src/services/standingsService.ts
@@ -22,9 +22,11 @@ export async function getMyStandings(): Promise<MyLeagueStanding[]> {
   return await apiClient.get<MyLeagueStanding[]>('/me/standings', 'get your league standings');
 }
 
-export const standingsKeys = { all: ['me', 'standings'] as const };
-
-export const standingsQuery = queryOptions({
-  queryKey: standingsKeys.all,
-  queryFn: getMyStandings,
-});
+export const standingsQueries = {
+  all: ['me', 'standings'] as const,
+  mine: () =>
+    queryOptions({
+      queryKey: [...standingsQueries.all, 'mine'] as const,
+      queryFn: getMyStandings,
+    }),
+};

--- a/web/src/services/teamService.ts
+++ b/web/src/services/teamService.ts
@@ -107,10 +107,12 @@ export async function getTeamSummary(): Promise<TeamSummary | null> {
   }
 }
 
-export const teamKeys = { all: ['me', 'team'] as const };
-
-export const myTeamQuery = queryOptions({
-  queryKey: teamKeys.all,
-  queryFn: getMyTeam,
-  staleTime: 5 * 60_000,
-});
+export const teamQueries = {
+  all: ['me', 'team'] as const,
+  mine: () =>
+    queryOptions({
+      queryKey: [...teamQueries.all, 'mine'] as const,
+      queryFn: getMyTeam,
+      staleTime: 5 * 60_000,
+    }),
+};

--- a/web/src/services/userProfileService.ts
+++ b/web/src/services/userProfileService.ts
@@ -21,10 +21,12 @@ export const userProfileService = {
   },
 };
 
-export const profileKeys = { all: ['me', 'profile'] as const };
-
-export const profileQuery = queryOptions({
-  queryKey: profileKeys.all,
-  queryFn: () => userProfileService.getCurrentProfile(),
-  staleTime: 5 * 60_000,
-});
+export const profileQueries = {
+  all: ['me', 'profile'] as const,
+  current: () =>
+    queryOptions({
+      queryKey: [...profileQueries.all, 'current'] as const,
+      queryFn: () => userProfileService.getCurrentProfile(),
+      staleTime: 5 * 60_000,
+    }),
+};

--- a/web/src/tests/integration/account.integration.test.tsx
+++ b/web/src/tests/integration/account.integration.test.tsx
@@ -3,7 +3,7 @@ import { RouteErrorComponent } from '@/components/RouteErrorComponent/RouteError
 import type { UserProfile } from '@/contracts/UserProfile';
 import type { RouterContext } from '@/lib/router-context';
 import { API_BASE, server } from '@/mocks';
-import { profileQuery } from '@/services/userProfileService';
+import { profileQueries } from '@/services/userProfileService';
 import {
   buildAuthenticatedLayout,
   createAuthedAuth,
@@ -35,7 +35,7 @@ function buildAccountRouteTree() {
     getParentRoute: () => authenticatedLayoutRoute,
     path: 'account',
     loader: async ({ context }) => {
-      await context.queryClient.ensureQueryData(profileQuery);
+      await context.queryClient.ensureQueryData(profileQueries.current());
     },
     component: Account,
     errorComponent: RouteErrorComponent,
@@ -99,7 +99,7 @@ describe('Account page', () => {
 
     await screen.findAllByText(/profile updated successfully/i);
     // The query cache — read by the always-mounted sidebar — now holds the new name.
-    expect(queryClient.getQueryData(profileQuery.queryKey)).toMatchObject({
+    expect(queryClient.getQueryData(profileQueries.current().queryKey)).toMatchObject({
       displayName: 'Updated',
     });
   });

--- a/web/src/tests/integration/create-team.integration.test.tsx
+++ b/web/src/tests/integration/create-team.integration.test.tsx
@@ -1,7 +1,7 @@
 import { CreateTeam } from '@/components/CreateTeam/CreateTeam';
 import { safeInternalPath } from '@/lib/safeInternalPath';
 import { API_BASE, server } from '@/mocks';
-import { myTeamQuery } from '@/services/teamService';
+import { teamQueries } from '@/services/teamService';
 import {
   buildAuthenticatedLayout,
   buildRootRoute,
@@ -107,7 +107,7 @@ describe('Create team', () => {
     expect(capturedBody).toEqual({ name: 'My Racing Team' });
     // The POST response is slimmer than GET /me/team, so the team query must be
     // evicted, not seeded with it — the next guard read fetches the full shape.
-    expect(queryClient.getQueryData(myTeamQuery.queryKey)).toBeUndefined();
+    expect(queryClient.getQueryData(teamQueries.mine().queryKey)).toBeUndefined();
   });
 
   it('surfaces an InlineError when team creation fails', async () => {

--- a/web/src/tests/integration/join-invite.integration.test.tsx
+++ b/web/src/tests/integration/join-invite.integration.test.tsx
@@ -4,7 +4,7 @@ import type { Team } from '@/contracts/Team';
 import type { RouterContext } from '@/lib/router-context';
 import { API_BASE, server } from '@/mocks';
 import { previewInvite } from '@/services/leagueInviteService';
-import { standingsKeys } from '@/services/standingsService';
+import { standingsQueries } from '@/services/standingsService';
 import {
   createAuthedAuth,
   createMockLeague,
@@ -227,12 +227,12 @@ describe('Join via invite token', () => {
     });
 
     // A cached standings entry is required for the invalidation to be observable.
-    queryClient.setQueryData(standingsKeys.all, []);
+    queryClient.setQueryData(standingsQueries.mine().queryKey, []);
 
     await user.click(await screen.findByRole('button', { name: /join league/i }));
 
     await waitFor(() =>
-      expect(queryClient.getQueryState(standingsKeys.all)?.isInvalidated).toBe(true),
+      expect(queryClient.getQueryState(standingsQueries.mine().queryKey)?.isInvalidated).toBe(true),
     );
   });
 

--- a/web/src/tests/integration/leagues.integration.test.tsx
+++ b/web/src/tests/integration/leagues.integration.test.tsx
@@ -5,7 +5,7 @@ import { RouteErrorComponent } from '@/components/RouteErrorComponent/RouteError
 import type { RouterContext } from '@/lib/router-context';
 import { API_BASE, server } from '@/mocks';
 import { getAvailableLeagues, getLeagueById, getMyLeagues } from '@/services/leagueService';
-import { getLeagueStandings, standingsKeys } from '@/services/standingsService';
+import { getLeagueStandings, standingsQueries } from '@/services/standingsService';
 import {
   buildAuthenticatedLayout,
   buildTeamRequiredLayout,
@@ -333,13 +333,13 @@ describe('Browse leagues', () => {
     });
 
     // A cached standings entry is required for the invalidation to be observable.
-    queryClient.setQueryData(standingsKeys.all, []);
+    queryClient.setQueryData(standingsQueries.mine().queryKey, []);
 
     await user.click(await screen.findByRole('button', { name: /join league/i }));
     await user.click(await screen.findByRole('button', { name: /confirm join/i }));
 
     await waitFor(() =>
-      expect(queryClient.getQueryState(standingsKeys.all)?.isInvalidated).toBe(true),
+      expect(queryClient.getQueryState(standingsQueries.mine().queryKey)?.isInvalidated).toBe(true),
     );
   });
 });
@@ -404,7 +404,7 @@ describe('My leagues', () => {
       auth: createAuthedAuth(),
     });
 
-    queryClient.setQueryData(standingsKeys.all, []);
+    queryClient.setQueryData(standingsQueries.mine().queryKey, []);
 
     await user.click(await screen.findByRole('button', { name: /create league/i }));
     await user.type(await screen.findByLabelText(/league name/i), '  Night Race Crew  ');
@@ -420,7 +420,7 @@ describe('My leagues', () => {
       }),
     );
     await waitFor(() =>
-      expect(queryClient.getQueryState(standingsKeys.all)?.isInvalidated).toBe(true),
+      expect(queryClient.getQueryState(standingsQueries.mine().queryKey)?.isInvalidated).toBe(true),
     );
   });
 

--- a/web/src/tests/integration/root-routing.integration.test.tsx
+++ b/web/src/tests/integration/root-routing.integration.test.tsx
@@ -3,7 +3,7 @@ import { RouteErrorComponent } from '@/components/RouteErrorComponent/RouteError
 import type { RouterContext } from '@/lib/router-context';
 import { API_BASE, server } from '@/mocks';
 import { getRaceWeekends } from '@/services/raceWeekendService';
-import { seasonQuery } from '@/services/seasonService';
+import { seasonQueries } from '@/services/seasonService';
 import { getTeamSummary } from '@/services/teamService';
 import {
   createAuthedAuth,
@@ -57,7 +57,7 @@ function buildIndexRouteTree() {
         return { home: null };
       }
 
-      const season = await context.queryClient.ensureQueryData(seasonQuery);
+      const season = await context.queryClient.ensureQueryData(seasonQueries.current());
 
       const [summary, races] = await Promise.all([
         getTeamSummary(),

--- a/web/src/tests/integration/team-lineup.integration.test.tsx
+++ b/web/src/tests/integration/team-lineup.integration.test.tsx
@@ -2,11 +2,11 @@ import { MyTeamRoute } from '@/components/Team/Team';
 import type { Team } from '@/contracts/Team';
 import type { RouterContext } from '@/lib/router-context';
 import { API_BASE, server } from '@/mocks';
-import { constructorsQuery } from '@/services/constructorService';
-import { driversQuery } from '@/services/driverService';
+import { constructorQueries } from '@/services/constructorService';
+import { driverQueries } from '@/services/driverService';
 import { getRaceWeekends } from '@/services/raceWeekendService';
-import { seasonQuery } from '@/services/seasonService';
-import { myTeamQuery } from '@/services/teamService';
+import { seasonQueries } from '@/services/seasonService';
+import { teamQueries } from '@/services/teamService';
 import {
   buildAuthenticatedLayout,
   buildStubRoute,
@@ -44,12 +44,12 @@ function buildMyTeamRouteTree() {
     getParentRoute: () => teamRequiredLayoutRoute,
     path: 'my-team',
     loader: async ({ context }) => {
-      const season = await context.queryClient.ensureQueryData(seasonQuery);
-      await context.queryClient.ensureQueryData(myTeamQuery);
+      const season = await context.queryClient.ensureQueryData(seasonQueries.current());
+      await context.queryClient.ensureQueryData(teamQueries.mine());
       const [races] = await Promise.all([
         season ? getRaceWeekends(season.id) : Promise.resolve([]),
-        context.queryClient.ensureQueryData(driversQuery),
-        context.queryClient.ensureQueryData(constructorsQuery),
+        context.queryClient.ensureQueryData(driverQueries.list()),
+        context.queryClient.ensureQueryData(constructorQueries.list()),
       ]);
       return { races };
     },

--- a/web/src/tests/integration/view-team.integration.test.tsx
+++ b/web/src/tests/integration/view-team.integration.test.tsx
@@ -1,11 +1,11 @@
 import { TeamRoute } from '@/components/Team/Team';
 import type { RouterContext } from '@/lib/router-context';
 import { API_BASE, server } from '@/mocks';
-import { constructorsQuery } from '@/services/constructorService';
-import { driversQuery } from '@/services/driverService';
+import { constructorQueries } from '@/services/constructorService';
+import { driverQueries } from '@/services/driverService';
 import { getRaceWeekends } from '@/services/raceWeekendService';
-import { seasonQuery } from '@/services/seasonService';
-import { getTeamById, myTeamQuery } from '@/services/teamService';
+import { seasonQueries } from '@/services/seasonService';
+import { getTeamById, teamQueries } from '@/services/teamService';
 import {
   buildAuthenticatedLayout,
   buildStubRoute,
@@ -50,19 +50,19 @@ function buildTeamByIdRouteTree() {
     beforeLoad: async ({ context, params }) => {
       const teamId = Number(params.teamId);
       if (!Number.isInteger(teamId)) return;
-      const team = await context.queryClient.ensureQueryData(myTeamQuery);
+      const team = await context.queryClient.ensureQueryData(teamQueries.mine());
       if (team?.id === teamId) {
         throw redirect({ to: '/my-team', replace: true });
       }
     },
     loader: async ({ params, context }) => {
-      const season = await context.queryClient.ensureQueryData(seasonQuery);
+      const season = await context.queryClient.ensureQueryData(seasonQueries.current());
       const teamId = Number(params.teamId);
       const [team, races] = await Promise.all([
         getTeamById(teamId),
         season ? getRaceWeekends(season.id) : Promise.resolve([]),
-        context.queryClient.ensureQueryData(driversQuery),
-        context.queryClient.ensureQueryData(constructorsQuery),
+        context.queryClient.ensureQueryData(driverQueries.list()),
+        context.queryClient.ensureQueryData(constructorQueries.list()),
       ]);
       if (!team) {
         throw notFound({ routeId: '/_authenticated/_team-required/team/$teamId' });


### PR DESCRIPTION
Closes #305.

## What

Replaces the six single-member `…Keys` / standalone `…Query` pairs (team, profile, season, standings, drivers, constructors) with a per-resource `…Queries` factory: an `all` base key plus one named member per read whose key _extends_ `all`. Invalidate a whole resource through `all`; address a single read through the member's `.queryKey`.

This is a mechanical, no-behavior-change refactor. Cache keys are ephemeral (rebuilt each session; user-switch reset is `queryClient.clear()`, which is key-agnostic), so changing the key strings has no observable effect as long as every reader and writer stays consistent.

- `drivers` / `constructors` gain a `list(seasonYear?)` member exposing the season param their service already accepts.
- The seed/read-vs-invalidate split is honored at every touchpoint: group invalidations stay on `…Queries.all` (prefix-matches the member); specific seeds/reads/asserts move to `…Queries.<member>().queryKey`.

## Docs

- `web/CLAUDE.md` → Data Loading Pattern records the convention and refreshes the inline `profileQueries.current()` / `teamQueries.mine()` examples.
- ADR 003 & 006 de-specified: the index loader reads the season from the Query cache rather than naming the old `seasonQuery` symbol.

## Verification

- `npm run web:test` — full frontend suite green (integration tests exercise the real router/loaders/guards through MSW, catching any seed/read key mismatch).
- `npm run web:lint`, `npm run web:format:check`, `npm run web:build` — clean.
- `rg "teamKeys|profileKeys|seasonKeys|standingsKeys|driverKeys|constructorKeys|myTeamQuery|profileQuery|seasonQuery|standingsQuery|driversQuery|constructorsQuery" web/src` returns nothing.

Plan: `docs/plans/305-per-resource-query-factories.md`.