### PR TITLE
Remove SVG marks and dead CSS from auth email templates

### DIFF
--- a/api/supabase/templates/confirmation.html
+++ b/api/supabase/templates/confirmation.html
@@ -8,26 +8,19 @@
     <meta name="x-apple-disable-message-reformatting" />
     <title>Confirm your email — F1 Fantasy</title>
     <style>
-      /* Reset (clients ignore most, but harmless) */
+      /* Outlook (Word engine) table spacing + text auto-inflation guards */
       body,
       table,
       td,
       p,
       a {
         -webkit-text-size-adjust: 100%;
-        -ms-text-size-adjust: 100%;
       }
       table,
       td {
         mso-table-lspace: 0pt;
         mso-table-rspace: 0pt;
         border-collapse: collapse;
-      }
-      img {
-        -ms-interpolation-mode: bicubic;
-        border: 0;
-        outline: none;
-        text-decoration: none;
       }
 
       /* Dark mode for clients that honour prefers-color-scheme (Apple Mail, iOS, etc.) */
@@ -42,18 +35,12 @@
         .text-dim {
           color: #a1a1aa !important;
         }
-        .text-faint {
-          color: #71717b !important;
-        }
         .rule {
           border-color: rgba(255, 255, 255, 0.1) !important;
         }
         .btn {
           background: #fafafa !important;
           color: #18181b !important;
-        }
-        .brand-stroke {
-          stroke: #fafafa !important;
         }
       }
 
@@ -75,12 +62,6 @@
           display: block !important;
           margin: 10px 0 0 0 !important;
         }
-      }
-
-      /* Force solid background on the page in Outlook desktop */
-      body {
-        margin: 0 !important;
-        padding: 0 !important;
       }
     </style>
   </head>
@@ -104,37 +85,8 @@
           >
             <!-- Wordmark -->
             <tr>
-              <td style="padding: 0 0 40px">
-                <table role="presentation" cellpadding="0" cellspacing="0" border="0">
-                  <tr>
-                    <td valign="middle" style="padding-right: 8px; line-height: 0">
-                      <!-- Trophy mark -->
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="18"
-                        height="18"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="#09090b"
-                        class="brand-stroke"
-                        stroke-width="2"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        aria-hidden="true"
-                      >
-                        <path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6" />
-                        <path d="M18 9h1.5a2.5 2.5 0 0 0 0-5H18" />
-                        <path d="M4 22h16" />
-                        <path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20.24 7 22" />
-                        <path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20.24 17 22" />
-                        <path d="M18 2H6v7a6 6 0 0 0 12 0V2Z" />
-                      </svg>
-                    </td>
-                    <td valign="middle" class="text-strong" style="font-size: 13px; font-weight: 600; color: #09090b; letter-spacing: 0.04em">
-                      F1 Fantasy
-                    </td>
-                  </tr>
-                </table>
+              <td class="text-strong" style="padding: 0 0 40px; font-size: 13px; font-weight: 600; color: #09090b; letter-spacing: 0.04em">
+                F1 Fantasy
               </td>
             </tr>
 
@@ -164,7 +116,6 @@
                 <table role="presentation" cellpadding="0" cellspacing="0" border="0" class="cta-row">
                   <tr>
                     <td valign="middle">
-                      <!-- Bulletproof button -->
                       <!-- type tells /auth/confirm which token kind to verify — `signup` for this confirmation email -->
                       <a
                         href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=signup&next={{ .RedirectTo }}"
@@ -185,9 +136,7 @@
                         Confirm your email
                       </a>
                     </td>
-                    <td valign="middle" class="cta-aside text-faint" style="padding-left: 12px; font-size: 13px; color: #71717b">
-                      or paste the code below
-                    </td>
+                    <td valign="middle" class="cta-aside" style="padding-left: 12px; font-size: 13px; color: #71717b">or paste the code below</td>
                   </tr>
                 </table>
               </td>
@@ -201,7 +150,7 @@
               <td class="rule" style="padding: 16px 0 18px; border-bottom: 1px solid #e4e4e7">
                 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
                   <tr>
-                    <td valign="middle" class="text-faint" style="font-size: 12px; color: #71717b; letter-spacing: 0.04em">Verification code</td>
+                    <td valign="middle" style="font-size: 12px; color: #71717b; letter-spacing: 0.04em">Verification code</td>
                     <td
                       valign="middle"
                       align="right"
@@ -231,7 +180,7 @@
 
             <!-- Postscript -->
             <tr>
-              <td class="text-faint" style="padding: 32px 0 0; font-size: 12.5px; color: #71717b; line-height: 1.6">
+              <td style="padding: 32px 0 0; font-size: 12.5px; color: #71717b; line-height: 1.6">
                 <span class="text-dim" style="color: #52525b; font-weight: 500">P.S.</span>
                 Didn't sign up for F1 Fantasy? You can safely ignore this email — no account will be created.
               </td>

--- a/api/supabase/templates/password-reset.html
+++ b/api/supabase/templates/password-reset.html
@@ -8,26 +8,19 @@
     <meta name="x-apple-disable-message-reformatting" />
     <title>Reset your password — F1 Fantasy</title>
     <style>
-      /* Reset (clients ignore most, but harmless) */
+      /* Outlook (Word engine) table spacing + text auto-inflation guards */
       body,
       table,
       td,
       p,
       a {
         -webkit-text-size-adjust: 100%;
-        -ms-text-size-adjust: 100%;
       }
       table,
       td {
         mso-table-lspace: 0pt;
         mso-table-rspace: 0pt;
         border-collapse: collapse;
-      }
-      img {
-        -ms-interpolation-mode: bicubic;
-        border: 0;
-        outline: none;
-        text-decoration: none;
       }
 
       /* Dark mode for clients that honour prefers-color-scheme (Apple Mail, iOS, etc.) */
