### PR TITLE
Notify account owners when their password changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,12 +245,13 @@ See [Local Services Topology](README.md#local-services-topology) in the README f
 
 Hosted on Fly.io + Supabase (free tier).
 
-| Resource                | Identifier                            |
-| ----------------------- | ------------------------------------- |
-| Fly.io app name         | `f1fantasyapp`                        |
-| Fly.io region           | `iad` (Virginia)                      |
-| Supabase project ref    | `cfuccajsckqzecbfyqrv`                |
-| Supabase direct DB host | `db.cfuccajsckqzecbfyqrv.supabase.co` |
+| Resource                | Identifier                                              |
+| ----------------------- | ------------------------------------------------------- |
+| Fly.io app name         | `f1fantasyapp`                                          |
+| Fly.io region           | `iad` (Virginia)                                        |
+| Supabase project ref    | `cfuccajsckqzecbfyqrv`                                  |
+| Supabase direct DB host | `db.cfuccajsckqzecbfyqrv.supabase.co`                   |
+| Email delivery          | Resend via Supabase custom SMTP, from `team@emsqrd.dev` |
 
 **MCP servers available for investigation:**
 

--- a/api/supabase/config.toml
+++ b/api/supabase/config.toml
@@ -147,7 +147,7 @@ password_requirements = ""
 
 [auth.rate_limit]
 # Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
-email_sent = 2
+email_sent = 100
 # Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
 sms_sent = 30
 # Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
@@ -206,6 +206,12 @@ content_path = "./supabase/templates/confirmation.html"
 [auth.email.template.recovery]
 subject = "Reset your password"
 content_path = "./supabase/templates/password-reset.html"
+
+[auth.email.notification.password_changed]
+enabled = true
+subject = "Your F1 Fantasy password was changed"
+# Unlike [auth.email.template.*], this path resolves from supabase/, not the project root.
+content_path = "./templates/password-changed.html"
 
 [auth.sms]
 # Allow/disallow new user signups via SMS to your project.

--- a/api/supabase/templates/password-changed.html
+++ b/api/supabase/templates/password-changed.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <meta name="supported-color-schemes" content="light dark" />
+    <meta name="x-apple-disable-message-reformatting" />
+    <title>Your password was changed — F1 Fantasy</title>
+    <style>
+      /* Outlook (Word engine) table spacing + text auto-inflation guards */
+      body,
+      table,
+      td,
+      p,
+      a {
+        -webkit-text-size-adjust: 100%;
+      }
+      table,
+      td {
+        mso-table-lspace: 0pt;
+        mso-table-rspace: 0pt;
+        border-collapse: collapse;
+      }
+
+      /* Dark mode for clients that honour prefers-color-scheme (Apple Mail, iOS, etc.) */
+      @media (prefers-color-scheme: dark) {
+        body,
+        .bg {
+          background: #18181b !important;
+        }
+        .text-strong {
+          color: #fafafa !important;
+        }
+        .text-dim {
+          color: #a1a1aa !important;
+        }
+      }
+
+      /* Mobile */
+      @media only screen and (max-width: 520px) {
+        .container {
+          width: 100% !important;
+          padding-left: 24px !important;
+          padding-right: 24px !important;
+        }
+        .h1 {
+          font-size: 24px !important;
+          line-height: 1.22 !important;
+        }
+      }
+    </style>
+  </head>
+  <body class="bg" style="margin: 0; padding: 0; background: #ffffff">
+    <!-- Hidden preheader -->
+    <div style="display: none; max-height: 0; overflow: hidden; mso-hide: all; font-size: 1px; line-height: 1px; color: #ffffff">
+      The password for your F1 Fantasy account was just changed.
+    </div>
+
+    <table role="presentation" class="bg" width="100%" cellpadding="0" cellspacing="0" border="0" style="background: #ffffff">
+      <tr>
+        <td align="center" style="padding: 56px 16px 48px">
+          <table
+            role="presentation"
+            class="container"
+            width="480"
+            cellpadding="0"
+            cellspacing="0"
+            border="0"
+            style="max-width: 480px; width: 100%; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
+          >
+            <!-- Wordmark -->
+            <tr>
+              <td class="text-strong" style="padding: 0 0 40px; font-size: 13px; font-weight: 600; color: #09090b; letter-spacing: 0.04em">
+                F1 Fantasy
+              </td>
+            </tr>
+
+            <!-- Headline -->
+            <tr>
+              <td style="padding: 0 0 14px">
+                <h1
+                  class="h1 text-strong"
+                  style="margin: 0; font-size: 28px; font-weight: 600; color: #09090b; letter-spacing: -0.022em; line-height: 1.2"
+                >
+                  Your password was changed
+                </h1>
+              </td>
+            </tr>
+
+            <!-- Body paragraphs -->
+            <tr>
+              <td class="text-dim" style="padding: 0 0 16px; font-size: 15.5px; color: #52525b; line-height: 1.65">
+                Success! You've just changed the password for your F1 Fantasy account ({{ .Email }}).
+              </td>
+            </tr>
+            <tr>
+              <td class="text-dim" style="padding: 0 0 28px; font-size: 15.5px; color: #52525b; line-height: 1.65">
+                If you didn't make this change, please contact support.
+              </td>
+            </tr>
+
+            <!-- Sign-off -->
+            <tr>
+              <td style="padding: 32px 0 0">
+                <p class="text-dim" style="margin: 0 0 6px; font-size: 14.5px; color: #52525b; line-height: 1.6">See you on the grid,</p>
+                <p class="text-strong" style="margin: 0; font-size: 14.5px; color: #09090b; font-weight: 500">The F1 Fantasy team</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/docs/plans/342-password-changed-notification.md
+++ b/docs/plans/342-password-changed-notification.md
@@ -33,7 +33,8 @@ Supersedes the implementation notes on the issue: the rate limits go to 100 (not
   [auth.email.notification.password_changed]
   enabled = true
   subject = "Your F1 Fantasy password was changed"
-  content_path = "./supabase/templates/password-changed.html"
+  # Unlike [auth.email.template.*], this path resolves from supabase/, not the project root.
+  content_path = "./templates/password-changed.html"
   ```
 
   In the same edit, `email_sent = 2` → `100` (dev) and `email_sent = 30` → `100` (e2e); scaffold comment untouched.
@@ -42,17 +43,22 @@ Supersedes the implementation notes on the issue: the rate limits go to 100 (not
 - **Modify `e2e/tests/password-reset.spec.ts`** — in the first happy path, after the reset lands on `/` (after the welcome-heading assertion, before the sign-out section):
 
   ```ts
+  const notificationSubject = 'Your F1 Fantasy password was changed';
+
   await expect
     .poll(
-      async () =>
-        (await searchByRecipient(user.email, { subject: 'Your F1 Fantasy password was changed' }))
-          .count,
+      async () => (await searchByRecipient(user.email, { subject: notificationSubject })).count,
       { timeout: 10_000 },
     )
     .toBe(1);
+
+  // The subject comes from config, so only the body proves the template rendered.
+  const notification = await searchByRecipient(user.email, { subject: notificationSubject });
+  const notificationBody = (await getMessage(notification.messages[0].ID)).Text;
+  expect(notificationBody).toContain(user.email);
   ```
 
-  The pre-link `.toBe(1)` poll stays (the notification cannot exist before the reset completes); the two-tabs test is untouched.
+  The subject alone would pass on a template that never rendered, since it comes from `config.toml` rather than the template. The body assertion on the substituted `{{ .Email }}` is what makes this a real check. The pre-link `.toBe(1)` poll stays (the notification cannot exist before the reset completes); the two-tabs test is untouched.
 - **Modify `CLAUDE.md`** — Production Infrastructure table gains a row: Email delivery → Resend (Supabase custom SMTP).
 
 **Tests:** the e2e assertion above is the test — no unit or backend-integration layer can see a gotrue config change. `config-sync.spec.ts` guards the config drift, now covering `email_sent` too.

--- a/docs/plans/342-password-changed-notification.md
+++ b/docs/plans/342-password-changed-notification.md
@@ -1,0 +1,71 @@
+# Password-changed notification email (#342)
+
+## Context
+
+When an account's password is changed, the owner gets no signal — a silent takeover leaves the victim nothing to act on. Supabase ships a native security notification for exactly this: a gotrue-level toggle that emails the account address after every password change. This plan enables it in both local stacks with a branded template, asserts it in the existing e2e reset happy path, and lists the manual production steps.
+
+Part of #166; depends on #339 (closed). No app code changes — config, one template, three e2e-side edits, one CLAUDE.md line.
+
+Supersedes the implementation notes on the issue: the rate limits go to 100 (not 50), for the reasons below.
+
+## Design decisions
+
+- **Native notification, global toggle, no suppression.** `[auth.email.notification.password_changed]` fires on every password update through any path — completing a recovery today, the future account-page change-password automatically when it exists. gotrue offers no per-flow suppression, and none is wanted: notifying on every change (including self-service resets the user just performed) is the OWASP-recommended posture.
+- **Custom template, informational only.** The template gets only `{{ .Email }}` and `{{ .SiteURL }}` — no timestamp, IP, or device data — so the email can only say *that* the password changed, not when or from where. No CTA button, no links, no P.S. The body (verbatim, only `{{ .Email }}` used):
+
+  > Success! You've just changed the password for your F1 Fantasy account ({{ .Email }}).
+  >
+  > If you didn't make this change, please contact support.
+
+  "Contact support" is a placeholder — no contact page exists yet; the line gets revisited when one ships.
+- **Subject: "Your F1 Fantasy password was changed"** — unlike the confirmation and reset emails, this one arrives unprompted, so the product name goes in the subject for inbox attribution.
+- **Styling matches the existing templates as they stand at implementation time.** Clone the `confirmation.html`/`password-reset.html` structure as it is on `main` when this lands.
+- **`email_sent = 100` in both stacks, and the key is currently inert.** On the current CLI, the config value only reaches gotrue when `[auth.email.smtp]` is enabled; without it the CLI injects `GOTRUE_RATE_LIMIT_EMAIL_SENT=360000` (verified in CLI source and against both running local containers). 100 matches Supabase's own local-testing configs on GitHub (`supabase/ui-library` `config.toml`, `supabase/auth` `example.env`) and is generous if a future CLI version enforces the key again. With both stacks equal, the `email_sent` exemption in `config-sync.spec.ts` guards a divergence that no longer exists — drop it so the key is sync-checked like any other. No new config comments: the scaffold comment already states the requires-SMTP constraint.
+- **E2E asserts the notification by subject, not by count.** After a completed reset the user's mailbox holds two emails (recovery + notification); a bare count can't tell "notification landed" from "recovery double-sent." Mailpit's search syntax documents `subject:"..."` filtering, and the suite already drives the same `/api/v1/search` endpoint with `to:` filters. One assertion on the existing happy path — the e2e stack is the only automated layer running a real gotrue with this config, and "deployment/config" is e2e-owned per the testing strategy.
+- **Production is dashboard-managed.** Per #164/#339, the hosted project reads email config and templates from the dashboard, not the repo. Prod delivery goes through Resend (custom SMTP) — recorded in CLAUDE.md as part of this commit.
+
+## Commit — `feat(auth): enable password-changed notification email`
+
+- **Add `api/supabase/templates/password-changed.html`** — clone the current template structure and palette (dark-mode blocks included). Heading "Your password was changed"; body copy verbatim from Design decisions; `{{ .Email }}` is the only variable; no links, button, code row, or P.S. (e2e sees the file via the `e2e/supabase/templates` symlink.)
+- **Modify `api/supabase/config.toml` + `e2e/supabase/config.toml`** — identical block directly after `[auth.email.template.recovery]` in both (config-sync compares ordered lines):
+
+  ```toml
+  [auth.email.notification.password_changed]
+  enabled = true
+  subject = "Your F1 Fantasy password was changed"
+  content_path = "./supabase/templates/password-changed.html"
+  ```
+
+  In the same edit, `email_sent = 2` → `100` (dev) and `email_sent = 30` → `100` (e2e); scaffold comment untouched.
+- **Modify `e2e/tests/_infra/config-sync.spec.ts`** — remove `email_sent` from `IGNORED_KEY_RE` and delete its bullet from the exceptions comment.
+- **Modify `e2e/fixtures/mailpit.ts`** — `searchByRecipient(email, opts?: { subject?: string })`; with a subject, the query becomes `to:${email} subject:"${opts.subject}"`.
+- **Modify `e2e/tests/password-reset.spec.ts`** — in the first happy path, after the reset lands on `/` (after the welcome-heading assertion, before the sign-out section):
+
+  ```ts
+  await expect
+    .poll(
+      async () =>
+        (await searchByRecipient(user.email, { subject: 'Your F1 Fantasy password was changed' }))
+          .count,
+      { timeout: 10_000 },
+    )
+    .toBe(1);
+  ```
+
+  The pre-link `.toBe(1)` poll stays (the notification cannot exist before the reset completes); the two-tabs test is untouched.
+- **Modify `CLAUDE.md`** — Production Infrastructure table gains a row: Email delivery → Resend (Supabase custom SMTP).
+
+**Tests:** the e2e assertion above is the test — no unit or backend-integration layer can see a gotrue config change. `config-sync.spec.ts` guards the config drift, now covering `email_sent` too.
+
+**Verify:** restart both local stacks to pick up config (`npm run` supabase start/stop scripts). `npm run e2e` (requires the e2e stack), `npm run e2e:lint`, `npm run e2e:format:check`. Manual, dev stack: complete a password reset in the browser, then in Mailpit (54324) confirm the notification arrived alongside the recovery email — subject, body copy, email substitution, light/dark rendering.
+
+## Production deployment (post-merge, manual)
+
+1. In the hosted dashboard, enable the password-changed security notification; paste the subject ("Your F1 Fantasy password was changed") and the contents of `password-changed.html` — same routine as #339's reset template. If the dashboard has no password-changed notification section, stop here: hosted auth doesn't ship the feature yet, and nothing in the local setup depends on it.
+2. Run one real password reset against production and confirm both emails arrive and render correctly.
+
+## Out of scope
+
+- Glossary entries (decided against for this issue).
+- Custom email-sending infrastructure, capacity/volume checks.
+- Any `web/` code; OTP path and resend remain sibling sub-issues of #166.

--- a/e2e/fixtures/mailpit.ts
+++ b/e2e/fixtures/mailpit.ts
@@ -17,8 +17,12 @@ export interface MailpitMessage {
   HTML: string;
 }
 
-export async function searchByRecipient(email: string): Promise<MailpitSearchResult> {
-  const url = `${MAILPIT_BASE_URL}/api/v1/search?query=${encodeURIComponent(`to:${email}`)}`;
+export async function searchByRecipient(
+  email: string,
+  opts?: { subject?: string },
+): Promise<MailpitSearchResult> {
+  const query = opts?.subject ? `to:${email} subject:"${opts.subject}"` : `to:${email}`;
+  const url = `${MAILPIT_BASE_URL}/api/v1/search?query=${encodeURIComponent(query)}`;
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error(`Mailpit search failed (${res.status}): ${await res.text()}`);

--- a/e2e/supabase/config.toml
+++ b/e2e/supabase/config.toml
@@ -150,7 +150,7 @@ password_requirements = ""
 
 [auth.rate_limit]
 # Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
-email_sent = 30
+email_sent = 100
 # Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
 sms_sent = 30
 # Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
@@ -209,6 +209,12 @@ content_path = "./supabase/templates/confirmation.html"
 [auth.email.template.recovery]
 subject = "Reset your password"
 content_path = "./supabase/templates/password-reset.html"
+
+[auth.email.notification.password_changed]
+enabled = true
+subject = "Your F1 Fantasy password was changed"
+# Unlike [auth.email.template.*], this path resolves from supabase/, not the project root.
+content_path = "./templates/password-changed.html"
 
 [auth.sms]
 # Allow/disallow new user signups via SMS to your project.

--- a/e2e/tests/_infra/config-sync.spec.ts
+++ b/e2e/tests/_infra/config-sync.spec.ts
@@ -19,12 +19,10 @@ const E2E_CONFIG = path.join(REPO_ROOT, 'e2e', 'supabase', 'config.toml');
 //     Services Topology) to run alongside dev
 //   - site_url / additional_redirect_urls: contain the web port
 //     (5173 dev, 5273 e2e), so they shift too
-//   - email_sent: e2e raises the per-hour cap so the suite has
-//     headroom for signup + resend within a single run
 //   - max_frequency: e2e drops the per-user resend cool-down to 0s
 //     so resend tests don't have to sleep past gotrue's throttle
 const IGNORED_KEY_RE =
-  /^\s*(project_id|[a-z_]*port|site_url|additional_redirect_urls|email_sent|max_frequency)\s*=/;
+  /^\s*(project_id|[a-z_]*port|site_url|additional_redirect_urls|max_frequency)\s*=/;
 
 // Compare config values only: drop blank lines, comments (the two files carry
 // different header blocks), and the keys above that must differ between stacks.

--- a/e2e/tests/password-reset.spec.ts
+++ b/e2e/tests/password-reset.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 import { randomUUID } from 'node:crypto';
 
 import { createTestUser } from '../fixtures/auth';
-import { clearAll, getRecoveryUrl, searchByRecipient } from '../fixtures/mailpit';
+import { clearAll, getMessage, getRecoveryUrl, searchByRecipient } from '../fixtures/mailpit';
 import { resetDb } from '../fixtures/reset';
 import { signInAs } from '../fixtures/session';
 
@@ -49,14 +49,19 @@ test.describe('password reset', () => {
     await expect(page).toHaveURL('/');
     await expect(page.getByRole('heading', { name: `Welcome, ${user.displayName}` })).toBeVisible();
 
+    const notificationSubject = 'Your F1 Fantasy password was changed';
+
     await expect
       .poll(
-        async () =>
-          (await searchByRecipient(user.email, { subject: 'Your F1 Fantasy password was changed' }))
-            .count,
+        async () => (await searchByRecipient(user.email, { subject: notificationSubject })).count,
         { timeout: 10_000 },
       )
       .toBe(1);
+
+    // The subject comes from config, so only the body proves the template rendered.
+    const notification = await searchByRecipient(user.email, { subject: notificationSubject });
+    const notificationBody = (await getMessage(notification.messages[0].ID)).Text;
+    expect(notificationBody).toContain(user.email);
 
     await page.getByRole('button', { name: 'Account menu' }).click();
     await page.getByRole('menuitem', { name: 'Sign Out' }).click();

--- a/e2e/tests/password-reset.spec.ts
+++ b/e2e/tests/password-reset.spec.ts
@@ -49,6 +49,15 @@ test.describe('password reset', () => {
     await expect(page).toHaveURL('/');
     await expect(page.getByRole('heading', { name: `Welcome, ${user.displayName}` })).toBeVisible();
 
+    await expect
+      .poll(
+        async () =>
+          (await searchByRecipient(user.email, { subject: 'Your F1 Fantasy password was changed' }))
+            .count,
+        { timeout: 10_000 },
+      )
+      .toBe(1);
+
     await page.getByRole('button', { name: 'Account menu' }).click();
     await page.getByRole('menuitem', { name: 'Sign Out' }).click();
     await expect(page.getByRole('heading', { name: /race to glory/i })).toBeVisible();


### PR DESCRIPTION
## Summary

A password change left the account owner with no signal, so a silent takeover gave the victim nothing to act on. gotrue ships a native security notification for this; both local stacks now enable it with a branded template. Closes #342.

## Verification

Ran a full reset against the dev stack and confirmed in Mailpit (54324) that the notification arrives alongside the recovery email: subject, body copy, `{{ .Email }}` substitution, and light/dark rendering all correct.

## Risk & scope

Production reads email config and templates from the dashboard, not this repo, so merging changes nothing hosted. The dashboard steps are in `docs/plans/342-password-changed-notification.md#production-deployment-post-merge-manual`.

The template's "contact support" line points nowhere. No contact page exists yet; it gets revisited when one ships.