@@ -42,18 +35,9 @@
         .text-dim {
           color: #a1a1aa !important;
         }
-        .text-faint {
-          color: #71717b !important;
-        }
-        .rule {
-          border-color: rgba(255, 255, 255, 0.1) !important;
-        }
         .btn {
           background: #fafafa !important;
           color: #18181b !important;
-        }
-        .brand-stroke {
-          stroke: #fafafa !important;
         }
       }
 
@@ -68,12 +52,6 @@
           font-size: 24px !important;
           line-height: 1.22 !important;
         }
-      }
-
-      /* Force solid background on the page in Outlook desktop */
-      body {
-        margin: 0 !important;
-        padding: 0 !important;
       }
     </style>
   </head>
@@ -97,37 +75,8 @@
           >
             <!-- Wordmark -->
             <tr>
-              <td style="padding: 0 0 40px">
-                <table role="presentation" cellpadding="0" cellspacing="0" border="0">
-                  <tr>
-                    <td valign="middle" style="padding-right: 8px; line-height: 0">
-                      <!-- Trophy mark -->
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="18"
-                        height="18"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="#09090b"
-                        class="brand-stroke"
-                        stroke-width="2"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        aria-hidden="true"
-                      >
-                        <path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6" />
-                        <path d="M18 9h1.5a2.5 2.5 0 0 0 0-5H18" />
-                        <path d="M4 22h16" />
-                        <path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20.24 7 22" />
-                        <path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20.24 17 22" />
-                        <path d="M18 2H6v7a6 6 0 0 0 12 0V2Z" />
-                      </svg>
-                    </td>
-                    <td valign="middle" class="text-strong" style="font-size: 13px; font-weight: 600; color: #09090b; letter-spacing: 0.04em">
-                      F1 Fantasy
-                    </td>
-                  </tr>
-                </table>
+              <td class="text-strong" style="padding: 0 0 40px; font-size: 13px; font-weight: 600; color: #09090b; letter-spacing: 0.04em">
+                F1 Fantasy
               </td>
             </tr>
 
@@ -153,32 +102,25 @@
             <!-- CTA -->
             <tr>
               <td style="padding: 0 0 36px">
-                <table role="presentation" cellpadding="0" cellspacing="0" border="0">
-                  <tr>
-                    <td valign="middle">
-                      <!-- Bulletproof button -->
-                      <!-- type tells /reset-password which token kind to verify — `recovery` for this password reset email -->
-                      <a
-                        href="{{ .SiteURL }}/reset-password?token_hash={{ .TokenHash }}&type=recovery"
-                        class="btn"
-                        style="
-                          display: inline-block;
-                          padding: 11px 20px;
-                          background: #09090b;
-                          color: #ffffff;
-                          border-radius: 8px;
-                          font-size: 14px;
-                          font-weight: 600;
-                          text-decoration: none;
-                          letter-spacing: -0.005em;
-                          font-family: inherit;
-                        "
-                      >
-                        Reset your password
-                      </a>
-                    </td>
-                  </tr>
-                </table>
+                <!-- type tells /reset-password which token kind to verify — `recovery` for this password reset email -->
+                <a
+                  href="{{ .SiteURL }}/reset-password?token_hash={{ .TokenHash }}&type=recovery"
+                  class="btn"
+                  style="
+                    display: inline-block;
+                    padding: 11px 20px;
+                    background: #09090b;
+                    color: #ffffff;
+                    border-radius: 8px;
+                    font-size: 14px;
+                    font-weight: 600;
+                    text-decoration: none;
+                    letter-spacing: -0.005em;
+                    font-family: inherit;
+                  "
+                >
+                  Reset your password
+                </a>
               </td>
             </tr>
 
@@ -192,7 +134,7 @@
 
             <!-- Postscript -->
             <tr>
-              <td class="text-faint" style="padding: 32px 0 0; font-size: 12.5px; color: #71717b; line-height: 1.6">
+              <td style="padding: 32px 0 0; font-size: 12.5px; color: #71717b; line-height: 1.6">
                 <span class="text-dim" style="color: #52525b; font-weight: 500">P.S.</span>
                 Didn't request a password reset? You can safely ignore this email. Your password won't change.
               </td>


### PR DESCRIPTION
## Summary
The confirmation and password-reset emails carried a trophy SVG and a layer of CSS that
stopped matching anything (image resets with no images, a dark-mode rule that set the same
value as its light-mode counterpart, an IE Mobile prefix). Removing it cuts the confirmation
email from 8,913 to 6,979 bytes.

## Verification
Signed up throwaway accounts against the dev stack and checked both delivered messages in
the local mail catcher: rendering in light and dark, at desktop and 390px, plus both links
followed through to a signed-in session and the set-new-password form.

Worth knowing for the next template edit: local GoTrue caches the parsed templates, so
`docker restart supabase_auth_f1-companion-api` is needed before a change shows up in sent
mail. Kong bind-mounts the files, so disk always looks correct and proves nothing.

## Risk & scope
The buttons are not bulletproof buttons — all the styling sits on the `<a>`, so Outlook
desktop renders them as plain links. That predates this change and is left alone; the
misleading `<!-- Bulletproof button -->` comments are gone.

At mobile widths the confirmation's "or paste the code below" aside does not stack below
the button despite the `.cta-row` rules, because `display: block` lands on that `<td>` but
not its sibling. Also pre-existing, confirmed by rendering a pre-change email at 390px.